### PR TITLE
Allow strikethrough tags in HTML

### DIFF
--- a/gramps_webapi/api/html.py
+++ b/gramps_webapi/api/html.py
@@ -49,6 +49,8 @@ ALLOWED_TAGS = [
     "p",
     "br",
     "div",
+    "s",
+    "del",
 ]
 
 ALLOWED_ATTRIBUTES = {


### PR DESCRIPTION
Strikethrough is supported in styled text since Gramps 5.2, see #496.