### PR TITLE
Close connection to the undo database

### DIFF
--- a/gramps_webapi/__main__.py
+++ b/gramps_webapi/__main__.py
@@ -31,7 +31,7 @@ import warnings
 import click
 
 from .api.search import get_search_indexer
-from .api.util import get_db_manager, list_trees
+from .api.util import get_db_manager, list_trees, close_db
 from .app import create_app
 from .auth import add_user, delete_user, fill_tree, user_db
 from .const import ENV_CONFIG_FILE, TREE_MULTI
@@ -172,7 +172,7 @@ def index_full(ctx):
     except:
         LOG.exception("Error during indexing")
     finally:
-        db.close()
+        close_db(db)
     LOG.info(f"Done building search index in {time.time() - t0:.0f} seconds.")
 
 
@@ -189,7 +189,7 @@ def index_incremental(ctx):
     except Exception:
         LOG.exception("Error during indexing")
     finally:
-        db.close()
+        close_db(db)
     LOG.info("Done updating search index.")
 
 

--- a/gramps_webapi/api/media.py
+++ b/gramps_webapi/api/media.py
@@ -363,8 +363,11 @@ def update_usage_media(
     db_handle = get_db_outside_request(
         tree=tree, view_private=True, readonly=True, user_id=user_id
     )
-    media_handler = get_media_handler(db_handle, tree=tree)
-    usage_media = media_handler.get_media_size(db_handle=db_handle)
+    try:
+        media_handler = get_media_handler(db_handle, tree=tree)
+        usage_media = media_handler.get_media_size(db_handle=db_handle)
+    finally:
+        db_handle.close()
     set_tree_usage(tree, usage_media=usage_media)
     return usage_media
 

--- a/gramps_webapi/api/media.py
+++ b/gramps_webapi/api/media.py
@@ -37,6 +37,7 @@ from .file import FileHandler, LocalFileHandler, upload_file_local
 from .s3 import ObjectStorageFileHandler, get_object_keys_size, upload_file_s3
 from .util import (
     abort_with_message,
+    close_db,
     get_db_handle,
     get_db_outside_request,
     get_tree_from_jwt,
@@ -367,7 +368,7 @@ def update_usage_media(
         media_handler = get_media_handler(db_handle, tree=tree)
         usage_media = media_handler.get_media_size(db_handle=db_handle)
     finally:
-        db_handle.close()
+        close_db(db_handle)
     set_tree_usage(tree, usage_media=usage_media)
     return usage_media
 

--- a/gramps_webapi/api/util.py
+++ b/gramps_webapi/api/util.py
@@ -64,6 +64,7 @@ from gramps.gen.db.exceptions import DbUpgradeRequiredError
 from gramps.gen.dbstate import DbState
 from gramps.gen.errors import HandleError
 from gramps.gen.proxy import PrivateProxyDb
+from gramps.gen.proxy.proxybase import ProxyDbBase
 from gramps.gen.proxy.private import sanitize_media
 from gramps.gen.user import UserBase
 from gramps.gen.utils.grampslocale import GrampsLocale
@@ -404,6 +405,15 @@ def get_db_outside_request(
     return dbstate.db
 
 
+def close_db(db_handle: DbReadBase) -> None:
+    """Close the connection to the database including the undo log."""
+    db_handle.close()
+    if isinstance(db_handle, ProxyDbBase):
+        db_handle.basedb.undodb.close()
+    else:
+        db_handle.undodb.close()
+
+
 def get_db_handle(readonly: bool = True) -> DbReadBase:
     """Open the database and get the current instance.
 
@@ -624,7 +634,7 @@ def update_usage_people(
     try:
         usage_people = db_handle.get_number_of_people()
     finally:
-        db_handle.close()
+        close_db(db_handle)
     set_tree_usage(tree, usage_people=usage_people)
     return usage_people
 

--- a/gramps_webapi/undodb.py
+++ b/gramps_webapi/undodb.py
@@ -224,7 +224,7 @@ class DbUndoSQL(DbUndo):
 
     def close(self) -> None:
         """Close the backing storage."""
-        pass
+        self.engine.dispose()
 
     def append(self, value) -> None:
         """Add a new entry on the end."""


### PR DESCRIPTION
This disposes of the SQLAlchemy engine connecting to the undo database at the end of each request. Hopefully, this will fix #552. I intend to release v2.4.3 cherry-picking this fix on top of v2.4.2 before the next feature release.