### PR TITLE
#681 validate name_format query parameter with regexp to prevent mali…

### DIFF
--- a/gramps_webapi/api/resources/base.py
+++ b/gramps_webapi/api/resources/base.py
@@ -37,7 +37,7 @@ from webargs import fields, validate
 from gramps_webapi.types import ResponseReturnValue
 
 from ...auth.const import PERM_ADD_OBJ, PERM_DEL_OBJ, PERM_EDIT_OBJ
-from ...const import GRAMPS_OBJECT_PLURAL
+from ...const import GRAMPS_OBJECT_PLURAL, NAME_FORMAT_REGEXP
 from ..auth import require_permissions
 from ..cache import request_cache_decorator
 from ..search import SearchIndexer, get_search_indexer
@@ -210,7 +210,7 @@ class GrampsObjectResource(GrampsObjectResourceHelper, Resource):
             "locale": fields.Str(
                 load_default=None, validate=validate.Length(min=1, max=5)
             ),
-            "name_format": fields.Str(validate=validate.Length(min=1)),
+            "name_format": fields.Str(validate=validate.Regexp(NAME_FORMAT_REGEXP)),
             "profile": fields.DelimitedList(
                 fields.Str(validate=validate.Length(min=1)),
                 validate=validate.ContainsOnly(
@@ -377,7 +377,7 @@ class GrampsObjectsResource(GrampsObjectResourceHelper, Resource):
             "soundex": fields.Boolean(load_default=False),
             "strip": fields.Boolean(load_default=False),
             "filemissing": fields.Boolean(load_default=False),
-            "name_format": fields.Str(validate=validate.Length(min=1)),
+            "name_format": fields.Str(validate=validate.Regexp(NAME_FORMAT_REGEXP)),
         },
         location="query",
     )

--- a/gramps_webapi/api/resources/timeline.py
+++ b/gramps_webapi/api/resources/timeline.py
@@ -43,6 +43,7 @@ from ..util import get_db_handle, get_locale_for_language, use_args
 from . import ProtectedResource
 from .emit import GrampsJSONEncoder
 from .filters import apply_filter
+from ...const import NAME_FORMAT_REGEXP
 from .util import (
     get_person_profile_for_object,
     get_place_profile_for_object,
@@ -540,7 +541,7 @@ class PersonTimelineResource(ProtectedResource, GrampsJSONEncoder):
             "keys": fields.DelimitedList(fields.Str(validate=validate.Length(min=1))),
             "last": fields.Boolean(load_default=True),
             "locale": fields.Str(load_default=None),
-            "name_format": fields.Str(validate=validate.Length(min=1)),
+            "name_format": fields.Str(validate=validate.Regexp(NAME_FORMAT_REGEXP)),
             "offspring": fields.Integer(
                 load_default=1, validate=validate.Range(min=1, max=5)
             ),
@@ -633,7 +634,7 @@ class FamilyTimelineResource(ProtectedResource, GrampsJSONEncoder):
             "events": fields.DelimitedList(fields.Str(validate=validate.Length(min=1))),
             "keys": fields.DelimitedList(fields.Str(validate=validate.Length(min=1))),
             "locale": fields.Str(load_default=None),
-            "name_format": fields.Str(validate=validate.Length(min=1)),
+            "name_format": fields.Str(validate=validate.Regexp(NAME_FORMAT_REGEXP)),
             "page": fields.Integer(load_default=0, validate=validate.Range(min=1)),
             "pagesize": fields.Integer(load_default=20, validate=validate.Range(min=1)),
             "ratings": fields.Boolean(load_default=False),

--- a/gramps_webapi/const.py
+++ b/gramps_webapi/const.py
@@ -200,3 +200,7 @@ DISABLED_EXPORTERS = ["gpkg"]
 TELEMETRY_ENDPOINT = "https://telemetry-cloud-run-442080026669.europe-west1.run.app"
 TELEMETRY_TIMESTAMP_KEY = "telemetry_last_sent"
 TELEMETRY_SERVER_ID_KEY = "telemetry_server_uuid"
+
+NAME_FORMAT_REGEXP = (
+    r'^(%[%tTfFlLcCxXiImMyYoOrRpPqQsSnNgG]|%[0-2][mMyY]|[ "\',.:;\]\]\(\)\{\}\&\@])*$'
+)

--- a/gramps_webapi/const.py
+++ b/gramps_webapi/const.py
@@ -201,6 +201,5 @@ TELEMETRY_ENDPOINT = "https://telemetry-cloud-run-442080026669.europe-west1.run.
 TELEMETRY_TIMESTAMP_KEY = "telemetry_last_sent"
 TELEMETRY_SERVER_ID_KEY = "telemetry_server_uuid"
 
-NAME_FORMAT_REGEXP = (
-    r'^(%[%tTfFlLcCxXiImMyYoOrRpPqQsSnNgG]|%[0-2][mMyY]|[ "\',.:;\]\]\(\)\{\}\&\@])*$'
-)
+# Regular expression for allowed values of the `name_format` query parameter.
+NAME_FORMAT_REGEXP = r"^(%[%tTfFlLcCxXiImMyYoOrRpPqQsSnNgG]|%[0-2][mMyY]|[ \u0022\u0027,.:;\]\[\(\)\{\}\&\@])*$"

--- a/tests/test_endpoints/test_events.py
+++ b/tests/test_endpoints/test_events.py
@@ -782,7 +782,7 @@ class TestEventsHandle(unittest.TestCase):
         """Test response as expected."""
         rv = check_success(
             self,
-            TEST_URL + "a5af0eb6dd140de132c?profile=all&name_format=Given%20SURNAME",
+            TEST_URL + "a5af0eb6dd140de132c?profile=all&name_format=%25f%20%25M",
         )
         self.assertEqual(
             rv["profile"],

--- a/tests/test_endpoints/test_people.py
+++ b/tests/test_endpoints/test_people.py
@@ -1290,7 +1290,7 @@ class TestPeopleHandle(unittest.TestCase):
         rv = check_success(
             self,
             TEST_URL
-            + "0PWJQCZYFXOS0HGREE?profile=all&name_format=Given%20%28Common%29%20SURNAME",
+            + "0PWJQCZYFXOS0HGREE?profile=all&name_format=%25f%20%28%25x%29%20%25M",
         )
         self.assertEqual(
             rv["profile"]["name_display"], "Mary Grace Elizabeth (Mary) WARNER"


### PR DESCRIPTION
…cious code injection

I suppose, the regexp for accepted name display format and the name of the constant NAME_FORMAT_REGEXP may be changed.

Even the current regexp should pass any reasonable combinations of Name instance components with various punctuation added to them, but it prohibits any "words" including python identifiers and keywords, and therefore makes impossible malicious code injections.

This is, of course, a kind of paranoiac approach which is very restrictive. I'm ready to adopt a better one, not necessary with regexp, but maybe with some custom validate function.