### PR TITLE
Pin pillow below 12.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
     "webargs",
     "SQLAlchemy>=2.0.0",
     "pdf2image",
-    "Pillow<15.0.0",
+    "Pillow<12.0.0",
     "bleach[css]>=5.0.0",
     "jsonschema",
     "ffmpeg-python",


### PR DESCRIPTION
The new Pillow version causes a CI failure in the OCR test that I wasn't able to resolve so far.