### PR TITLE
OIDC: Allow cookies for HTTP in a local-only deployment

### DIFF
--- a/gramps_webapi/api/resources/oidc.py
+++ b/gramps_webapi/api/resources/oidc.py
@@ -64,6 +64,8 @@ def _is_local_deployment(frontend_url: Optional[str]) -> bool:
     if frontend_url and frontend_url.startswith("http://"):
         try:
             hostname = urlparse(frontend_url).hostname
+            if hostname is None:
+                return False
             ip = ipaddress.ip_address(hostname)
             return ip.is_private
         except ValueError:


### PR DESCRIPTION
Gramps can be deployed in an environment that is only reachable within a LAN.

HTTP is fine here as all actors in the network themselves are considered trustworthy.

Gramps would then be reachable within one of the private IP ranges, e.g via `http://192.168.x.x`

Currently, OIDC providers in Gramps work for the creation of a new users via OIDC, but Gramps fails subsequently to login the user successfully, because it tries to set the cookies with `Secure;` on a HTTP site. Browser reject those `Set-Cookie` requests as invalid and the users stays logged-out.

This PR uses a Python standard library & function to test if the `FRONTEND_URL` is of the format `http://<private IP address> ....`. If it is, the cookie won't be flagged as secure, so that browsers will accept the cookies.

References:
https://docs.python.org/3/library/ipaddress.html#ipaddress.IPv4Address.is_private  
https://datatracker.ietf.org/doc/html/rfc1918#section-3