### PR TITLE
Bump Gramps to 6.0.4, version 3.2.1

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get update && apt-get install -y \
   && rm -rf /var/lib/apt/lists/*
 
 RUN pip install opencv-python
-RUN pip install gramps==6.0.1
+RUN pip install gramps==6.0.4
 
 # CPU-only version of PyTorch
 RUN pip install torch --index-url https://download.pytorch.org/whl/cpu

--- a/gramps_webapi/_version.py
+++ b/gramps_webapi/_version.py
@@ -21,4 +21,4 @@
 
 """Version information."""
 
-__version__ = "3.2.0"
+__version__ = "3.2.1"

--- a/gramps_webapi/data/apispec.yaml
+++ b/gramps_webapi/data/apispec.yaml
@@ -1,7 +1,7 @@
 swagger: "2.0"
 info:
   title: "Gramps Web API"
-  version: "3.2.0"
+  version: "3.2.1"
   description: >
     The Gramps Web API is a REST API that provides access to family tree databases generated and maintained with Gramps, a popular Open Source genealogical research software package.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ classifiers = [
 ]
 requires-python = ">=3.9"
 dependencies = [
-    "gramps[all]>=6.0.1,<6.1.0",
+    "gramps[all]>=6.0.4,<6.1.0",
     "PYGObject<=3.50.0",
     "orjson",
     "Click>=7.0",


### PR DESCRIPTION
6.0.4 is still missing on PyPI, thus keeping as draft