### PR TITLE
Test with Python 3.14

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        python-version: ["3.10", "3.13"]
+        python-version: ["3.10", "3.14"]
     steps:
       - uses: actions/checkout@v4
       - name: Free up disk space


### PR DESCRIPTION
This pull request makes a small update to the test workflow configuration. The Python version matrix in `.github/workflows/test.yml` has been updated to test against Python 3.14 instead of 3.13.