### PR TITLE
python.linting settings are deprecated

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,6 +1,7 @@
 {
   "recommendations": [
     "ms-python.python",
+    "ms-python.black-formatter",
     "editorconfig.editorconfig"
   ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,11 +1,4 @@
 {
-
-  "python.formatting.provider": "black",
-  "python.linting.pydocstyleEnabled": true,
-  "python.linting.pylintEnabled": true,
-  "python.linting.mypyEnabled": true,
-  "python.linting.flake8Enabled": false,
-  "python.linting.pylintArgs": ["--rcfile=setup.cfg"],
   "[python]": {
     "editor.formatOnSave": true
   }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,6 @@
 {
   "[python]": {
+    "editor.defaultFormatter": "ms-python.black-formatter",
     "editor.formatOnSave": true
   }
 }


### PR DESCRIPTION
Just a simple fix for the updated Python extensions in VSCode, seeing that the `settings.json` for VSCode is checked into the repo... I was wondering where the warnings were coming from until I realized that the `settings.json` was in the repo itself.