### PR TITLE
Fix signature error when using recent boto3 versions with GCS

### DIFF
--- a/gramps_webapi/api/s3.py
+++ b/gramps_webapi/api/s3.py
@@ -22,6 +22,7 @@
 from typing import BinaryIO, Dict, Optional
 
 import boto3
+from botocore.config import Config
 from botocore.exceptions import ClientError
 from flask import current_app, redirect, send_file
 from gramps.gen.db.base import DbReadBase
@@ -33,14 +34,14 @@ from .util import abort_with_message
 
 
 def get_client(endpoint_url: Optional[str] = None):
-    """Return an S3 client."""
-    return boto3.client(
-        "s3",
-        endpoint_url=endpoint_url,
-        config=boto3.session.Config(
-            s3={"addressing_style": "path"}, signature_version="s3v4"
-        ),
+    """Return an S3 client configured for GCS compatibility."""
+    config = Config(
+        s3={"addressing_style": "path"},
+        signature_version="s3v4",
+        request_checksum_calculation="when_required",
+        response_checksum_validation="when_supported",
     )
+    return boto3.client("s3", endpoint_url=endpoint_url, config=config)
 
 
 def get_object_name(checksum: str, prefix: Optional[str] = None):


### PR DESCRIPTION
Versions of `boto3` starting from 1.36.0 - such as the one included in the image of the v3.7.0 release - break the S3 media backend when using Google Cloud Storage, due to a change in how checksums are verified. This change restores the previous default behaviour.