### PR TITLE
Add opt-out telemetry

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -2,7 +2,7 @@
   "recommendations": [
     "ms-python.python",
     "ms-python.black-formatter",
-    "editorconfig.editorconfig"
+    "ms-python.isort"
   ]
 }
 

--- a/gramps_webapi/api/cache.py
+++ b/gramps_webapi/api/cache.py
@@ -21,6 +21,7 @@ from gramps_webapi.auth.const import PERM_VIEW_PRIVATE
 
 thumbnail_cache = Cache()
 request_cache = Cache()
+persistent_cache = Cache()
 
 
 def get_db_last_change_timestamp(tree_id: str) -> int | float | None:

--- a/gramps_webapi/api/tasks.py
+++ b/gramps_webapi/api/tasks.py
@@ -53,6 +53,7 @@ from .resources.util import (
     transaction_to_json,
 )
 from .search import get_search_indexer, get_semantic_search_indexer
+from .telemetry import get_telemetry_payload, send_telemetry, update_telemetry_timestamp
 from .util import (
     abort_with_message,
     check_quota_people,
@@ -547,7 +548,7 @@ def process_transactions(
     finally:
         close_db(db_handle)
     return trans_dict
-        
+
 
 def handle_delete(trans: DbTxn, class_name: str, handle: str) -> None:
     """Handle a delete action."""
@@ -606,3 +607,12 @@ def update_search_indices_from_transaction(
                 indexer_semantic.add_or_update_object(handle, db_handle, class_name)
     finally:
         close_db(db_handle)
+
+
+@shared_task()
+def send_telemetry_task(tree: str):
+    """Send telemetry"""
+    data = get_telemetry_payload(tree_id=tree)
+    # if the request fails, an exception will be raised
+    send_telemetry(data=data)
+    update_telemetry_timestamp()

--- a/gramps_webapi/api/telemetry.py
+++ b/gramps_webapi/api/telemetry.py
@@ -1,0 +1,80 @@
+"""Optional telemetry for Gramps Web API."""
+
+import os
+import time
+import uuid
+
+import requests
+from flask import current_app
+
+from gramps_webapi.api.cache import persistent_cache
+from gramps_webapi.auth.passwords import hash_password_salt
+from gramps_webapi.const import (
+    TELEMETRY_ENDPOINT,
+    TELEMETRY_SERVER_ID_KEY,
+    TELEMETRY_TIMESTAMP_KEY,
+)
+
+
+def send_telemetry(data: dict[str, str | int | float]) -> None:
+    """Send telemetry"""
+    response = requests.post(TELEMETRY_ENDPOINT, json=data, timeout=30)
+    response.raise_for_status()  # Raise exception for HTTP errors
+
+
+def should_send_telemetry() -> bool:
+    """Whether telemetry should be sent."""
+    if current_app.config.get("DISABLE_TELEMETRY"):
+        return False
+    if os.getenv("FLASK_RUN_FROM_CLI"):
+        # Flask development server, not a production environment (hopefully!)
+        return False
+    if (os.environ.get("PYTEST_CURRENT_TEST") or current_app.testing) and not os.getenv(
+        "MOCK_TELEMETRY"
+    ):
+        # do not send telemetry during tests unless MOCK_TELEMETRY is set
+        return False
+    # only send telemetry if it has not been sent in the last 24 hours
+    if time.time() - telemetry_last_sent() < 24 * 60 * 60:
+        return False
+    return True
+
+
+def telemetry_last_sent() -> float:
+    """Timestamp when telemetry was last sent successfully."""
+    return persistent_cache.get(TELEMETRY_TIMESTAMP_KEY) or 0.0
+
+
+def update_telemetry_timestamp() -> None:
+    """Update the telemetry timestamp."""
+    persistent_cache.set(TELEMETRY_TIMESTAMP_KEY, time.time())
+
+
+def generate_server_uuid() -> str:
+    """Generate a random, unique server UUID."""
+    return uuid.uuid4().hex
+
+
+def generate_tree_uuid(tree_id: str, server_uuid: str) -> str:
+    """Generate a unique tree UUID for the given tree ID and server UUID.
+
+    The tree UUID is uniquely determined for a given tree ID and server
+    UUID but does not allow reconstructing the tree ID.
+    """
+    return hash_password_salt(password=tree_id, salt=server_uuid.encode()).hex()
+
+
+def get_telemetry_payload(tree_id: str) -> dict[str, str | int | float]:
+    """Get the telemetry payload for the given tree ID."""
+    if not tree_id:
+        raise ValueError("Tree ID must not be empty")
+    server_uuid = persistent_cache.get(TELEMETRY_SERVER_ID_KEY)
+    if not server_uuid:
+        server_uuid = generate_server_uuid()
+        persistent_cache.set(TELEMETRY_SERVER_ID_KEY, server_uuid)
+    tree_uuid = generate_tree_uuid(tree_id=tree_id, server_uuid=server_uuid)
+    return {
+        "server_uuid": server_uuid,
+        "tree_uuid": tree_uuid,
+        "timestamp": time.time(),
+    }

--- a/gramps_webapi/app.py
+++ b/gramps_webapi/app.py
@@ -27,15 +27,17 @@ from typing import Any, Dict, Optional
 from flask import Flask, abort, g, send_from_directory
 from flask_compress import Compress
 from flask_cors import CORS
-from flask_jwt_extended import JWTManager
+from flask_jwt_extended import JWTManager, verify_jwt_in_request
 from gramps.gen.config import config as gramps_config
 from gramps.gen.config import set as setconfig
 
 from .api import api_blueprint
-from .api.cache import request_cache, thumbnail_cache
+from .api.cache import persistent_cache, request_cache, thumbnail_cache
 from .api.ratelimiter import limiter
 from .api.search.embeddings import load_model
-from .api.util import close_db
+from .api.tasks import run_task, send_telemetry_task
+from .api.telemetry import should_send_telemetry
+from .api.util import close_db, get_tree_from_jwt
 from .auth import user_db
 from .config import DefaultConfig, DefaultConfigJWT
 from .const import API_PREFIX, ENV_CONFIG_FILE, TREE_MULTI
@@ -145,6 +147,7 @@ def create_app(config: Optional[Dict[str, Any]] = None, config_from_env: bool = 
 
     request_cache.init_app(app, config=app.config["REQUEST_CACHE_CONFIG"])
     thumbnail_cache.init_app(app, config=app.config["THUMBNAIL_CACHE_CONFIG"])
+    persistent_cache.init_app(app, config=app.config["PERSISTENT_CACHE_CONFIG"])
 
     # enable CORS for /api/... resources
     if app.config.get("CORS_ORIGINS"):
@@ -179,6 +182,19 @@ def create_app(config: Optional[Dict[str, Any]] = None, config_from_env: bool = 
 
     # instantiate celery
     create_celery(app)
+
+    @app.before_request
+    def maybe_send_telemetry() -> None:
+        """Send telementry if needed."""
+        if verify_jwt_in_request(optional=True) is None:
+            # for requests without JWT, do nothing
+            return None
+        tree_id = get_tree_from_jwt()
+        if not tree_id:
+            # for endpoints that don't require a JWT, we do nothing
+            return None
+        if should_send_telemetry():
+            run_task(send_telemetry_task, tree=tree_id)
 
     @app.teardown_appcontext
     def close_db_connection(exception) -> None:

--- a/gramps_webapi/config.py
+++ b/gramps_webapi/config.py
@@ -51,6 +51,12 @@ class DefaultConfig(object):
         "CACHE_THRESHOLD": 1000,
         "CACHE_DEFAULT_TIMEOUT": 0,
     }
+    PERSISTENT_CACHE_CONFIG = {
+        "CACHE_TYPE": "FileSystemCache",
+        "CACHE_DIR": str(Path.cwd() / "persistent_cache"),
+        "CACHE_THRESHOLD": 0,
+        "CACHE_DEFAULT_TIMEOUT": 0,
+    }
     POSTGRES_USER = None
     POSTGRES_PASSWORD = None
     POSTGRES_HOST = "localhost"
@@ -69,6 +75,7 @@ class DefaultConfig(object):
     LLM_MODEL = ""
     LLM_MAX_CONTEXT_LENGTH = 50000
     VECTOR_EMBEDDING_MODEL = ""
+    DISABLE_TELEMETRY = False
 
 
 class DefaultConfigJWT(object):

--- a/gramps_webapi/const.py
+++ b/gramps_webapi/const.py
@@ -195,3 +195,8 @@ DISABLED_IMPORTERS = ["gpkg"]
 
 # list of exporters (by file extension) that are not allowed
 DISABLED_EXPORTERS = ["gpkg"]
+
+# Settings for the opt-out telemetry
+TELEMETRY_ENDPOINT = "https://telemetry-cloud-run-442080026669.europe-west1.run.app"
+TELEMETRY_TIMESTAMP_KEY = "telemetry_last_sent"
+TELEMETRY_SERVER_ID_KEY = "telemetry_server_uuid"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ dependencies = [
     "gramps-ql>=0.4.0",
     "object-ql>=0.1.3",
     "sifts>=0.8.3",
+    "requests",
 ]
 
 [project.optional-dependencies]

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -1,0 +1,92 @@
+""" "Test the telemetry functionality."""
+
+#
+# Gramps Web API - A RESTful API for the Gramps genealogy program
+#
+# Copyright (C) 2025      David Straub
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+#
+
+import time
+import unittest
+from unittest.mock import patch
+
+from gramps.cli.clidbman import CLIDbManager
+from gramps.gen.dbstate import DbState
+
+from gramps_webapi.api.cache import persistent_cache
+from gramps_webapi.app import create_app
+from gramps_webapi.auth import add_user, user_db
+from gramps_webapi.auth.const import ROLE_GUEST
+from gramps_webapi.const import ENV_CONFIG_FILE, TEST_AUTH_CONFIG
+from gramps_webapi.dbmanager import WebDbManager
+
+
+class TestPerson(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.name = "Test Web API test_jwt"
+        cls.dbman = CLIDbManager(DbState())
+        _, _name = cls.dbman.create_new_db_cli(cls.name, dbid="sqlite")
+        with patch.dict("os.environ", {ENV_CONFIG_FILE: TEST_AUTH_CONFIG}):
+            cls.app = create_app(
+                config={"TESTING": True, "RATELIMIT_ENABLED": False},
+                config_from_env=False,
+            )
+        cls.client = cls.app.test_client()
+        # add a user to the database
+        db_manager = WebDbManager(cls.name, create_if_missing=False)
+        tree = db_manager.dirname
+        with cls.app.app_context():
+            user_db.create_all()
+            add_user(name="user", password="123", role=ROLE_GUEST, tree=tree)
+        persistent_cache.clear()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.dbman.remove_database(cls.name)
+        persistent_cache.clear()
+
+    def test_telemetry(self):
+        with patch.dict("os.environ", {"MOCK_TELEMETRY": "1"}):
+            with patch("requests.post") as mock_post:
+                rv = self.client.post(
+                    "/api/token/", json={"username": "user", "password": "123"}
+                )
+                access_token = rv.json["access_token"]
+                header = {"Authorization": "Bearer {}".format(access_token)}
+                rv = self.client.get("/api/people/")
+                assert rv.status_code == 401
+                # No JWT in request, so telemetry should not have been sent
+                mock_post.assert_not_called()
+                rv = self.client.get("/api/people/", headers=header)
+                now = time.time()
+                assert rv.status_code == 200
+                # Telemetry should have been sent
+                mock_post.assert_called_once()
+                _, kwargs = mock_post.call_args
+                assert "timestamp" in kwargs["json"]
+                assert "server_uuid" in kwargs["json"]
+                assert "tree_uuid" in kwargs["json"]
+                last_sent = persistent_cache.get("telemetry_last_sent")
+                assert last_sent is not None
+                assert abs(now - last_sent) < 5.0
+                assert kwargs["json"]["timestamp"] - last_sent < 5.0
+                server_uuid = persistent_cache.get("telemetry_server_uuid")
+                assert server_uuid == kwargs["json"]["server_uuid"]
+                # call again
+                rv = self.client.get("/api/people/", headers=header)
+                # sent still just once
+                mock_post.assert_called_once()


### PR DESCRIPTION
This adds opt-out telemetry sending anonymized server UUID, tree UUID, and a timestamp to an analytics endpoint every 24 hours (when a request is made) to an analytics endpoint. The request is sent by the background worker, so it does not delay the request. The telemetry server is deployed to Google Cloud Run using this open source repository https://github.com/DavidMStraub/cloud-run-telemetry forked from https://github.com/GoogleCloudPlatform/cloud-run-microservice-template-python.

Discussion: https://gramps.discourse.group/t/discussion-minimal-anonymized-opt-out-telemetry-for-gramps-web-api/7750