### PR TITLE
Show tree enabled/disabled status

### DIFF
--- a/gramps_webapi/api/resources/trees.py
+++ b/gramps_webapi/api/resources/trees.py
@@ -29,7 +29,12 @@ from gramps.gen.config import config
 from webargs import fields
 from werkzeug.security import safe_join
 
-from ...auth import disable_enable_tree, get_tree_usage, set_tree_quota
+from ...auth import (
+    disable_enable_tree,
+    get_tree_usage,
+    is_tree_disabled,
+    set_tree_quota,
+)
 from ...auth.const import (
     PERM_ADD_TREE,
     PERM_DISABLE_TREE,
@@ -68,7 +73,8 @@ def get_tree_details(tree_id: str) -> Dict[str, str]:
     except ValueError:
         abort(404)
     usage = get_tree_usage(tree_id) or {}
-    return {"name": dbmgr.name, "id": tree_id, **usage}
+    enabled = not is_tree_disabled(tree=tree_id)
+    return {"name": dbmgr.name, "id": tree_id, **usage, "enabled": enabled}
 
 
 def get_tree_path(tree_id: str) -> Optional[str]:

--- a/gramps_webapi/data/apispec.yaml
+++ b/gramps_webapi/data/apispec.yaml
@@ -10589,3 +10589,7 @@ definitions:
         description: "The current number of people."
         type: integer
         example: 96
+      enabled:
+        description: "Whether the tree is enabled."
+        type: boolean
+        example: true

--- a/tests/test_endpoints/test_trees.py
+++ b/tests/test_endpoints/test_trees.py
@@ -95,7 +95,7 @@ class TestTrees(unittest.TestCase):
         assert rv.status_code == 200
         trees = rv.json
         # owner can see only one tree
-        assert trees == [{"id": self.tree, "name": self.name}]
+        assert trees == [{"id": self.tree, "name": self.name, "enabled": True}]
 
     def test_get_tree(self):
         rv = self.client.post(
@@ -126,7 +126,7 @@ class TestTrees(unittest.TestCase):
             headers={"Authorization": f"Bearer {token}"},
         )
         assert rv.status_code == 200
-        assert rv.json == {"name": self.name, "id": self.tree}
+        assert rv.json == {"name": self.name, "id": self.tree, "enabled": True}
 
     def test_post_tree(self):
         rv = self.client.post(
@@ -162,6 +162,7 @@ class TestTrees(unittest.TestCase):
         assert rv.json["name"] == "some name"
         assert rv.json["quota_media"] == 1000000
         assert rv.json["quota_people"] is None
+        assert rv.json["enabled"]
 
     def test_rename_tree(self):
         rv = self.client.post(


### PR DESCRIPTION
This adds the "enabled" key to the `/trees/` and `/trees/<treeid>` to make the status not only editable, but also visible. This was simply forgotten before.