### PR TITLE
Fix birth/death index corruption on NAS/Btrfs storage

### DIFF
--- a/gramps_webapi/api/resources/base.py
+++ b/gramps_webapi/api/resources/base.py
@@ -282,6 +282,11 @@ class GrampsObjectResource(GrampsObjectResourceHelper, Resource):
         if not obj:
             abort_with_message(400, "Empty object")
         db_handle = self.db_handle_writable
+        # For Person objects, set birth/death indices before the transaction,
+        # matching desktop Gramps (editperson.py). This avoids reading events
+        # during a write transaction, which can fail on some storage backends.
+        if self.gramps_class_name == "Person":
+            db_handle.set_birth_death_index(obj)
         with DbTxn(f"Edit {self.gramps_class_name}", db_handle) as trans:
             try:
                 update_object(db_handle, obj, trans)

--- a/gramps_webapi/api/resources/util.py
+++ b/gramps_webapi/api/resources/util.py
@@ -1240,8 +1240,6 @@ def update_object(
             update_family_update_refs(
                 db_handle=db_handle, obj_old=obj_old, obj=obj, trans=trans
             )
-        elif obj_class == "person":
-            db_handle.set_birth_death_index(obj)
         return commit_method(obj, trans)
     except AttributeError as exc:
         raise ValueError("Database does not support writing.") from exc


### PR DESCRIPTION
## Motivation

When running Gramps Web on a NAS with Btrfs filesystem (CoW is enabled per default in Btrfs file systems and Docker host-mounted volumes are configured in the docker compose file), editing a person's **name** causes their birth/death dates to disappear from the people list. The person detail page still shows the dates correctly — only the list view is affected.

### Scenario
**Given** a person "Erna Schmidt" (I0001) with a birth date, created and saved via the UI:
![Bildschirmfoto_20260207_141044](https://github.com/user-attachments/assets/ae250edb-26be-4516-b1da-8b6e154b1da5)

The API confirms `birth_ref_index: 0` and the birth date in the profile:

<details>
<summary><code>GET /api/people/?gramps_id=I0001&profile=all</code> — birth_ref_index: 0 ✅</summary>

```json
{
  "birth_ref_index": 0,
  "event_ref_list": [
    { "ref": "b6aa40cc-a45c-4bed-b799-66bcd930694d", "role": "Primary" }
  ],
  "profile": {
    "birth": {
      "date": "1948-11-09",
      "type": "Geburt",
      "summary": "Geburt - Schmidt, Erna"
    }
  }
}
```

</details>

**And** the birth date is correctly displayed in the people list (`/people`):
![Bildschirmfoto_20260207_141211](https://github.com/user-attachments/assets/f622efe7-1230-4d3e-a622-7881439bbea3)

**When** the user opens person I0001 for editing
**And** adds a married name "Erna Meier", and saves that change
(note: only names are changed — no events are modified)
**Then** the `PUT` response already shows `birth_ref_index` corrupted from `0` to `-1`, despite `event_ref_list` being unchanged:

<details>
<summary><code>PUT /api/people/{handle}</code> — birth_ref_index: 0 → -1 ❌</summary>

```json
{
  "old": {
    "birth_ref_index": 0,
    "event_ref_list": [{ "ref": "b6aa40cc-...", "role": "Primary" }]
  },
  "new": {
    "birth_ref_index": -1,
    "event_ref_list": [{ "ref": "b6aa40cc-...", "role": "Primary" }]
  }
}
```

</details>

**When** the user navigates to the people list page (`/people`)
**Then** the birth date of person I0001 is not displayed
![Bildschirmfoto_20260207_144309](https://github.com/user-attachments/assets/26ba4eef-f7b8-4660-b7ef-c1365d83796b)

<details>
<summary><code>GET /api/people/?profile=self</code> — empty birth object</summary>

```json
{
  "gramps_id": "I0001",
  "profile": {
    "birth": {},
    "death": {}
  }
}
```

</details>

**But** the person detail page (`/person/I0001`) still shows the birth date correctly, even after a hard reload — because the detail view renders from `profile.events`, not from `profile.birth`:
![Bildschirmfoto_20260207_141044](https://github.com/user-attachments/assets/5a0af2d3-dcac-42b3-9765-6606ef89d134)

<details>
<summary><code>GET /api/people/?gramps_id=I0001&profile=all</code> — birth_ref_index: -1, but birth event still in events list</summary>

```json
{
  "birth_ref_index": -1,
  "event_ref_list": [
    { "ref": "b6aa40cc-a45c-4bed-b799-66bcd930694d", "role": "Primary" }
  ],
  "profile": {
    "birth": {},
    "events": [
      { "type": "Geburt", "date": "1948-11-09", "summary": "Geburt - Schmidt, Erna" }
    ]
  }
}
```

</details>

## Analysis

`set_birth_death_index()` reads events from the database to determine which event references correspond to birth/death events. In gramps-web-api, this call happened **inside** the write transaction (in `update_object()`). On storage backends like Btrfs with Docker host-mounted volumes, SQLite reads during an active write transaction can fail, resetting `birth_ref_index` to `-1`. Since `get_birth_or_fallback()` does not fall back to actual `BIRTH` events (only to baptism/christening), the birth date becomes invisible.

Desktop Gramps calls `set_birth_death_index()` **before** the transaction (`editperson.py:968`), avoiding this entirely:

```mermaid
sequenceDiagram
    participant App as Application
    participant Core as Gramps Core
    participant DB as SQLite

    rect rgb(200, 255, 200)
        Note over App,DB: Desktop Gramps (editperson.py:968)
        App->>Core: set_birth_death_index(person)
        Core->>DB: get_event_from_handle(ref)
        Note over DB: ✅ Read OUTSIDE transaction
        DB-->>Core: Event object
        App->>DB: BEGIN TRANSACTION
        App->>Core: commit_person(person)
        App->>DB: COMMIT
    end

    rect rgb(255, 200, 200)
        Note over App,DB: Web API before this fix
        App->>DB: BEGIN TRANSACTION
        App->>Core: set_birth_death_index(person)
        Core->>DB: get_event_from_handle(ref)
        Note over DB: ⚠️ Read INSIDE transaction — can fail on Btrfs
        DB-->>Core: None or stale data
        Note over Core: birth_ref_index = -1 ❌
        App->>Core: commit_person(person)
        App->>DB: COMMIT
    end
```

## Proposed Fix

This PR moves `set_birth_death_index()` from inside the write transaction (in `update_object()`) to before the transaction (in `put()`), aligning gramps-web-api with the desktop Gramps pattern. No changes to Gramps core are needed.

## Testing

The existing test `test_objects_add_person_seperate` in `test_post.py` covers this path — it verifies that `birth_ref_index` is correctly set to `0` after a PUT that adds a birth event. To reproduce the original bug, a NAS with Btrfs and Docker host-mounted volumes is needed.

## Related

- Fixes #743
- Supersedes #744 — this PR addresses the root cause (transaction timing) rather than the symptom (skipping recalculation), following up on the [deeper issue identified by @DavidMStraub](https://github.com/gramps-project/gramps-web-api/pull/744#issuecomment-3645695518)
- Replaces https://github.com/gramps-project/gramps/pull/2149 — the fix belongs in gramps-web-api (aligning with desktop Gramps' transaction pattern) rather than adding defensive handling in Gramps core, consistent with the [feedback from @DavidMStraub and @stevenyoungs](https://github.com/gramps-project/gramps/pull/2149#issuecomment-3646730184)