### PR TITLE
Pin Gramps docker image version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM dmstraub/gramps:latest
+FROM dmstraub/gramps:5.1.4
 
 WORKDIR /app
 ENV PYTHONPATH="${PYTHONPATH}:/usr/lib/python3/dist-packages"


### PR DESCRIPTION
I updated the Gramps docker image at https://github.com/DavidMStraub/gramps-docker, which is used as a base image for the web API image, to Debian Bullseye (from Buster) and Gramps 5.1.4 (from 5.1.3). I took the opportunity to start tagging that image with the Gramps version instead of only using `latest` and this PR is to fix that version in our Dockerfile. This way, we can control when we are switching the recommended Docker image to a new Gramps version.