### PR TITLE
silence warning gtk version

### DIFF
--- a/gramps_webapi/const.py
+++ b/gramps_webapi/const.py
@@ -136,6 +136,7 @@ MIME_TYPES = {
 # depending on whether needed dependencies are available.
 try:
     import gi
+    gi.require_version('Gtk', '3.0')
 
     REPORT_FILTERS = ["gv", "dot", "gvpdf"]
     REPORT_DEFAULTS = {


### PR DESCRIPTION
Gtk was imported without specifying a version first. Use gi.require_version('Gtk', '3.0') before import to ensure that the right version gets loaded.