### PR TITLE
Endpoint for Y chromosome clade information

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -97,6 +97,9 @@ RUN ARCH=$(uname -m) && \
 model = SentenceTransformer('sentence-transformers/distiluse-base-multilingual-cased-v2')"; \
     fi
 
+# download and cache YFull tree for yclade
+RUN python3 -c "import yclade; yclade.tree.download_yfull_tree()"
+
 EXPOSE 5000
 
 COPY docker-entrypoint.sh /

--- a/gramps_webapi/api/__init__.py
+++ b/gramps_webapi/api/__init__.py
@@ -120,6 +120,7 @@ from .resources.user import (
     UsersResource,
     UserTriggerResetPasswordResource,
 )
+from .resources.ydna import PersonYDnaResource
 from .util import get_db_handle, get_tree_from_jwt, use_args
 
 api_blueprint = Blueprint("api", __name__, url_prefix=API_PREFIX)
@@ -157,6 +158,7 @@ register_endpt(
     "/people/<string:handle>/dna/matches",
     "person-dna-matches",
 )
+register_endpt(PersonYDnaResource, "/people/<string:handle>/ydna", "person-ydna")
 register_endpt(PeopleResource, "/people/", "people")
 # Families
 register_endpt(

--- a/gramps_webapi/api/resources/metadata.py
+++ b/gramps_webapi/api/resources/metadata.py
@@ -20,6 +20,8 @@
 
 """Metadata API resource."""
 
+from importlib import metadata
+
 import gramps_ql as gql
 import object_ql as oql
 import pytesseract
@@ -125,6 +127,7 @@ class MetadataResource(ProtectedResource, GrampsJSONEncoder):
             },
             "gramps_ql": {"version": gql.__version__},
             "object_ql": {"version": oql.__version__},
+            "yclade": {"version": metadata.version("yclade")},
             "locale": {
                 "lang": GRAMPS_LOCALE.lang,
                 "language": GRAMPS_LOCALE.language[0],

--- a/gramps_webapi/api/resources/ydna.py
+++ b/gramps_webapi/api/resources/ydna.py
@@ -80,7 +80,10 @@ class PersonYDnaResource(ProtectedResource):
         clade_lineage = yclade.find.get_clade_lineage(
             tree=tree_data, node=most_likely_clade
         )
-        result = {"clade_lineage": [asdict(clade_info) for clade_info in clade_lineage]}
+        result = {
+            "clade_lineage": [asdict(clade_info) for clade_info in clade_lineage],
+            "tree_version": tree_data.version,
+        }
         if args["raw"]:
             result["raw_data"] = snp_string
         return result

--- a/gramps_webapi/api/resources/ydna.py
+++ b/gramps_webapi/api/resources/ydna.py
@@ -46,7 +46,11 @@ class PersonYDnaResource(ProtectedResource):
     )
     @request_cache_decorator
     def get(self, args: dict, handle: str):
-        """Get the Y-DNA data."""
+        """Get Y-DNA data.
+
+        The raw data is expected to be in a person attribute of type 'Y-DNA'
+        in a format the yclade library understands.
+        """
         db_handle = get_db_handle()
         try:
             person: Person | None = db_handle.get_person_from_handle(handle)
@@ -76,4 +80,7 @@ class PersonYDnaResource(ProtectedResource):
         clade_lineage = yclade.find.get_clade_lineage(
             tree=tree_data, node=most_likely_clade
         )
-        return [asdict(clade_info) for clade_info in clade_lineage]
+        result = {"clade_lineage": [asdict(clade_info) for clade_info in clade_lineage]}
+        if args["raw"]:
+            result["raw_data"] = snp_string
+        return result

--- a/gramps_webapi/api/resources/ydna.py
+++ b/gramps_webapi/api/resources/ydna.py
@@ -1,0 +1,79 @@
+#
+# Gramps Web API - A RESTful API for the Gramps genealogy program
+#
+# Copyright (C) 2025  David Straub
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+#
+
+"""Y-DNA resources."""
+
+from __future__ import annotations
+from dataclasses import asdict
+
+import yclade
+from gramps.gen.errors import HandleError
+from gramps.gen.lib import Person
+from webargs import fields, validate
+
+from ..cache import request_cache_decorator
+from ..util import get_db_handle, use_args, abort_with_message
+from . import ProtectedResource
+
+
+class PersonYDnaResource(ProtectedResource):
+    """Resource for getting Y-DNA data for a person."""
+
+    @use_args(
+        {
+            "locale": fields.Str(
+                load_default=None, validate=validate.Length(min=2, max=5)
+            ),
+            "raw": fields.Bool(load_default=False),
+        },
+        location="query",
+    )
+    @request_cache_decorator
+    def get(self, args: dict, handle: str):
+        """Get the Y-DNA data."""
+        db_handle = get_db_handle()
+        try:
+            person: Person | None = db_handle.get_person_from_handle(handle)
+        except HandleError:
+            abort_with_message(404, "Person not found")
+        if person is None:
+            abort_with_message(404, "Person not found")
+            raise AssertionError  # for type checker
+        attribute = next(
+            (attr for attr in person.attribute_list if attr.type == "Y-DNA"), None
+        )
+        if attribute is None:
+            return {}
+        snp_string = attribute.value
+        snp_results = yclade.snps.parse_snp_results(snp_string)
+        tree_data = yclade.tree.get_yfull_tree_data()
+        snp_results = yclade.snps.normalize_snp_results(
+            snp_results=snp_results,
+            snp_aliases=tree_data.snp_aliases,
+        )
+        ordered_clade_details = yclade.find.get_ordered_clade_details(
+            tree=tree_data, snps=snp_results
+        )
+        if len(ordered_clade_details) == 0:
+            return {}
+        most_likely_clade = ordered_clade_details[0].name
+        clade_lineage = yclade.find.get_clade_lineage(
+            tree=tree_data, node=most_likely_clade
+        )
+        return [asdict(clade_info) for clade_info in clade_lineage]

--- a/gramps_webapi/data/apispec.yaml
+++ b/gramps_webapi/data/apispec.yaml
@@ -1329,6 +1329,47 @@ paths:
           description: "Unprocessable Entity: Invalid or bad parameter provided."
 
 
+  /people/{handle}/dna/ydna:
+    get:
+      tags:
+        - people
+      summary: Get Y-DNA clade lineage for a person
+      description: >
+        Returns the Y-DNA clade lineage for the person with the given handle, including clade age and confidence intervals if available.
+      parameters:
+        - name: handle
+          in: path
+          required: true
+          type: string
+          description: The handle of the person.
+        - name: raw
+          in: query
+          required: false
+          type: boolean
+          description: If true, include raw data in the response.
+      responses:
+        200:
+          description: Successful response with clade lineage information.
+          schema:
+            type: object
+            properties:
+              clade_lineage:
+                type: array
+                items:
+                  $ref: '#/definitions/CladeInfo'
+              raw_data:
+                description: The raw Y chromosome SNP data in a format compatible with the yclade library.
+                type: string
+                example: M215+, BY61636-, FTF15749-, TY15744-
+        401:
+          description: "Unauthorized: Missing authorization header."
+        404:
+          description: "Person not found."
+        422:
+          description: "Unprocessable Entity: Invalid or bad parameter provided."
+
+
+
 ##############################################################################
 # Endpoint - Families
 ##############################################################################
@@ -7511,6 +7552,66 @@ paths:
 ##############################################################################
 
 definitions:
+
+##############################################################################
+# Model - CladeAgeInfo
+##############################################################################
+
+  CladeAgeInfo:
+    type: object
+    properties:
+      formed:
+        type: number
+        format: float
+        description: How many years ago the clade was formed.
+        nullable: true
+        example: 4500
+      formed_confidence_interval:
+        type: array
+        items:
+          type: number
+          format: float
+        minItems: 2
+        maxItems: 2
+        description: 95% confidence interval for the formed age.
+        nullable: true
+      most_recent_common_ancestor:
+        type: number
+        format: float
+        description: How many years ago the most recent common ancestor was born.
+        nullable: true
+        example: 3800
+      most_recent_common_ancestor_confidence_interval:
+        type: array
+        items:
+          type: number
+          format: float
+        minItems: 2
+        maxItems: 2
+        description: 95% confidence interval for the most recent common ancestor age.
+        nullable: true
+
+##############################################################################
+# Model - CladeInfo
+##############################################################################
+
+  CladeInfo:
+    type: object
+    properties:
+      name:
+        type: string
+        description: The ID of the clade.
+        example: BY61636
+      age_info:
+        $ref: '#/definitions/CladeAgeInfo'
+        description: The age information for the clade.
+        nullable: true
+      score:
+        type: number
+        format: float
+        description: The score for the clade (optional).
+        nullable: true
+        example: 9.0
 
 ##############################################################################
 # Model - Token

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ dependencies = [
     "object-ql>=0.1.3",
     "sifts>=0.8.3",
     "requests",
-    "yclade>=0.4.0",
+    "yclade>=0.5.0",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ dependencies = [
     "object-ql>=0.1.3",
     "sifts>=0.8.3",
     "requests",
+    "yclade>=0.4.0",
 ]
 
 [project.optional-dependencies]

--- a/tests/test_endpoints/test_ydna.py
+++ b/tests/test_endpoints/test_ydna.py
@@ -109,5 +109,11 @@ class TestYDnaEndpoint(unittest.TestCase):
         assert rv.status_code == 201
         rv = self.client.get(f"/api/people/{handle}/ydna", headers=headers)
         assert rv.status_code == 200
-        assert isinstance(rv.json, list)
-        assert all("name" in item and "age_info" in item for item in rv.json)
+        assert "clade_lineage" in rv.json
+        assert all(
+            "name" in item and "age_info" in item for item in rv.json["clade_lineage"]
+        )
+        assert "raw_data" not in rv.json
+        rv = self.client.get(f"/api/people/{handle}/ydna?raw=1", headers=headers)
+        assert "raw_data" in rv.json
+        assert rv.json["raw_data"] == ydna_string

--- a/tests/test_endpoints/test_ydna.py
+++ b/tests/test_endpoints/test_ydna.py
@@ -1,0 +1,113 @@
+#
+# Gramps Web API - A RESTful API for the Gramps genealogy program
+#
+# Copyright (C) 2025   David Straub
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+#
+
+"""Tests for the /people/<handle>/ydna/ endpoint."""
+
+import os
+import unittest
+import uuid
+from unittest.mock import patch
+
+from gramps.cli.clidbman import CLIDbManager
+from gramps.gen.dbstate import DbState
+
+from gramps_webapi.app import create_app
+from gramps_webapi.auth import add_user, user_db
+from gramps_webapi.auth.const import ROLE_GUEST, ROLE_OWNER
+from gramps_webapi.const import ENV_CONFIG_FILE, TEST_AUTH_CONFIG
+
+
+def get_headers(client, user: str, password: str):
+    rv = client.post("/api/token/", json={"username": user, "password": password})
+    access_token = rv.json["access_token"]
+    return {"Authorization": f"Bearer {access_token}"}
+
+
+def make_handle():
+    return str(uuid.uuid4())
+
+
+class TestYDnaEndpoint(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.name = "Test Web API YDNA"
+        cls.dbman = CLIDbManager(DbState())
+        dbpath, _ = cls.dbman.create_new_db_cli(cls.name, dbid="sqlite")
+        tree = os.path.basename(dbpath)
+        with patch.dict("os.environ", {ENV_CONFIG_FILE: TEST_AUTH_CONFIG}):
+            cls.app = create_app(config_from_env=False)
+        cls.app.config["TESTING"] = True
+        cls.client = cls.app.test_client()
+        with cls.app.app_context():
+            user_db.create_all()
+            add_user(name="user", password="123", role=ROLE_GUEST, tree=tree)
+            add_user(name="admin", password="123", role=ROLE_OWNER, tree=tree)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.dbman.remove_database(cls.name)
+
+    def test_without_token(self):
+        rv = self.client.get("/api/people/nope/ydna")
+        assert rv.status_code == 401
+
+    def test_person_not_found(self):
+        headers = get_headers(self.client, "user", "123")
+        rv = self.client.get("/api/people/nope/ydna", headers=headers)
+        assert rv.status_code == 404
+
+    def test_no_ydna(self):
+        headers = get_headers(self.client, "admin", "123")
+        person = {
+            "primary_name": {
+                "surname_list": [{"_class": "Surname", "surname": "Doe"}],
+                "first_name": "John",
+            },
+            "gender": 1,
+        }
+        rv = self.client.post("/api/people/", json=person, headers=headers)
+        assert rv.status_code == 201
+        handle = rv.json[0]["handle"]
+        rv = self.client.get(f"/api/people/{handle}/ydna", headers=headers)
+        assert rv.status_code == 200
+        assert rv.json == {}
+
+    def test_with_ydna(self):
+        headers = get_headers(self.client, "admin", "123")
+        handle = make_handle()
+        ydna_string = "M269+, CTS1078+, P312+, U106-, L21-, Z290-, Z2103+, FGC3845-"
+        person = {
+            "_class": "Person",
+            "handle": handle,
+            "primary_name": {
+                "_class": "Name",
+                "surname_list": [{"_class": "Surname", "surname": "Smith"}],
+                "first_name": "Adam",
+            },
+            "gender": 1,
+            "attribute_list": [
+                {"_class": "Attribute", "type": "Y-DNA", "value": ydna_string}
+            ],
+        }
+        rv = self.client.post("/api/objects/", json=[person], headers=headers)
+        assert rv.status_code == 201
+        rv = self.client.get(f"/api/people/{handle}/ydna", headers=headers)
+        assert rv.status_code == 200
+        assert isinstance(rv.json, list)
+        assert all("name" in item and "age_info" in item for item in rv.json)


### PR DESCRIPTION
This adds a new endpoint `/api/people/<handle>/ydna` that takes raw Y chromosome SNP information from a person attribute of type `Y-DNA` (in a format compatible with [yclade](https://github.com/DavidMStraub/yclade)) and returns the most likely clade from the Y full tree as well as all ancestor clades with age information (date format and date of the MRCA).