### PR TITLE
Don't push images from forks

### DIFF
--- a/.github/workflows/base-image.yml
+++ b/.github/workflows/base-image.yml
@@ -57,7 +57,7 @@ jobs:
           PLATFORM_TAG=$(echo "${{ matrix.platform }}" | sed 's/linux\///')
           echo "tag=${PLATFORM_TAG}" >> $GITHUB_OUTPUT
       - name: Build and push base image
-        if: ${{ !github.event.repository.fork }}
+        if: ${{ github.repository_owner == 'gramps-project' && github.repository == 'gramps-project/gramps-web-api' }}
         uses: docker/build-push-action@v6
         with:
           context: .
@@ -72,7 +72,7 @@ jobs:
           provenance: false
 
   create-manifest:
-    if: ${{ !github.event.repository.fork }}
+    if: ${{ github.repository_owner == 'gramps-project' && github.repository == 'gramps-project/gramps-web-api' }}
     runs-on: ubuntu-24.04
     needs: [generate-date, build-base]
     steps:


### PR DESCRIPTION
Attempt to fix #781 where the GitHub workflow attempts to push the built image even when building a fork where the owner does not have permission to push the docker image to the destination.