### PR TITLE
Provide more insights in emails to admin and self-registered user

### DIFF
--- a/gramps_webapi/api/emails.py
+++ b/gramps_webapi/api/emails.py
@@ -52,14 +52,15 @@ def email_confirm_email(base_url: str, token: str):
     """Confirm e-mail address e-mail text."""
     intro = (
         _(
-            "You are receiving this e-mail because you (or someone else) "
-            "have registered a new account at %s."
+            "You are receiving this email because this e-mail address "
+            "was used to register a new account at %s."
         )
         % base_url
     )
     action = _(
         "Please click on the following link, or paste this into your browser "
-        "to complete the process:"
+        "to confirm your email address. You will be able to log on once an "
+        "administrator reviews and approves your account."
     )
 
     return f"""{intro}
@@ -72,7 +73,11 @@ def email_confirm_email(base_url: str, token: str):
 
 def email_new_user(base_url: str, username: str, fullname: str, email: str):
     """E-mail notifying owners of a new registered user."""
-    intro = _("A new user registered at %s:") % base_url
+    intro = _("A new user registered at %s.") % base_url
+    next_step = _(
+        "Please review this user registration and assign a role to "
+        "enable access:"
+    )
     label_username = _("User name")
     label_fullname = _("Full name")
     label_email = _("E-mail")
@@ -81,6 +86,8 @@ def email_new_user(base_url: str, username: str, fullname: str, email: str):
 {label_email}: {email}
 """
     return f"""{intro}
+
+{next_step}
 
 {user_details}
 """

--- a/gramps_webapi/api/emails.py
+++ b/gramps_webapi/api/emails.py
@@ -52,15 +52,15 @@ def email_confirm_email(base_url: str, token: str):
     """Confirm e-mail address e-mail text."""
     intro = (
         _(
-            "You are receiving this email because this e-mail address "
+            "You are receiving this message because this e-mail address "
             "was used to register a new account at %s."
         )
         % base_url
     )
     action = _(
         "Please click on the following link, or paste this into your browser "
-        "to confirm your email address. You will be able to log on once an "
-        "administrator reviews and approves your account."
+        "to confirm your email address. You will be able to log on once a "
+        "tree owner reviews and approves your account."
     )
 
     return f"""{intro}

--- a/gramps_webapi/api/resources/user.py
+++ b/gramps_webapi/api/resources/user.py
@@ -569,5 +569,8 @@ class UserConfirmEmailResource(LimitedScopeProtectedResource):
                 include_admins=not is_multi,
             )
         title = _("E-mail address confirmation")
-        message = _("Thank you for confirming your e-mail address.")
+        message = _(
+            "Thank you for confirming your e-mail address. "
+            "An administrator will review your account request."
+        )
         return render_template("confirmation.html", title=title, message=message)


### PR DESCRIPTION
Changed email sent to self-registered user so they know that after they confirm their email address, an admin still needs to approve the account. User will also see this message when they confirm their email.

Changed admin notification to let them know that they need to set the self-registered user's role to allow them to log in.

Documentation updated with [gramps-web-docs PR #24](https://github.com/gramps-project/gramps-web-docs/pull/24)