### PR TITLE
Remove caching for search indexer

### DIFF
--- a/gramps_webapi/api/search/__init__.py
+++ b/gramps_webapi/api/search/__init__.py
@@ -28,17 +28,10 @@ from flask import current_app
 from .indexer import SearchIndexer, SemanticSearchIndexer, SearchIndexerBase
 from .embeddings import embedding_function_factory
 
-_KEY_INDEXER = "_SEARCH_INDEXER"
-_KEY_INDEXER_SEMANTIC = "_SEARCH_INDEXER_SEMANTIC"
-
 
 def get_search_indexer(tree: str, semantic: bool = False) -> SearchIndexerBase:
     """Get the search indexer for the tree."""
     # return cached instances if possible
-    if not semantic and (indexer := current_app.config.get(_KEY_INDEXER)):
-        return indexer
-    if semantic and (indexer := current_app.config.get(_KEY_INDEXER_SEMANTIC)):
-        return indexer
     db_url = current_app.config["SEARCH_INDEX_DB_URI"] or None
     if not db_url and current_app.config["SEARCH_INDEX_DIR"]:
         # backwards compatibility...
@@ -65,10 +58,7 @@ def get_search_indexer(tree: str, semantic: bool = False) -> SearchIndexerBase:
         except OSError:
             raise ValueError(f"Failed initializing model {model}")
         # cache on app instance
-        current_app.config[_KEY_INDEXER_SEMANTIC] = SemanticSearchIndexer(
+        return SemanticSearchIndexer(
             db_url=db_url, tree=tree, embedding_function=embedding_function
         )
-        return current_app.config[_KEY_INDEXER_SEMANTIC]
-    # cache on app instance
-    current_app.config[_KEY_INDEXER] = SearchIndexer(db_url=db_url, tree=tree)
-    return current_app.config[_KEY_INDEXER]
+    return SearchIndexer(db_url=db_url, tree=tree)


### PR DESCRIPTION
Investigating issues with search on a multi-tree instance, I realized that the caching of the search indexer introduced in v2.5.0 broke searching on multi-tree deployments :unamused: 

This hotfix removes caching for the moment.

Note: the bug did not lead to any data leaks! The only consequence was that users sometimes did not get any search result, and this was not deterministic.