### PR TITLE
Add a Client and programmatic login/logout

### DIFF
--- a/gramps_webapi/api/__init__.py
+++ b/gramps_webapi/api/__init__.py
@@ -92,6 +92,8 @@ from .resources.timeline import (
     TimelinePeopleResource,
 )
 from .resources.token import (
+    LoginResource,
+    LoginTokenResource,
     TokenCreateOwnerResource,
     TokenRefreshResource,
     TokenResource,
@@ -165,6 +167,9 @@ register_endpt(
 register_endpt(TokenResource, "/token/", "token")
 register_endpt(TokenRefreshResource, "/token/refresh/", "token_refresh")
 register_endpt(TokenCreateOwnerResource, "/token/create_owner/", "token_create_owner")
+# Login (programmatic)
+register_endpt(LoginResource, "/login/", "login")
+register_endpt(LoginTokenResource, "/login/token/", "login_token")
 # OIDC
 register_endpt(OIDCLoginResource, "/oidc/login/", "oidcloginresource")
 register_endpt(OIDCCallbackResource, "/oidc/callback/", "oidccallbackresource")

--- a/gramps_webapi/api/resources/token.py
+++ b/gramps_webapi/api/resources/token.py
@@ -19,9 +19,12 @@
 
 """Authentication endpoint blueprint."""
 
-from typing import Any, Iterable, Optional
+import logging
+import secrets
+from datetime import datetime, timedelta
+from typing import Any, Dict, Iterable, Optional
 
-from flask import abort, current_app
+from flask import abort, current_app, request
 from flask_jwt_extended import (
     create_access_token,
     create_refresh_token,
@@ -43,6 +46,16 @@ from ...const import TREE_MULTI
 from ..ratelimiter import limiter
 from ..util import abort_with_message, get_tree_id, tree_exists, use_args
 from . import RefreshProtectedResource, Resource
+
+logger = logging.getLogger(__name__)
+
+# In-memory storage for temporary login tokens
+# Maps token -> {user_id, tree_id, permissions, expires_at}
+_LOGIN_TOKENS: Dict[str, Dict[str, Any]] = {}
+_LOGIN_TOKEN_TIMESTAMPS: Dict[str, datetime] = {}
+
+# Temporary token expiration time (5 minutes)
+LOGIN_TOKEN_EXPIRY_MINUTES = 5
 
 
 def get_tokens(
@@ -85,9 +98,12 @@ class TokenResource(Resource):
     def post(self, args):
         """Post username and password to fetch a token."""
         # Check if local authentication is disabled when OIDC is enabled
-        if (is_oidc_enabled() and
-            current_app.config.get("OIDC_DISABLE_LOCAL_AUTH", False)):
-            abort_with_message(403, "Local authentication is disabled. Please use OIDC authentication.")
+        if is_oidc_enabled() and current_app.config.get(
+            "OIDC_DISABLE_LOCAL_AUTH", False
+        ):
+            abort_with_message(
+                403, "Local authentication is disabled. Please use OIDC authentication."
+            )
 
         if "username" not in args or "password" not in args:
             abort_with_message(401, "Missing username or password")
@@ -183,3 +199,176 @@ class TokenCreateOwnerResource(Resource):
             claims = {CLAIM_LIMITED_SCOPE: SCOPE_CREATE_ADMIN}
         token = create_access_token(identity="owner", additional_claims=claims)
         return {"access_token": token}, 201
+
+
+def _create_login_token(user_id: str, tree_id: str, permissions: Iterable[str]) -> str:
+    """Create a temporary login token.
+
+    Args:
+        user_id: User GUID
+        tree_id: Tree ID
+        permissions: User permissions
+
+    Returns:
+        Temporary token string
+    """
+    token = secrets.token_urlsafe(32)
+    expires_at = datetime.now() + timedelta(minutes=LOGIN_TOKEN_EXPIRY_MINUTES)
+    _LOGIN_TOKENS[token] = {
+        "user_id": user_id,
+        "tree_id": tree_id,
+        "permissions": list(permissions),
+        "expires_at": expires_at,
+    }
+    _LOGIN_TOKEN_TIMESTAMPS[token] = datetime.now()
+    logger.debug(f"Created temporary login token for user {user_id}")
+    return token
+
+
+def _get_login_token_data(token: str) -> Optional[Dict[str, Any]]:
+    """Get data for a temporary login token.
+
+    Args:
+        token: Temporary token string
+
+    Returns:
+        Token data dict or None if invalid/expired
+    """
+    if token not in _LOGIN_TOKENS:
+        return None
+    data = _LOGIN_TOKENS[token]
+    if datetime.now() > data["expires_at"]:
+        # Token expired, remove it
+        _LOGIN_TOKENS.pop(token, None)
+        _LOGIN_TOKEN_TIMESTAMPS.pop(token, None)
+        return None
+    return data
+
+
+def _consume_login_token(token: str) -> Optional[Dict[str, Any]]:
+    """Get and remove a temporary login token (one-time use).
+
+    Args:
+        token: Temporary token string
+
+    Returns:
+        Token data dict or None if invalid/expired
+    """
+    data = _get_login_token_data(token)
+    if data:
+        # Remove token after use (one-time use)
+        _LOGIN_TOKENS.pop(token, None)
+        _LOGIN_TOKEN_TIMESTAMPS.pop(token, None)
+    return data
+
+
+def _cleanup_expired_login_tokens() -> int:
+    """Remove expired login tokens.
+
+    Returns:
+        Number of tokens removed
+    """
+    now = datetime.now()
+    to_remove = [
+        token for token, data in _LOGIN_TOKENS.items() if now > data["expires_at"]
+    ]
+    for token in to_remove:
+        _LOGIN_TOKENS.pop(token, None)
+        _LOGIN_TOKEN_TIMESTAMPS.pop(token, None)
+    if to_remove:
+        logger.debug(f"Cleaned up {len(to_remove)} expired login tokens")
+    return len(to_remove)
+
+
+class LoginResource(Resource):
+    """Resource for programmatic login that returns a redirect URL with token."""
+
+    @limiter.limit("1/second")
+    @use_args(
+        {
+            "username": fields.Str(required=True, validate=validate.Length(min=1)),
+            "password": fields.Str(required=True, validate=validate.Length(min=1)),
+            "redirect": fields.Str(required=False, validate=validate.Length(min=1)),
+        },
+        location="json",
+    )
+    def post(self, args):
+        """Post username and password to get a redirect URL with temporary token."""
+        # Check if local authentication is disabled when OIDC is enabled
+        if is_oidc_enabled() and current_app.config.get(
+            "OIDC_DISABLE_LOCAL_AUTH", False
+        ):
+            abort_with_message(
+                403, "Local authentication is disabled. Please use OIDC authentication."
+            )
+
+        if "username" not in args or "password" not in args:
+            abort_with_message(401, "Missing username or password")
+        if not authorized(args.get("username"), args.get("password")):
+            abort_with_message(403, "Invalid username or password")
+
+        user_id = get_guid(args["username"])
+        tree_id = get_tree_id(user_id)
+        if is_tree_disabled(tree=tree_id):
+            abort_with_message(503, "This tree is temporarily disabled")
+        permissions = get_permissions(username=args["username"], tree=tree_id)
+
+        # Create temporary token
+        temp_token = _create_login_token(user_id, tree_id, permissions)
+
+        # Clean up expired tokens periodically
+        _cleanup_expired_login_tokens()
+
+        # Build redirect URL
+        redirect_path = args.get("redirect", "/")
+        # Get the frontend URL from request origin or config
+        frontend_url = request.headers.get("Origin") or current_app.config.get(
+            "FRONTEND_URL", ""
+        )
+        if frontend_url:
+            # Remove trailing slash if present
+            frontend_url = frontend_url.rstrip("/")
+        else:
+            # Fallback to relative URL
+            frontend_url = ""
+
+        redirect_url = (
+            f"{frontend_url}/login?token={temp_token}&redirect={redirect_path}"
+        )
+
+        # Return redirect URL
+        return {"redirect_url": redirect_url}, 200
+
+
+class LoginTokenResource(Resource):
+    """Resource for exchanging temporary login token for access tokens."""
+
+    @limiter.limit("1/second")
+    @use_args(
+        {
+            "token": fields.Str(required=True, validate=validate.Length(min=1)),
+        },
+        location="query",
+    )
+    def get(self, args):
+        """Exchange temporary token for access and refresh tokens."""
+        token = args.get("token")
+        if not token:
+            abort_with_message(400, "Missing token parameter")
+
+        # Get and consume token (one-time use)
+        token_data = _consume_login_token(token)
+        if not token_data:
+            abort_with_message(401, "Invalid or expired token")
+
+        # Clean up expired tokens periodically
+        _cleanup_expired_login_tokens()
+
+        # Generate real tokens
+        return get_tokens(
+            user_id=token_data["user_id"],
+            permissions=token_data["permissions"],
+            tree_id=token_data["tree_id"],
+            include_refresh=True,
+            fresh=True,
+        )

--- a/gramps_webapi/client.py
+++ b/gramps_webapi/client.py
@@ -1,0 +1,150 @@
+#
+# Gramps Web API - A RESTful API for the Gramps genealogy program
+#
+# Copyright (C) 2026      Doug Blank
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+#
+
+import requests
+from urllib.parse import urlparse, parse_qs
+from typing import Optional, Dict, Any
+
+
+class Client:
+    """Client for Gramps Web API with programmatic login support."""
+
+    def __init__(self, api_host: str):
+        """
+        Initialize the client.
+
+        Args:
+            api_host: Base URL of the API (e.g., "http://localhost:5000")
+        """
+        self.api_host = api_host.rstrip("/")
+        self.access_token: Optional[str] = None
+        self.refresh_token: Optional[str] = None
+
+    def login(
+        self, username: str, password: str, redirect: str = "/"
+    ) -> Dict[str, str]:
+        """
+        Log in programmatically.
+
+        Args:
+            username: Username
+            password: Password
+            redirect: Optional redirect path (default: "/")
+
+        Returns:
+            Dictionary with access_token and refresh_token
+
+        Raises:
+            requests.HTTPError: If login fails
+        """
+        # Step 1: POST credentials
+        response = requests.post(
+            f"{self.api_host}/api/login/",
+            json={"username": username, "password": password, "redirect": redirect},
+            headers={"Content-Type": "application/json"},
+        )
+        response.raise_for_status()
+
+        # Step 2: Extract token from redirect URL
+        redirect_url = response.json()["redirect_url"]
+        parsed_url = urlparse(redirect_url)
+        query_params = parse_qs(parsed_url.query)
+        token = query_params.get("token", [None])[0]
+
+        if not token:
+            raise ValueError("No token found in redirect URL")
+
+        # Step 3: Exchange token for real tokens
+        token_response = requests.get(
+            f"{self.api_host}/api/login/token/",
+            params={"token": token},
+            headers={"Accept": "application/json"},
+        )
+        token_response.raise_for_status()
+
+        # Step 4: Store tokens
+        tokens = token_response.json()
+        self.access_token = tokens["access_token"]
+        self.refresh_token = tokens.get("refresh_token")
+
+        return {
+            "access_token": self.access_token,
+            "refresh_token": self.refresh_token,
+        }
+
+    def _get_headers(self) -> Dict[str, str]:
+        """Get headers with authentication."""
+        headers = {"Accept": "application/json"}
+        if self.access_token:
+            headers["Authorization"] = f"Bearer {self.access_token}"
+        return headers
+
+    def get(self, endpoint: str, **kwargs) -> Any:
+        """Make a GET request."""
+        if not self.access_token:
+            raise ValueError("Not logged in. Call login() first.")
+        response = requests.get(
+            f"{self.api_host}{endpoint}", headers=self._get_headers(), **kwargs
+        )
+        response.raise_for_status()
+        return response.json()
+
+    def post(self, endpoint: str, data: Any = None, json: Any = None, **kwargs) -> Any:
+        """Make a POST request."""
+        if not self.access_token:
+            raise ValueError("Not logged in. Call login() first.")
+        headers = self._get_headers()
+        if json is not None:
+            headers["Content-Type"] = "application/json"
+        response = requests.post(
+            f"{self.api_host}{endpoint}",
+            headers=headers,
+            data=data,
+            json=json,
+            **kwargs,
+        )
+        response.raise_for_status()
+        return response.json()
+
+    def put(self, endpoint: str, data: Any = None, json: Any = None, **kwargs) -> Any:
+        """Make a PUT request."""
+        if not self.access_token:
+            raise ValueError("Not logged in. Call login() first.")
+        headers = self._get_headers()
+        if json is not None:
+            headers["Content-Type"] = "application/json"
+        response = requests.put(
+            f"{self.api_host}{endpoint}",
+            headers=headers,
+            data=data,
+            json=json,
+            **kwargs,
+        )
+        response.raise_for_status()
+        return response.json()
+
+    def delete(self, endpoint: str, **kwargs) -> Any:
+        """Make a DELETE request."""
+        if not self.access_token:
+            raise ValueError("Not logged in. Call login() first.")
+        response = requests.delete(
+            f"{self.api_host}{endpoint}", headers=self._get_headers(), **kwargs
+        )
+        response.raise_for_status()
+        return response.json() if response.content else None


### PR DESCRIPTION
This PR:

1. Adds a Client class for programmatic control of the gramps-web-api server.
2. Adds login endpoint for programmatic login/logout

Example usage:

```python
from gramps_webapi.client import Client

# Create client
client = Client("http://localhost:5000")

# Log in
print("Logging in...")
client.login("USERNAME", "PASSWORD")
print("✓ Logged in!")

# Make authenticated requests
print("\nFetching metadata...")
metadata = client.get("/api/metadata/")
print(f"Database: {metadata}")

print("\nFetching people...")
people = client.get("/api/people/?pagesize=5&page=1")
print(f"Found {len(people)} people")
``` 