### PR TITLE
enable editable mode via pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,4 @@
+[build-system]
+# XXX: If your project needs other packages to build properly, add them to this list.
+requires = ["setuptools >= 64"]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
> There is now a [standardized mechanism](https://peps.python.org/pep-0660/) for an installer like pip to request an editable install of a project.
> 
> pip is transitioning to using this standard only instead of invoking the deprecated setup.py develop command.
> 
> Since pip 21.3, pip has switched to using this mechanism where possible. 
> 
> Add a pyproject.toml to your project, making sure the [build-system] section requires setuptools >= 64, as well as other libraries required to build your project (the equivalent of setuptools' setup_requires parameter). A basic example is included below:
> 
> ```
> [build-system]
> # XXX: If your project needs other packages to build properly, add them to this list.
> requires = ["setuptools >= 64"]
> build-backend = "setuptools.build_meta"
> ```
> 
See https://github.com/pypa/pip/issues/11457

Not having built this project yet (am testing out setting up the development environment), I'm not sure if there are any counter-indications to this approach? I seem to have successfully set up the development environment with this approach.

Running `pip install -e .` with the `pyproject.toml` file in place resulted in no `gramps_web` package getting installed to `/lib/python3.12/site-packages` within the virtual environment. Instead, in the related `dist-info` folder there is a **direct_url.json** file with contents:
```json
{"dir_info": {"editable": true}, "url": "file:///path_to_project/gramps-web-api"}
```