### PR TITLE
Speed up incremental search reindex

### DIFF
--- a/gramps_webapi/_version.py
+++ b/gramps_webapi/_version.py
@@ -18,4 +18,4 @@
 #
 
 # make sure to match this version with the one in apispec.yaml
-__version__ = "2.4.0"
+__version__ = "2.4.1"

--- a/gramps_webapi/api/search/indexer.py
+++ b/gramps_webapi/api/search/indexer.py
@@ -203,14 +203,18 @@ class SearchIndexer:
 
         # add objects
         for class_name, handles in update_info["new"].items():
+            obj_dicts = []
             for handle in handles:
+                obj_dicts.append(obj_strings_from_handle(db_handle, class_name, handle))
                 i = progress(i)
-                self.add_or_update_object(handle, db_handle, class_name)
+            self._add_objects(obj_dicts)
         # update objects
         for class_name, handles in update_info["updated"].items():
+            obj_dicts = []
             for handle in handles:
+                obj_dicts.append(obj_strings_from_handle(db_handle, class_name, handle))
                 i = progress(i)
-                self.add_or_update_object(handle, db_handle, class_name)
+            self._add_objects(obj_dicts)
 
     @staticmethod
     def _format_hit(hit, rank) -> Dict[str, Any]:

--- a/gramps_webapi/api/tasks.py
+++ b/gramps_webapi/api/tasks.py
@@ -364,3 +364,8 @@ def delete_objects(
         db_handle.close()
 
     update_usage_people(tree=tree, user_id=user_id)
+    _search_reindex_incremental(
+        tree=tree,
+        user_id=user_id,
+        progress_cb=progress_callback_count(self, title="Updating search index..."),
+    )

--- a/gramps_webapi/data/apispec.yaml
+++ b/gramps_webapi/data/apispec.yaml
@@ -8,7 +8,7 @@ info:
 
 
     * More about Gramps and the numerous features it provides for genealogists can be found at https://gramps-project.org
-  version: "2.4.0"  # make sure to match this version with the one in _version.py
+  version: "2.4.1"  # make sure to match this version with the one in _version.py
   license:
     name: "GNU Affero General Public License v3.0"
     url: "http://www.gnu.org/licenses/agpl-3.0.html"


### PR DESCRIPTION
The incremental search reindex was *very* inefficient in case of many updates. And that is what is used after importing a file. Imprting `example.gramps` locally using a SQLite index, before:

```
[2024-08-04 17:43:40,381: INFO/ForkPoolWorker-6] Task
gramps_webapi.api.tasks.import_file[48c173e5-0d0f-4cd6-b682-aef48bbdda9e]
succeeded in 2314.4943576940022s: None
```

... and after:

```
[2024-08-04 22:24:36,800: INFO/ForkPoolWorker-6] Task 
gramps_webapi.api.tasks.import_file[57839f70-15a8-4540-9d46-9d3e63f6d451]
succeeded in 77.58003538799676s: None
```

:open_mouth: 

I believe this fixes #436.