### PR TITLE
Generate app/secret only if SECRET_KEY is unset

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,15 +1,15 @@
 #!/bin/sh
 set -e
 
-# create random flask secret key
-if [ ! -s /app/secret/secret ]
-then
-    mkdir -p /app/secret
-    python3 -c "import secrets;print(secrets.token_urlsafe(32))"  | tr -d "\n" > /app/secret/secret
-fi
 # use the secret key if none is set (will be overridden by config file if present)
 if [ -z "$GRAMPSWEB_SECRET_KEY" ]
 then
+    # create random flask secret key
+    if [ ! -s /app/secret/secret ]
+    then
+        mkdir -p /app/secret
+        python3 -c "import secrets;print(secrets.token_urlsafe(32))"  | tr -d "\n" > /app/secret/secret
+    fi
     export GRAMPSWEB_SECRET_KEY=$(cat /app/secret/secret)
 fi
 


### PR DESCRIPTION
If we already have a secret key, we don't need to create another.

I caught this trying to reduce the number of volume mounts (https://github.com/gramps-project/gramps-web/discussions/478) while simultaneously running as non-root. Compose failed to start anything:
```
grampsweb_celery  | mkdir: cannot create directory ‘/app/secret’: Permission denied
grampsweb-1       | mkdir: cannot create directory ‘/app/secret’: Permission denied
```
Injecting this `docker-compose.sh` let me move my secret to env and the service starts and runs normally.