### PR TITLE
fix mails over tls

### DIFF
--- a/gramps_webapi/api/util.py
+++ b/gramps_webapi/api/util.py
@@ -396,13 +396,15 @@ def send_email(
     use_tls = get_config("EMAIL_USE_TLS")
     try:
         if use_tls:
-            smtp = smtplib.SMTP_SSL(host=host, port=port, timeout=10)
-        else:
-            smtp = smtplib.SMTP(host=host, port=port, timeout=10)
-            smtp.ehlo()
-            if port != 25:
+            if port == 465:
+                smtp = smtplib.SMTP_SSL(host=host, port=port, timeout=10)
+            else:
+                smtp = smtplib.SMTP(host=host, port=port, timeout=10)
+                smtp.ehlo()
                 smtp.starttls()
                 smtp.ehlo()
+        else:
+            smtp = smtplib.SMTP(host=host, port=port, timeout=10)
         if user:
             smtp.login(user, password)
         smtp.send_message(msg)


### PR DESCRIPTION
Send mails using the flag use_tls was only following the workflow of sending via ssh (not tls), but tls uses another workflow then ssh. This change allows using tls