### PR TITLE
Remove mediapath from imported Gramps XML file

### DIFF
--- a/gramps_webapi/api/resources/util.py
+++ b/gramps_webapi/api/resources/util.py
@@ -1451,24 +1451,16 @@ def remove_mediapath_from_gramps_xml(file_name: FilenameOrPath) -> None:
     Args:
         file_name: Path to the Gramps XML file.
     """
-    # First, detect if file is gzipped by trying to read it
-    is_compressed = False
+    # Try to read as gzipped file first
     try:
         with gzip.open(file_name, "rb") as f:
-            # Try to read first few bytes to confirm it's gzipped
-            f.read(10)
-            is_compressed = True
-    except (OSError, gzip.BadGzipFile):
-        # Not gzipped or can't read as gzip
-        is_compressed = False
-
-    # Read the file content
-    if is_compressed:
-        with gzip.open(file_name, "rb") as f:
             content = f.read()
-    else:
+        is_compressed = True
+    except (OSError, gzip.BadGzipFile):
+        # Not gzipped or can't read as gzip: fall back to plain file
         with open(file_name, "rb") as f:
             content = f.read()
+        is_compressed = False
 
     # Remove the mediapath tag using regex
     # Match <mediapath>...</mediapath> or <mediapath/> (empty tag)

--- a/tests/test_import_util.py
+++ b/tests/test_import_util.py
@@ -48,7 +48,9 @@ class TestRemoveMediapathFromGrampsXml(unittest.TestCase):
 </database>
 """
 
-        with tempfile.NamedTemporaryFile(mode="wb", suffix=".gramps", delete=False) as f:
+        with tempfile.NamedTemporaryFile(
+            mode="wb", suffix=".gramps", delete=False
+        ) as f:
             temp_file = f.name
             f.write(xml_content)
 
@@ -83,7 +85,9 @@ class TestRemoveMediapathFromGrampsXml(unittest.TestCase):
 </database>
 """
 
-        with tempfile.NamedTemporaryFile(mode="wb", suffix=".gramps", delete=False) as f:
+        with tempfile.NamedTemporaryFile(
+            mode="wb", suffix=".gramps", delete=False
+        ) as f:
             temp_file = f.name
             with gzip.open(f, "wb") as gz:
                 gz.write(xml_content)
@@ -118,7 +122,9 @@ class TestRemoveMediapathFromGrampsXml(unittest.TestCase):
 </database>
 """
 
-        with tempfile.NamedTemporaryFile(mode="wb", suffix=".gramps", delete=False) as f:
+        with tempfile.NamedTemporaryFile(
+            mode="wb", suffix=".gramps", delete=False
+        ) as f:
             temp_file = f.name
             f.write(xml_content)
 
@@ -149,7 +155,9 @@ class TestRemoveMediapathFromGrampsXml(unittest.TestCase):
 </database>
 """
 
-        with tempfile.NamedTemporaryFile(mode="wb", suffix=".gramps", delete=False) as f:
+        with tempfile.NamedTemporaryFile(
+            mode="wb", suffix=".gramps", delete=False
+        ) as f:
             temp_file = f.name
             f.write(xml_content)
 
@@ -183,7 +191,9 @@ class TestRemoveMediapathFromGrampsXml(unittest.TestCase):
 </database>
 """
 
-        with tempfile.NamedTemporaryFile(mode="wb", suffix=".gramps", delete=False) as f:
+        with tempfile.NamedTemporaryFile(
+            mode="wb", suffix=".gramps", delete=False
+        ) as f:
             temp_file = f.name
             f.write(xml_content)
 
@@ -214,7 +224,9 @@ class TestRemoveMediapathFromGrampsXml(unittest.TestCase):
 </database>
 """
 
-        with tempfile.NamedTemporaryFile(mode="wb", suffix=".gramps", delete=False) as f:
+        with tempfile.NamedTemporaryFile(
+            mode="wb", suffix=".gramps", delete=False
+        ) as f:
             temp_file = f.name
             f.write(xml_content)
 
@@ -259,7 +271,9 @@ class TestRemoveMediapathFromGrampsXml(unittest.TestCase):
 </database>
 """
 
-        with tempfile.NamedTemporaryFile(mode="wb", suffix=".gramps", delete=False) as f:
+        with tempfile.NamedTemporaryFile(
+            mode="wb", suffix=".gramps", delete=False
+        ) as f:
             temp_file = f.name
             f.write(xml_content)
 
@@ -280,7 +294,7 @@ class TestRemoveMediapathFromGrampsXml(unittest.TestCase):
             self.assertIn(b"<namemaps>", result)
             self.assertIn(b'<map type="group_as"', result)
             self.assertIn(b"<people>", result)
-            self.assertIn(b"<name type=\"Birth Name\">", result)
+            self.assertIn(b'<name type="Birth Name">', result)
             self.assertIn(b"<first>John</first>", result)
             self.assertIn(b"<surname>Doe</surname>", result)
         finally:


### PR DESCRIPTION
Gramps always sets the media path when importing an XML file. When the media path is already set, this fails and prevents the import from succeeding (#521). In Gramps Web, we actually don't care about the media path in the XML file as Gramps Web has its own media path (for security reasons).

Since currently there is no elegant way to disable setting the media path, this change simply modifies an uploaded file by removing its media path tag.

Fixes #521.