### PR TITLE
Add DNA match parser resource

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,25 +1,28 @@
 repos:
-  - repo: https://github.com/pre-commit/mirrors-isort
-    rev: v5.10.1
+  - repo: https://github.com/pycqa/isort
+    rev: 5.13.2
     hooks:
       - id: isort
         args: ["--profile", "black"]
   - repo: https://github.com/psf/black
-    rev: 24.8.0
+    rev: 24.10.0
     hooks:
       - id: black
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.11.2
+    rev: v1.14.1
     hooks:
     -   id: mypy
-        args: [--ignore-missing-imports]
+        args: [--ignore-missing-imports, --no-strict-optional]
+        additional_dependencies:
+          - types-setuptools
   - repo: https://github.com/PyCQA/pylint
-    rev: v3.2.7
+    rev: v3.3.3
     hooks:
       - id: pylint
         stages: [commit]
         args:
           - --score=n
+          - --disable=import-error,arguments-differ,too-many-locals
   - repo: https://github.com/PyCQA/pydocstyle
     rev: 6.3.0
     hooks:

--- a/gramps_webapi/_version.py
+++ b/gramps_webapi/_version.py
@@ -18,4 +18,7 @@
 #
 
 # make sure to match this version with the one in apispec.yaml
-__version__ = "2.7.0"
+
+"""Version information."""
+
+__version__ = "2.8.0"

--- a/gramps_webapi/api/__init__.py
+++ b/gramps_webapi/api/__init__.py
@@ -37,7 +37,7 @@ from .resources.bookmarks import (
 from .resources.chat import ChatResource
 from .resources.citations import CitationResource, CitationsResource
 from .resources.config import ConfigResource, ConfigsResource
-from .resources.dna import PersonDnaMatchesResource
+from .resources.dna import PersonDnaMatchesResource, DnaMatchParserResource
 from .resources.events import EventResource, EventSpanResource, EventsResource
 from .resources.export_media import MediaArchiveFileResource, MediaArchiveResource
 from .resources.exporters import (
@@ -235,6 +235,8 @@ register_endpt(FiltersResources, "/filters/", "filters")
 # Translations
 register_endpt(TranslationResource, "/translations/<string:language>", "translation")
 register_endpt(TranslationsResource, "/translations/", "translations")
+# Parsers
+register_endpt(DnaMatchParserResource, "/parsers/dna-match", "dna-match-parser")
 # Relations
 register_endpt(
     RelationResource,

--- a/gramps_webapi/api/resources/base.py
+++ b/gramps_webapi/api/resources/base.py
@@ -161,7 +161,7 @@ class GrampsObjectResourceHelper(GrampsJSONEncoder):
         try:
             obj_dict = fix_object_dict(obj_dict)
         except ValueError as exc:
-            abort_with_message(400, "Error while processing object")
+            abort_with_message(400, f"Error while processing object: {exc}")
         if not validate_object_dict(obj_dict):
             abort_with_message(400, "Schema validation failed")
         return from_json(json.dumps(obj_dict))

--- a/gramps_webapi/api/resources/dna.py
+++ b/gramps_webapi/api/resources/dna.py
@@ -21,29 +21,32 @@
 
 """DNA resources."""
 
-from typing import Any, Dict, List, Optional, Union
+from __future__ import annotations
+
+from typing import Any
 
 from flask import abort
 from gramps.gen.const import GRAMPS_LOCALE as glocale
 from gramps.gen.db.base import DbReadBase
 from gramps.gen.errors import HandleError
-from gramps.gen.lib import Person, PersonRef
+from gramps.gen.lib import Note, Person, PersonRef
 from gramps.gen.relationship import get_relationship_calculator
 from gramps.gen.utils.grampslocale import GrampsLocale
 from webargs import fields, validate
 
 from gramps_webapi.api.people_families_cache import CachePeopleFamiliesProxy
+from gramps_webapi.types import ResponseReturnValue
 
 from ...types import Handle
 from ..util import get_db_handle, get_locale_for_language, use_args
-from .util import get_person_profile_for_handle
 from . import ProtectedResource
+from .util import get_person_profile_for_handle
 
 SIDE_UNKNOWN = "U"
 SIDE_MATERNAL = "M"
 SIDE_PATERNAL = "P"
 
-Segment = Dict[str, Union[float, int, str]]
+Segment = dict[str, float | int | str]
 
 
 class PersonDnaMatchesResource(ProtectedResource):
@@ -57,7 +60,7 @@ class PersonDnaMatchesResource(ProtectedResource):
         },
         location="query",
     )
-    def get(self, args: Dict, handle: str):
+    def get(self, args: dict, handle: str):
         """Get the DNA match data."""
         db_handle = CachePeopleFamiliesProxy(get_db_handle())
 
@@ -84,12 +87,24 @@ class PersonDnaMatchesResource(ProtectedResource):
         return matches
 
 
+class DnaMatchParserResource(ProtectedResource):
+    """DNA match parser resource."""
+
+    @use_args(
+        {"string": fields.Str(required=True)},
+        location="json",
+    )
+    def post(self, args: dict) -> ResponseReturnValue:
+        """Parse DNA match string."""
+        return parse_raw_dna_match_string(args["string"])
+
+
 def get_match_data(
     db_handle: DbReadBase,
     person: Person,
     association: PersonRef,
     locale: GrampsLocale = glocale,
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """Get the DNA match data in the appropriate format."""
     relationship = get_relationship_calculator(reinit=True, clocale=locale)
     associate = db_handle.get_person_from_handle(association.ref)
@@ -154,19 +169,25 @@ def get_match_data(
 
 
 def get_segments_from_note(
-    db_handle: DbReadBase, handle: Handle, side: Optional[str] = None
-) -> List[Segment]:
+    db_handle: DbReadBase, handle: Handle, side: str | None = None
+) -> list[Segment]:
     """Get the segements from a note handle."""
-    note = db_handle.get_note_from_handle(handle)
+    note: Note = db_handle.get_note_from_handle(handle)
+    raw_string: str = note.get()
+    return parse_raw_dna_match_string(raw_string)
+
+
+def parse_raw_dna_match_string(raw_string: str) -> list[Segment]:
+    """Parse a raw DNA match string and return a list of segments."""
     segments = []
-    for line in note.get().split("\n"):
-        data = parse_line(line, side=side)
+    for line in raw_string.split("\n"):
+        data = parse_line(line)
         if data:
             segments.append(data)
     return segments
 
 
-def parse_line(line: str, side: Optional[str] = None) -> Optional[Segment]:
+def parse_line(line: str, side: str | None = None) -> Segment | None:
     """Parse a line from the CSV/TSV data and return a dictionary."""
     if "\t" in line:
         # Tabs are the field separators. Now determine THOUSEP and RADIXCHAR.

--- a/gramps_webapi/api/resources/dna.py
+++ b/gramps_webapi/api/resources/dna.py
@@ -23,7 +23,7 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Union
 
 from flask import abort
 from gramps.gen.const import GRAMPS_LOCALE as glocale
@@ -46,7 +46,7 @@ SIDE_UNKNOWN = "U"
 SIDE_MATERNAL = "M"
 SIDE_PATERNAL = "P"
 
-Segment = dict[str, float | int | str]
+Segment = dict[str, Union[float, int, str]]
 
 
 class PersonDnaMatchesResource(ProtectedResource):
@@ -174,14 +174,16 @@ def get_segments_from_note(
     """Get the segements from a note handle."""
     note: Note = db_handle.get_note_from_handle(handle)
     raw_string: str = note.get()
-    return parse_raw_dna_match_string(raw_string)
+    return parse_raw_dna_match_string(raw_string, side=side)
 
 
-def parse_raw_dna_match_string(raw_string: str) -> list[Segment]:
+def parse_raw_dna_match_string(
+    raw_string: str, side: str | None = None
+) -> list[Segment]:
     """Parse a raw DNA match string and return a list of segments."""
     segments = []
     for line in raw_string.split("\n"):
-        data = parse_line(line)
+        data = parse_line(line, side=side)
         if data:
             segments.append(data)
     return segments

--- a/gramps_webapi/data/apispec.yaml
+++ b/gramps_webapi/data/apispec.yaml
@@ -1,7 +1,7 @@
 swagger: "2.0"
 info:
   title: "Gramps Web API"
-  version: "2.7.0"
+  version: "2.8.0"
   description: >
     The Gramps Web API is a REST API that provides access to family tree databases generated and maintained with Gramps, a popular Open Source genealogical research software package.
 
@@ -7126,6 +7126,37 @@ paths:
             $ref: "#/definitions/Metadata"
         401:
           description: "Unauthorized: Missing authorization header."
+
+
+##############################################################################
+# Endpoint - Parsers
+##############################################################################
+
+  /parsers/dna-match:
+    post:
+      tags:
+      - parsers
+      summary: "Parse a DNA match file."
+      operationId: parseDnaMatch
+      security:
+        - Bearer: []
+      parameters:
+      - name: string
+        in: json
+        required: true
+        type: string
+        description: "The raw DNA match data to parse."
+      responses:
+        200:
+          description: "OK: sucessfully parser."
+          schema:
+            type: array
+            items:
+              $ref: "#/definitions/DnaMatch"
+        401:
+          description: "Unauthorized: Missing authorization header."
+        422:
+          description: "Unprocessable Entity: Invalid or bad parameter provided."
 
 
 ##############################################################################


### PR DESCRIPTION
This adds a new resource where a string can be posted and a list of DNA matches is returned. This is needed to implement a better DNA match editing experience in Gramps Web, see https://github.com/gramps-project/gramps-web/pull/568.

So far, it uses only the existing parser function. Actually improving the function (see #599) will be done in a follow-up PR.

To do:

- [x] Add to API spec
- [x] Add unit test