### PR TITLE
Added Object Query Language

### DIFF
--- a/gramps_webapi/api/resources/base.py
+++ b/gramps_webapi/api/resources/base.py
@@ -24,6 +24,7 @@ from abc import abstractmethod
 from typing import Dict, List
 
 import gramps_ql as gql
+import pythonish_ql as pql
 from flask import Response, abort, request
 from gramps.gen.const import GRAMPS_LOCALE as glocale
 from gramps.gen.db import DbTxn
@@ -350,6 +351,7 @@ class GrampsObjectsResource(GrampsObjectResourceHelper, Resource):
             ),
             "format_options": fields.Str(validate=validate.Length(min=1)),
             "gql": fields.Str(validate=validate.Length(min=1)),
+            "pql": fields.Str(validate=validate.Length(min=1)),
             "gramps_id": fields.Str(validate=validate.Length(min=1)),
             "keys": fields.DelimitedList(fields.Str(validate=validate.Length(min=1))),
             "locale": fields.Str(
@@ -426,6 +428,16 @@ class GrampsObjectsResource(GrampsObjectResourceHelper, Resource):
                     obj
                     for obj in objects
                     if gql.match(query=args["gql"], obj=obj, db=self.db_handle)
+                ]
+            except (ParseBaseException, ValueError, TypeError) as e:
+                abort_with_message(422, str(e))
+
+        if "pql" in args:
+            try:
+                objects = [
+                    obj
+                    for obj in objects
+                    if pql.match(query=args["pql"], obj=obj, db=self.db_handle)
                 ]
             except (ParseBaseException, ValueError, TypeError) as e:
                 abort_with_message(422, str(e))

--- a/gramps_webapi/api/resources/base.py
+++ b/gramps_webapi/api/resources/base.py
@@ -24,7 +24,7 @@ from abc import abstractmethod
 from typing import Dict, List
 
 import gramps_ql as gql
-import pythonish_ql as pql
+import object_ql as oql
 from flask import Response, abort, request
 from gramps.gen.const import GRAMPS_LOCALE as glocale
 from gramps.gen.db import DbTxn
@@ -351,7 +351,7 @@ class GrampsObjectsResource(GrampsObjectResourceHelper, Resource):
             ),
             "format_options": fields.Str(validate=validate.Length(min=1)),
             "gql": fields.Str(validate=validate.Length(min=1)),
-            "pql": fields.Str(validate=validate.Length(min=1)),
+            "oql": fields.Str(validate=validate.Length(min=1)),
             "gramps_id": fields.Str(validate=validate.Length(min=1)),
             "keys": fields.DelimitedList(fields.Str(validate=validate.Length(min=1))),
             "locale": fields.Str(
@@ -432,12 +432,12 @@ class GrampsObjectsResource(GrampsObjectResourceHelper, Resource):
             except (ParseBaseException, ValueError, TypeError) as e:
                 abort_with_message(422, str(e))
 
-        if "pql" in args:
+        if "oql" in args:
             try:
                 objects = [
                     obj
                     for obj in objects
-                    if pql.match(query=args["pql"], obj=obj, db=self.db_handle)
+                    if oql.match(query=args["oql"], obj=obj, db=self.db_handle)
                 ]
             except (ParseBaseException, ValueError, TypeError) as e:
                 abort_with_message(422, str(e))

--- a/gramps_webapi/api/resources/metadata.py
+++ b/gramps_webapi/api/resources/metadata.py
@@ -21,6 +21,7 @@
 """Metadata API resource."""
 
 import gramps_ql as gql
+import pythonish_ql as pql
 import pytesseract
 import sifts
 from flask import Response, current_app
@@ -119,6 +120,7 @@ class MetadataResource(ProtectedResource, GrampsJSONEncoder):
                 "version": VERSION,
             },
             "gramps_ql": {"version": gql.__version__},
+            "pythonish_ql": {"version": pql.__version__},
             "locale": {
                 "lang": GRAMPS_LOCALE.lang,
                 "language": GRAMPS_LOCALE.language[0],

--- a/gramps_webapi/api/resources/metadata.py
+++ b/gramps_webapi/api/resources/metadata.py
@@ -21,7 +21,7 @@
 """Metadata API resource."""
 
 import gramps_ql as gql
-import pythonish_ql as pql
+import object_ql as oql
 import pytesseract
 import sifts
 from flask import Response, current_app
@@ -120,7 +120,7 @@ class MetadataResource(ProtectedResource, GrampsJSONEncoder):
                 "version": VERSION,
             },
             "gramps_ql": {"version": gql.__version__},
-            "pythonish_ql": {"version": pql.__version__},
+            "object_ql": {"version": oql.__version__},
             "locale": {
                 "lang": GRAMPS_LOCALE.lang,
                 "language": GRAMPS_LOCALE.language[0],

--- a/gramps_webapi/data/apispec.yaml
+++ b/gramps_webapi/data/apispec.yaml
@@ -9974,7 +9974,7 @@ definitions:
           version:
             description: "The version of the Object QL library."
             type: string
-            example: "0.1.0"
+            example: "0.1.1"
       locale:
         description: "The active locale."
         type: object

--- a/gramps_webapi/data/apispec.yaml
+++ b/gramps_webapi/data/apispec.yaml
@@ -9964,9 +9964,17 @@ definitions:
         type: object
         properties:
           version:
-            description: "The version of the Gramps Gramps QL library."
+            description: "The version of the Gramps QL library."
             type: string
             example: "0.3.0"
+      pythonish_ql:
+        description: "Information about the installed Pythonish QL library."
+        type: object
+        properties:
+          version:
+            description: "The version of the Pythonish QL library."
+            type: string
+            example: "0.0.5"
       locale:
         description: "The active locale."
         type: object

--- a/gramps_webapi/data/apispec.yaml
+++ b/gramps_webapi/data/apispec.yaml
@@ -9967,14 +9967,14 @@ definitions:
             description: "The version of the Gramps QL library."
             type: string
             example: "0.3.0"
-      pythonish_ql:
-        description: "Information about the installed Pythonish QL library."
+      object_ql:
+        description: "Information about the installed Object QL library."
         type: object
         properties:
           version:
-            description: "The version of the Pythonish QL library."
+            description: "The version of the Object QL library."
             type: string
-            example: "0.0.5"
+            example: "0.1.0"
       locale:
         description: "The active locale."
         type: object

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ dependencies = [
     "Unidecode",
     "pytesseract",
     "gramps-ql>=0.3.0",
-    "pythonish-ql>=0.0.5",
+    "object-ql>=0.1.0",
     "sifts>=0.8.3",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ dependencies = [
     "Unidecode",
     "pytesseract",
     "gramps-ql>=0.3.0",
-    "object-ql>=0.1.1",
+    "object-ql>=0.1.2",
     "sifts>=0.8.3",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ dependencies = [
     "Unidecode",
     "pytesseract",
     "gramps-ql>=0.3.0",
-    "object-ql>=0.1.0",
+    "object-ql>=0.1.1",
     "sifts>=0.8.3",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ dependencies = [
     "Unidecode",
     "pytesseract",
     "gramps-ql>=0.3.0",
+    "pythonish-ql>=0.0.5",
     "sifts>=0.8.3",
 ]
 

--- a/tests/test_endpoints/test_people.py
+++ b/tests/test_endpoints/test_people.py
@@ -407,6 +407,39 @@ class TestPeople(unittest.TestCase):
         )
         assert len(rv) == 20
 
+    def test_get_people_parameter_oql_validate_semantics(self):
+        """Test invalid rules syntax."""
+        check_invalid_semantics(self, TEST_URL + "?oql=(")
+
+    def test_get_people_parameter_oql_handle(self):
+        """Test equal field."""
+        rv = check_success(
+            self,
+            TEST_URL + "?oql=" + quote("person.gramps_id == 'I0044'"),
+        )
+        assert len(rv) == 1
+        assert rv[0]["gramps_id"] == "I0044"
+
+    def test_get_people_parameter_oql_like(self):
+        """Test string in field."""
+        rv = check_success(
+            self,
+            TEST_URL + "?oql=" + quote("'I004' in person.gramps_id"),
+        )
+        assert len(rv) == 10
+
+    def test_get_people_parameter_oql_or(self):
+        """Test two expr combined with or."""
+        rv = check_success(
+            self,
+            TEST_URL
+            + "?oql="
+            + quote(
+                "(person.gramps_id.startswith('I004') or person.gramps_id.startswith('I003'))"
+            ),
+        )
+        assert len(rv) == 20
+
     def test_get_people_parameter_extend_validate_semantics(self):
         """Test invalid extend parameter and values."""
         check_invalid_semantics(self, TEST_URL + "?extend", check="list")


### PR DESCRIPTION
This PR adds a Python Object Query Language to the gramps-web-api. This allows using standard Python on Gramps primary objects. This is based on @DavidMStraub 's "Gramps Query Language".

The QL lives here: https://github.com/dsblank/object-ql and can work on any Python objects. It contains adopted copies of the GQL tests, and should be a drop-in replacement for GQL.

Example queries include:

Find the person with a particular gramps_id:

```python
person.gramps_id == 'person001'
```

Find all of the people with notes:

```python
person.get_note_list()
```

Find all of the people with notes that mention 'vote':

```python
any([('vote' in str(get_note(handle).text)) for handle in person.get_note_list()])
```
If you don't know what the type is, you can use obj, like:

```python
"23" in obj.gramps_id
```