### PR TITLE
Pre-commit: remove pylint, silence errors

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,14 +15,6 @@ repos:
         args: [--ignore-missing-imports, --no-strict-optional]
         additional_dependencies:
           - types-setuptools
-  - repo: https://github.com/PyCQA/pylint
-    rev: v3.3.3
-    hooks:
-      - id: pylint
-        stages: [commit]
-        args:
-          - --score=n
-          - --disable=import-error,arguments-differ,too-many-locals
   - repo: https://github.com/PyCQA/pydocstyle
     rev: 6.3.0
     hooks:

--- a/gramps_webapi/const.py
+++ b/gramps_webapi/const.py
@@ -23,7 +23,7 @@ import shutil
 
 import gramps.gen.lib as lib
 from gramps.gen.plug import CATEGORY_DRAW, CATEGORY_GRAPHVIZ, CATEGORY_TEXT
-from pkg_resources import resource_filename
+from pkg_resources import resource_filename  # type: ignore[import-untyped]
 
 from ._version import __version__ as VERSION
 
@@ -136,7 +136,8 @@ MIME_TYPES = {
 # depending on whether needed dependencies are available.
 try:
     import gi
-    gi.require_version('Gtk', '3.0')
+
+    gi.require_version("Gtk", "3.0")
 
     REPORT_FILTERS = ["gv", "dot", "gvpdf"]
     REPORT_DEFAULTS = {


### PR DESCRIPTION
This makse to changes to pre-commit. First, it removes pylint - actually, the codebase is not compliant with pylint and enforcing it as a pre-commit hook doesn't make sense. We don't even enforce it in the CI at present.

Concerning mypy, it works but raised some import-untyped error as pre-commit works in an isolated venv. This error is now suppressed.