### PR TITLE
Speed up metadata endpoint (fixes #568)

### DIFF
--- a/gramps_webapi/data/apispec.yaml
+++ b/gramps_webapi/data/apispec.yaml
@@ -9930,7 +9930,7 @@ definitions:
           type:
             description: "The database type."
             type: string
-            example: "SQLite"
+            example: "sqlite"
           version:
             description: "The database version."
             type: string

--- a/tests/test_endpoints/test_metadata.py
+++ b/tests/test_endpoints/test_metadata.py
@@ -42,6 +42,7 @@ class TestMetadata(unittest.TestCase):
     def test_get_metadata_conforms_to_schema(self):
         """Test conforms to schema."""
         res = check_conforms_to_schema(self, TEST_URL, "Metadata")
+        assert res["database"]["type"] == "sqlite"
         assert "search" in res
         assert "sifts" in res["search"]
         assert "version" in res["search"]["sifts"]


### PR DESCRIPTION
This avoids the iteration over all trees and simply takes the database backend from the database ID file. This is a slight API change because it uses the database ID rather than name, e.g. `sqlite` instead of `SQLite`.