### PR TITLE
Test with current and oldest supported Python version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.8", "3.12"]
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        python-version: ["3.6", "3.7", "3.8"]
+        python-version: ["3.7", "3.8"]
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,8 +7,15 @@ on:
 jobs:
   build:
     runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        python-version: ["3.6", "3.7", "3.8"]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
       - name: Install Ubuntu dependencies
         run: sudo apt update && sudo apt-get -y install gettext appstream pkg-config libcairo2-dev gir1.2-gtk-3.0 libgirepository1.0-dev libicu-dev libopencv-dev tesseract-ocr tesseract-ocr-all gir1.2-pango-1.0
       - name: Install Python dependencies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13.0-rc.1"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13-rc1"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13.0-rc.1"]
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,8 +2,6 @@ name: unit tests
 
 on:
   push:
-    branches:
-      - master
   pull_request:
 
 jobs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,10 +12,11 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Install Ubuntu dependencies
-        run: sudo apt update && sudo apt-get -y install gettext appstream pkg-config libcairo2-dev gir1.2-gtk-3.0 libgirepository1.0-dev libicu-dev libopencv-dev python3-opencv python3-numpy tesseract-ocr tesseract-ocr-all gir1.2-pango-1.0 python3-gi-cairo
+        run: sudo apt update && sudo apt-get -y install gettext appstream pkg-config libcairo2-dev gir1.2-gtk-3.0 libgirepository1.0-dev libicu-dev libopencv-dev tesseract-ocr tesseract-ocr-all gir1.2-pango-1.0
       - name: Install Python dependencies
         run: |
           python -m pip install --upgrade pip wheel setuptools
+          pip install opencv-python
           pip install -r requirements-dev.txt
           pip install .
           pip list

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        python-version: ["3.8", "3.12"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13-rc1"]
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        python-version: ["3.7", "3.8"]
+        python-version: ["3.8", "3.12"]
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}

--- a/gramps_webapi/api/media.py
+++ b/gramps_webapi/api/media.py
@@ -45,7 +45,7 @@ from .util import (
 PREFIX_S3 = "s3://"
 
 
-def removeprefix(string: str, prefix: str, /) -> str:
+def removeprefix(string: str, prefix: str) -> str:
     """Remove prefix from a string; see PEP 616."""
     if string.startswith(prefix):
         return string[len(prefix) :]

--- a/gramps_webapi/api/media.py
+++ b/gramps_webapi/api/media.py
@@ -45,7 +45,7 @@ from .util import (
 PREFIX_S3 = "s3://"
 
 
-def removeprefix(string: str, prefix: str) -> str:
+def removeprefix(string: str, prefix: str, /) -> str:
     """Remove prefix from a string; see PEP 616."""
     if string.startswith(prefix):
         return string[len(prefix) :]

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ REQUIREMENTS = [
 setup(
     author="Gramps Development Team",
     url="https://github.com/gramps-project/web-api",
-    python_requires=">=3.5",
+    python_requires=">=3.8",
     description="A RESTful web API for the Gramps genealogical database.",
     license="AGPL v3 or greater",
     install_requires=REQUIREMENTS,


### PR DESCRIPTION
The unit tests are now run with the current (3.12) and oldest supported (3.8) Python version.

Also, the minimum Python version has been corrected in setup.py.