### PR TITLE
Restore embedding model caching

### DIFF
--- a/gramps_webapi/api/search/__init__.py
+++ b/gramps_webapi/api/search/__init__.py
@@ -26,7 +26,6 @@ from urllib.parse import urlparse
 from flask import current_app
 
 from .indexer import SearchIndexer, SemanticSearchIndexer, SearchIndexerBase
-from .embeddings import embedding_function_factory
 
 
 def get_search_indexer(tree: str, semantic: bool = False) -> SearchIndexerBase:

--- a/gramps_webapi/api/search/__init__.py
+++ b/gramps_webapi/api/search/__init__.py
@@ -50,15 +50,10 @@ def get_search_indexer(tree: str, semantic: bool = False) -> SearchIndexerBase:
             if not path.exists() and not path.parent.exists():
                 path.parent.mkdir(parents=True, exist_ok=True)
     if semantic:
-        model = current_app.config.get("VECTOR_EMBEDDING_MODEL")
+        model = current_app.config.get("_INITIALIZED_VECTOR_EMBEDDING_MODEL")
         if not model:
             raise ValueError("VECTOR_EMBEDDING_MODEL option not set")
-        try:
-            embedding_function = embedding_function_factory(model)
-        except OSError:
-            raise ValueError(f"Failed initializing model {model}")
-        # cache on app instance
         return SemanticSearchIndexer(
-            db_url=db_url, tree=tree, embedding_function=embedding_function
+            db_url=db_url, tree=tree, embedding_function=model.encode
         )
     return SearchIndexer(db_url=db_url, tree=tree)

--- a/gramps_webapi/api/search/embeddings.py
+++ b/gramps_webapi/api/search/embeddings.py
@@ -3,15 +3,6 @@
 from ..util import get_logger
 
 
-def embedding_function_factory(model_name: str):
-    model = load_model(model_name)
-
-    def embedding_function(queries: list[str]):
-        return model.encode(queries)
-
-    return embedding_function
-
-
 def load_model(model_name: str):
     """Load the sentence transformer model.
 

--- a/gramps_webapi/app.py
+++ b/gramps_webapi/app.py
@@ -191,7 +191,9 @@ def create_app(config: Optional[Dict[str, Any]] = None):
         user_db.session.remove()  # pylint: disable=no-member
 
     if app.config.get("VECTOR_EMBEDDING_MODEL"):
-        load_model(app.config["VECTOR_EMBEDDING_MODEL"])
+        app.config["_INITIALIZED_VECTOR_EMBEDDING_MODEL"] = load_model(
+            app.config["VECTOR_EMBEDDING_MODEL"]
+        )
 
     @app.route("/ready", methods=["GET"])
     def ready():


### PR DESCRIPTION
Since search indexer caching had to be removed in the last release, this introduces embedding model caching at app instance level instead.