### PR TITLE
feat(api): add anniversaries ICS feed endpoint

### DIFF
--- a/gramps_webapi/api/__init__.py
+++ b/gramps_webapi/api/__init__.py
@@ -35,6 +35,7 @@ from .resources.bookmarks import (
     BookmarksResource,
 )
 from .resources.access_tokens import UserAccessTokenResource
+from .resources.anniversaries import AnniversariesIcsResource
 from .resources.chat import ChatResource
 from .resources.citations import CitationResource, CitationsResource
 from .resources.config import ConfigResource, ConfigsResource
@@ -559,6 +560,13 @@ register_endpt(
     "/metadata/researcher/",
     "metadata_researcher",
     tags=["Metadata"],
+)
+# Anniversaries
+register_endpt(
+    AnniversariesIcsResource,
+    "/anniversaries.ics",
+    "anniversaries_ics",
+    tags=["Anniversaries"],
 )
 # User
 register_endpt(UsersResource, "/users/", "users", tags=["Users"])

--- a/gramps_webapi/api/__init__.py
+++ b/gramps_webapi/api/__init__.py
@@ -31,6 +31,7 @@ from .blueprint import api_blueprint
 from .cache import thumbnail_cache_decorator, tile_cache_decorator
 from .media import get_media_handler
 from .resources.access_tokens import UserAccessTokenResource
+from .resources.anniversaries import AnniversariesIcsResource
 from .resources.base import Resource
 from .resources.bookmarks import (
     BookmarkEditResource,
@@ -593,6 +594,13 @@ register_endpt(
     "/metadata/researcher/",
     "metadata_researcher",
     tags=["Metadata"],
+)
+# Anniversaries
+register_endpt(
+    AnniversariesIcsResource,
+    "/anniversaries.ics",
+    "anniversaries_ics",
+    tags=["Anniversaries"],
 )
 # User
 register_endpt(UsersResource, "/users/", "users", tags=["Users"])

--- a/gramps_webapi/api/resources/anniversaries.py
+++ b/gramps_webapi/api/resources/anniversaries.py
@@ -234,8 +234,10 @@ class AnniversariesIcsResource(Resource):
         try:
             iter_event_handles = db_handle.method("iter_event_handles")
             get_event_from_handle = db_handle.method("get_event_from_handle")
-            assert iter_event_handles is not None
-            assert get_event_from_handle is not None
+            if iter_event_handles is None:
+                raise RuntimeError("Method iter_event_handles not found")
+            if get_event_from_handle is None:
+                raise RuntimeError("Method get_event_from_handle not found")
             events = []
             for handle in iter_event_handles():
                 event = get_event_from_handle(handle)

--- a/gramps_webapi/api/resources/anniversaries.py
+++ b/gramps_webapi/api/resources/anniversaries.py
@@ -1,0 +1,281 @@
+#
+# Gramps Web API - A RESTful API for the Gramps genealogy program
+#
+# Copyright (C) 2026      Gramps Web contributors
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+
+"""Anniversaries ICS resource."""
+
+import json
+from datetime import datetime, timezone
+from typing import Optional
+
+from flask import Response
+from gramps.gen.lib import Event
+from gramps.gen.lib.date import gregorian
+from marshmallow import Schema
+from webargs import fields, validate
+
+from ...auth import (
+    get_permissions,
+    get_user_from_access_token,
+    is_tree_disabled,
+)
+from ...auth.const import ACCESS_TOKEN_SCOPE_ANNIVERSARIES_ICS, PERM_VIEW_PRIVATE
+from ..blueprint import api_blueprint
+from ..util import (
+    abort_with_message,
+    close_db,
+    get_db_outside_request,
+    get_tree_id,
+)
+from . import Resource
+from .filters import apply_filter
+from .util import get_backlinks, get_event_summary_from_object
+
+
+def _escape_ics_text(value: str) -> str:
+    """Escape text fields according to RFC 5545."""
+    return (
+        value.replace("\\", "\\\\")
+        .replace(";", "\\;")
+        .replace(",", "\\,")
+        .replace("\r\n", "\\n")
+        .replace("\n", "\\n")
+    )
+
+
+def _event_matches_type(event: Event, allowed_types: set[str]) -> bool:
+    """Check if an event type matches one of the requested filters."""
+    if not allowed_types:
+        return True
+    event_values = {
+        str(event.get_type()).casefold().strip(),
+        event.get_type().xml_str().casefold().strip(),
+    }
+    return not event_values.isdisjoint(allowed_types)
+
+
+def _get_anniversary_date_components(event: Event) -> Optional[tuple[int, int, int]]:
+    """Get Gregorian (year, month, day) tuple for an event date."""
+    if event.date is None or not event.date.is_valid():
+        return None
+    gdate = gregorian(event.date)
+    month = gdate.get_month()
+    day = gdate.get_day()
+    if month < 1 or day < 1:
+        return None
+    year = gdate.get_year()
+    if year < 1:
+        year = 1970
+    if year > 9999:
+        year = 9999
+    return year, month, day
+
+
+def _is_event_in_anchor_scope(
+    db_handle,
+    event: Event,
+    allowed_people: set[str],
+    allowed_families: set[str],
+) -> bool:
+    """Check if an event is linked to people/families in anchor scope."""
+    backlinks = get_backlinks(db_handle, event.handle)
+    people = set(backlinks.get("person", []))
+    if not people.isdisjoint(allowed_people):
+        return True
+    families = set(backlinks.get("family", []))
+    return not families.isdisjoint(allowed_families)
+
+
+def _resolve_anchor_people_handles(
+    db_handle, anchor_gramps_id: str, generation_depth: int
+) -> set[str]:
+    """Resolve people handles to include for an anchor+generation filter."""
+    anchor = db_handle.get_person_from_gramps_id(anchor_gramps_id)
+    if anchor is None:
+        abort_with_message(404, "Anchor person not found")
+    rules = {
+        "function": "or",
+        "rules": [
+            {
+                "name": "IsLessThanNthGenerationAncestorOf",
+                "values": [anchor_gramps_id, generation_depth],
+            },
+            {
+                "name": "IsLessThanNthGenerationDescendantOf",
+                "values": [anchor_gramps_id, generation_depth],
+            },
+        ],
+    }
+    handles = db_handle.get_person_handles(sort_handles=True)
+    return set(
+        apply_filter(
+            db_handle,
+            {"rules": json.dumps(rules)},
+            "Person",
+            handles,
+        )
+    )
+
+
+def _resolve_family_handles_for_people(db_handle, people_handles: set[str]) -> set[str]:
+    """Resolve families attached to in-scope people handles."""
+    family_handles = set()
+    for handle in people_handles:
+        person = db_handle.get_person_from_handle(handle)
+        if person is None:
+            continue
+        family_handles.update(person.family_list)
+        family_handles.update(person.parent_family_list)
+    return family_handles
+
+
+def _build_ics(events: list[Event], db_handle, tree_id: str) -> str:
+    """Build ICS calendar content for a list of events."""
+    dtstamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    lines = [
+        "BEGIN:VCALENDAR",
+        "VERSION:2.0",
+        "PRODID:-//Gramps Web//Anniversaries//EN",
+        "CALSCALE:GREGORIAN",
+        "METHOD:PUBLISH",
+        "X-WR-CALNAME:Gramps Anniversaries",
+    ]
+    for event in events:
+        date_components = _get_anniversary_date_components(event)
+        if date_components is None:
+            continue
+        year, month, day = date_components
+        dtstart = f"{year:04d}{month:02d}{day:02d}"
+        summary = _escape_ics_text(get_event_summary_from_object(db_handle, event))
+        description = _escape_ics_text(
+            f"Gramps ID: {event.gramps_id or ''}\\nType: {event.get_type().xml_str()}"
+        )
+        uid = _escape_ics_text(f"{event.handle}@{tree_id}.anniversaries.gramps-web")
+        lines.extend(
+            [
+                "BEGIN:VEVENT",
+                f"UID:{uid}",
+                f"DTSTAMP:{dtstamp}",
+                f"DTSTART;VALUE=DATE:{dtstart}",
+                "RRULE:FREQ=YEARLY",
+                f"SUMMARY:{summary}",
+                f"DESCRIPTION:{description}",
+                "END:VEVENT",
+            ]
+        )
+    lines.append("END:VCALENDAR")
+    return "\r\n".join(lines) + "\r\n"
+
+
+def _event_sort_key(event: Event) -> tuple[int, int, int, str]:
+    """Return stable sort key for anniversary events."""
+    date_components = _get_anniversary_date_components(event)
+    if date_components is None:
+        return (12, 31, 9999, event.handle)
+    year, month, day = date_components
+    return (month, day, year, event.handle)
+
+
+class AnniversariesIcsQueryArgs(Schema):
+    """Query arguments for GET /anniversaries.ics."""
+
+    token = fields.Str(
+        required=True,
+        validate=validate.Length(min=1),
+        metadata={"description": "Persistent access token value."},
+    )
+    event_types = fields.DelimitedList(
+        fields.Str(validate=validate.Length(min=1)),
+        metadata={"description": "Comma-delimited event type names to include."},
+    )
+    anchor_gramps_id = fields.Str(
+        metadata={"description": "Anchor person Gramps ID for family-scope filtering."},
+    )
+    generation_depth = fields.Integer(
+        load_default=4,
+        validate=validate.Range(min=1, max=9),
+        metadata={"description": "Generation depth around the anchor person."},
+    )
+
+
+class AnniversariesIcsResource(Resource):
+    """Public anniversaries ICS feed resource."""
+
+    @api_blueprint.arguments(AnniversariesIcsQueryArgs, location="query")
+    def get(self, args: dict) -> Response:
+        """Return anniversaries in ICS format."""
+        user = get_user_from_access_token(
+            args["token"], ACCESS_TOKEN_SCOPE_ANNIVERSARIES_ICS
+        )
+        if user is None:
+            abort_with_message(401, "Invalid access token")
+        if user.role is None or user.role < 0:
+            abort_with_message(403, "User account is disabled")
+
+        tree_id = get_tree_id(str(user.id))
+        if is_tree_disabled(tree=tree_id):
+            abort_with_message(503, "This tree is temporarily disabled")
+
+        permissions = get_permissions(username=user.name, tree=tree_id)
+        view_private = PERM_VIEW_PRIVATE in permissions
+        db_handle = get_db_outside_request(
+            tree=tree_id,
+            view_private=view_private,
+            readonly=True,
+            user_id=str(user.id),
+        )
+        try:
+            iter_event_handles = db_handle.method("iter_event_handles")
+            get_event_from_handle = db_handle.method("get_event_from_handle")
+            assert iter_event_handles is not None
+            assert get_event_from_handle is not None
+            events = []
+            for handle in iter_event_handles():
+                event = get_event_from_handle(handle)
+                if event is not None:
+                    events.append(event)
+
+            allowed_types = {
+                event_type.casefold().strip()
+                for event_type in args.get("event_types", [])
+                if event_type and event_type.strip()
+            }
+            events = [
+                event for event in events if _event_matches_type(event, allowed_types)
+            ]
+            events = [
+                event
+                for event in events
+                if _get_anniversary_date_components(event) is not None
+            ]
+
+            if args.get("anchor_gramps_id"):
+                allowed_people = _resolve_anchor_people_handles(
+                    db_handle, args["anchor_gramps_id"], args["generation_depth"]
+                )
+                allowed_families = _resolve_family_handles_for_people(
+                    db_handle, allowed_people
+                )
+                events = [
+                    event
+                    for event in events
+                    if _is_event_in_anchor_scope(
+                        db_handle, event, allowed_people, allowed_families
+                    )
+                ]
+
+            events.sort(key=_event_sort_key)
+            payload = _build_ics(events=events, db_handle=db_handle, tree_id=tree_id)
+        finally:
+            close_db(db_handle)
+
+        response = Response(payload, status=200, mimetype="text/calendar")
+        response.headers["Content-Disposition"] = "inline; filename=anniversaries.ics"
+        return response

--- a/gramps_webapi/api/resources/anniversaries.py
+++ b/gramps_webapi/api/resources/anniversaries.py
@@ -238,40 +238,38 @@ class AnniversariesIcsResource(Resource):
                 raise RuntimeError("Method iter_event_handles not found")
             if get_event_from_handle is None:
                 raise RuntimeError("Method get_event_from_handle not found")
-            events = []
-            for handle in iter_event_handles():
-                event = get_event_from_handle(handle)
-                if event is not None:
-                    events.append(event)
 
             allowed_types = {
                 event_type.casefold().strip()
                 for event_type in args.get("event_types", [])
                 if event_type and event_type.strip()
             }
-            events = [
-                event for event in events if _event_matches_type(event, allowed_types)
-            ]
-            events = [
-                event
-                for event in events
-                if _get_anniversary_date_components(event) is not None
-            ]
 
-            if args.get("anchor_gramps_id"):
+            anchor_gramps_id = args.get("anchor_gramps_id")
+            allowed_people = set()
+            allowed_families = set()
+            if anchor_gramps_id:
                 allowed_people = _resolve_anchor_people_handles(
-                    db_handle, args["anchor_gramps_id"], args["generation_depth"]
+                    db_handle, anchor_gramps_id, args["generation_depth"]
                 )
                 allowed_families = _resolve_family_handles_for_people(
                     db_handle, allowed_people
                 )
-                events = [
-                    event
-                    for event in events
-                    if _is_event_in_anchor_scope(
-                        db_handle, event, allowed_people, allowed_families
-                    )
-                ]
+
+            events = []
+            for handle in iter_event_handles():
+                event = get_event_from_handle(handle)
+                if event is None:
+                    continue
+                if not _event_matches_type(event, allowed_types):
+                    continue
+                if _get_anniversary_date_components(event) is None:
+                    continue
+                if anchor_gramps_id and not _is_event_in_anchor_scope(
+                    db_handle, event, allowed_people, allowed_families
+                ):
+                    continue
+                events.append(event)
 
             events.sort(key=_event_sort_key)
             payload = _build_ics(events=events, db_handle=db_handle, tree_id=tree_id)

--- a/gramps_webapi/api/resources/anniversaries.py
+++ b/gramps_webapi/api/resources/anniversaries.py
@@ -155,7 +155,7 @@ def _build_ics(events: list[Event], db_handle, tree_id: str) -> str:
         dtstart = f"{year:04d}{month:02d}{day:02d}"
         summary = _escape_ics_text(get_event_summary_from_object(db_handle, event))
         description = _escape_ics_text(
-            f"Gramps ID: {event.gramps_id or ''}\\nType: {event.get_type().xml_str()}"
+            f"Gramps ID: {event.gramps_id or ''}\nType: {event.get_type().xml_str()}"
         )
         uid = _escape_ics_text(f"{event.handle}@{tree_id}.anniversaries.gramps-web")
         lines.extend(

--- a/tests/test_endpoints/test_anniversaries_ics.py
+++ b/tests/test_endpoints/test_anniversaries_ics.py
@@ -85,6 +85,8 @@ class TestAnniversariesIcs(unittest.TestCase):
         self.assertEqual(rv.status_code, 200)
         text = rv.data.decode("utf-8")
         self.assertIn("Type: Birth", text)
+        self.assertIn("\\nType: Birth", text)
+        self.assertNotIn("\\\\nType: Birth", text)
         self.assertNotIn("Type: Death", text)
 
     def test_public_feed_generation_depth_validation(self):

--- a/tests/test_endpoints/test_anniversaries_ics.py
+++ b/tests/test_endpoints/test_anniversaries_ics.py
@@ -1,0 +1,146 @@
+#
+# Gramps Web API - A RESTful API for the Gramps genealogy program
+#
+# Copyright (C) 2026      Gramps Web contributors
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+
+"""Tests for anniversaries ICS endpoint."""
+
+import unittest
+from unittest.mock import patch
+from uuid import uuid4
+
+from gramps_webapi.auth import (
+    add_user,
+    get_user_details,
+    rotate_user_access_token,
+)
+from gramps_webapi.auth.const import (
+    ACCESS_TOKEN_SCOPE_ANNIVERSARIES_ICS,
+    ROLE_DISABLED,
+    ROLE_GUEST,
+    ROLE_OWNER,
+)
+
+from . import BASE_URL, get_test_client
+from .util import fetch_header
+
+ICS_URL = BASE_URL + "/anniversaries.ics"
+TOKEN_URL = BASE_URL + "/users/-/access-tokens/anniversaries_ics/"
+
+
+class TestAnniversariesIcs(unittest.TestCase):
+    """Test cases for anniversaries ICS endpoint."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Test class setup."""
+        cls.client = get_test_client()
+
+    def _create_token(self, role=ROLE_OWNER):
+        """Create or rotate token for role and return (header, token)."""
+        header = fetch_header(self.client, role=role)
+        rv = self.client.post(TOKEN_URL, headers=header)
+        self.assertEqual(rv.status_code, 200)
+        self.assertTrue(rv.json["active"])
+        token = rv.json["token"]
+        self.assertIsNotNone(token)
+        return header, token
+
+    def test_public_feed_requires_valid_token(self):
+        """Public feed requires token query parameter and valid token value."""
+        rv = self.client.get(ICS_URL)
+        self.assertEqual(rv.status_code, 422)
+
+        rv = self.client.get(f"{ICS_URL}?token=invalid-token")
+        self.assertEqual(rv.status_code, 401)
+
+    def test_feed_access_and_revoke_flow(self):
+        """Public feed works with valid token and fails after revocation."""
+        header, token = self._create_token()
+
+        rv = self.client.get(f"{ICS_URL}?token={token}")
+        self.assertEqual(rv.status_code, 200)
+        self.assertIn("text/calendar", rv.content_type)
+        text = rv.data.decode("utf-8")
+        self.assertIn("BEGIN:VCALENDAR", text)
+        self.assertIn("END:VCALENDAR", text)
+        self.assertIn("RRULE:FREQ=YEARLY", text)
+
+        rv = self.client.delete(TOKEN_URL, headers=header)
+        self.assertEqual(rv.status_code, 200)
+
+        rv = self.client.get(f"{ICS_URL}?token={token}")
+        self.assertEqual(rv.status_code, 401)
+
+    def test_public_feed_event_type_filter(self):
+        """event_types filter limits event types included in ICS."""
+        _, token = self._create_token(role=ROLE_OWNER)
+        rv = self.client.get(f"{ICS_URL}?token={token}&event_types=Birth")
+        self.assertEqual(rv.status_code, 200)
+        text = rv.data.decode("utf-8")
+        self.assertIn("Type: Birth", text)
+        self.assertNotIn("Type: Death", text)
+
+    def test_public_feed_generation_depth_validation(self):
+        """generation_depth is bounded between 1 and 9."""
+        _, token = self._create_token(role=ROLE_OWNER)
+        rv = self.client.get(f"{ICS_URL}?token={token}&generation_depth=0")
+        self.assertEqual(rv.status_code, 422)
+        rv = self.client.get(f"{ICS_URL}?token={token}&generation_depth=10")
+        self.assertEqual(rv.status_code, 422)
+
+    def test_public_feed_anchor_scope_for_owner_and_guest(self):
+        """Anchor scope query works for both owner and guest roles."""
+        # Use a known person ID from example_gramps.
+        _, owner_token = self._create_token(role=ROLE_OWNER)
+        rv = self.client.get(
+            f"{ICS_URL}?token={owner_token}&anchor_gramps_id=I0044"
+        )
+        self.assertEqual(rv.status_code, 200)
+
+        _, guest_token = self._create_token(role=ROLE_GUEST)
+        rv = self.client.get(
+            f"{ICS_URL}?token={guest_token}&anchor_gramps_id=I0044"
+        )
+        self.assertEqual(rv.status_code, 200)
+
+    def test_public_feed_invalid_anchor(self):
+        """Unknown anchor Gramps ID returns 404."""
+        _, token = self._create_token(role=ROLE_OWNER)
+        rv = self.client.get(
+            f"{ICS_URL}?token={token}&anchor_gramps_id=NOT_A_REAL_GRMPS_ID"
+        )
+        self.assertEqual(rv.status_code, 404)
+
+    def test_public_feed_disabled_user(self):
+        """Disabled users cannot use access tokens."""
+        username = f"disabled-ics-{uuid4().hex[:8]}"
+        with self.client.application.app_context():
+            tree = get_user_details("owner")["tree"]
+            add_user(
+                name=username,
+                password="secret",
+                role=ROLE_DISABLED,
+                tree=tree,
+            )
+            token = rotate_user_access_token(
+                username, ACCESS_TOKEN_SCOPE_ANNIVERSARIES_ICS
+            )
+        rv = self.client.get(f"{ICS_URL}?token={token}")
+        self.assertEqual(rv.status_code, 403)
+
+    def test_public_feed_disabled_tree(self):
+        """If the tree is disabled, feed returns 503."""
+        _, token = self._create_token(role=ROLE_OWNER)
+        with patch(
+            "gramps_webapi.api.resources.anniversaries.is_tree_disabled",
+            return_value=True,
+        ):
+            rv = self.client.get(f"{ICS_URL}?token={token}")
+        self.assertEqual(rv.status_code, 503)


### PR DESCRIPTION
## Summary
Add the public anniversaries ICS endpoint using the persistent scoped token infrastructure merged in #790.

## Context
This branch has been rebuilt on current `master`, so this PR now only contains the anniversaries ICS endpoint changes.

## What’s included in this step
- Add `GET /api/anniversaries.ics?token=...`.
- Resolve token via the scoped persistent token infrastructure from #790.
- Apply filters: `event_types`, `anchor_gramps_id`, `generation_depth`.
- Return `text/calendar` ICS with yearly recurring `VEVENT`s.
- Add endpoint tests for token validity, revoke flow, filters, anchor scope, disabled user/tree.

## Related
- Uses token infrastructure from: #790
- Related issue: gramps-project/gramps-web#683
