### PR TITLE
Clean up undodb migration

### DIFF
--- a/gramps_webapi/api/tasks.py
+++ b/gramps_webapi/api/tasks.py
@@ -431,17 +431,6 @@ def upgrade_database_schema(self, tree: str, user_id: str):
         close_db(db_handle)
 
 
-@shared_task(bind=True)
-def upgrade_undodb_schema(self, tree: str, user_id: str):
-    """Upgrade the schema of the undo database."""
-    db_handle = get_db_outside_request(
-        tree=tree, view_private=True, readonly=False, user_id=user_id
-    )
-    try:
-        migrate_undodb(db_handle.undodb)
-    finally:
-        close_db(db_handle)
-
 
 @shared_task(bind=True)
 def delete_objects(

--- a/gramps_webapi/undodb.py
+++ b/gramps_webapi/undodb.py
@@ -188,6 +188,7 @@ class DbUndoSQL(DbUndo):
     ) -> None:
         DbUndo.__init__(self, grampsdb)
         self._connection_id: int | None = None
+        self._schema_initialized = False
         self.tree_id = tree_id
         self.user_id = user_id
         self.undodb: list[bytes] = []
@@ -196,6 +197,9 @@ class DbUndoSQL(DbUndo):
     @contextmanager
     def session_scope(self):
         """Provide a transactional scope around a series of operations."""
+        if not self._schema_initialized:
+            self._ensure_schema()
+            self._schema_initialized = True
         SQLSession = sessionmaker(self.engine)
         session = SQLSession()
         try:
@@ -209,9 +213,8 @@ class DbUndoSQL(DbUndo):
 
     @property
     def connection_id(self) -> int:
-        """Return the cached connection ID, creating the schema and row on first use."""
+        """Return the cached connection ID, creating it on first use."""
         if self._connection_id is None:
-            self._ensure_schema()
             self._connection_id = self._make_connection_id()
         return self._connection_id
 

--- a/gramps_webapi/undodb.py
+++ b/gramps_webapi/undodb.py
@@ -218,7 +218,10 @@ class DbUndoSQL(DbUndo):
         return self._connection_id
 
     def open(self, value=None) -> None:
-        """Open the backing storage (no-op: schema is created lazily on first DB access)."""
+        """Open the backing storage.
+
+        No-op: schema is created lazily on first DB access.
+        """
 
     def _ensure_schema(self) -> None:
         """Create the undo DB tables if not already present."""

--- a/gramps_webapi/undodb.py
+++ b/gramps_webapi/undodb.py
@@ -607,6 +607,7 @@ def _add_json_columns(undodb: DbUndoSQL) -> None:
 
 def migrate(undodb: DbUndoSQL) -> None:
     """Migrate the undo db to a new schema if needed."""
+    undodb._ensure_schema()
     _add_json_columns(undodb)
     with undodb.session_scope() as session:
         # return all rows where old_json AND new_json are NULL

--- a/gramps_webapi/undodb.py
+++ b/gramps_webapi/undodb.py
@@ -218,29 +218,9 @@ class DbUndoSQL(DbUndo):
         """Open the backing storage."""
         try:
             Base.metadata.create_all(self.engine)
-            self._add_json_columns_if_needed()
         except OperationalError as e:
             if "already exists" not in str(e):
                 raise
-
-    def _add_json_columns_if_needed(self) -> None:
-        """Add JSON columns to the change table if not already present."""
-        inspector = inspect(self.engine)
-        columns = {col["name"] for col in inspector.get_columns("changes")}
-        if "old_json" not in columns or "new_json" not in columns:
-            with self.engine.begin() as conn:
-                if "old_json" not in columns:
-                    conn.execute(
-                        text(
-                            "ALTER TABLE changes ADD COLUMN old_json TEXT DEFAULT NULL"
-                        )
-                    )
-                if "new_json" not in columns:
-                    conn.execute(
-                        text(
-                            "ALTER TABLE changes ADD COLUMN new_json TEXT DEFAULT NULL"
-                        )
-                    )
 
     def _make_connection_id(self) -> int:
         """Insert a row into the connection table."""
@@ -602,8 +582,27 @@ class DbUndoSQLWeb(DbUndoSQL):
             return transaction._to_dict(old_data=old_data, new_data=new_data)
 
 
+def _add_json_columns(undodb: DbUndoSQL) -> None:
+    """Add old_json/new_json columns to the changes table if not already present.
+
+    Only needed when migrating a database created before v3.0.
+    """
+    inspector = inspect(undodb.engine)
+    columns = {col["name"] for col in inspector.get_columns("changes")}
+    with undodb.engine.begin() as conn:
+        if "old_json" not in columns:
+            conn.execute(
+                text("ALTER TABLE changes ADD COLUMN old_json TEXT DEFAULT NULL")
+            )
+        if "new_json" not in columns:
+            conn.execute(
+                text("ALTER TABLE changes ADD COLUMN new_json TEXT DEFAULT NULL")
+            )
+
+
 def migrate(undodb: DbUndoSQL) -> None:
     """Migrate the undo db to a new schema if needed."""
+    _add_json_columns(undodb)
     with undodb.session_scope() as session:
         # return all rows where old_json AND new_json are NULL
         rows = (
@@ -637,4 +636,3 @@ def migrate(undodb: DbUndoSQL) -> None:
                     obj = obj_cls().unserialize(new_data)
                     row.new_json = object_to_string(obj)
         session.commit()
-        # add JSON columns if needed

--- a/gramps_webapi/undodb.py
+++ b/gramps_webapi/undodb.py
@@ -209,13 +209,17 @@ class DbUndoSQL(DbUndo):
 
     @property
     def connection_id(self) -> int:
-        """Return the cached connection ID or create if not exists."""
+        """Return the cached connection ID, creating the schema and row on first use."""
         if self._connection_id is None:
+            self._ensure_schema()
             self._connection_id = self._make_connection_id()
         return self._connection_id
 
     def open(self, value=None) -> None:
-        """Open the backing storage."""
+        """Open the backing storage (no-op: schema is created lazily on first write)."""
+
+    def _ensure_schema(self) -> None:
+        """Create the undo DB tables if not already present."""
         try:
             Base.metadata.create_all(self.engine)
         except OperationalError as e:

--- a/gramps_webapi/undodb.py
+++ b/gramps_webapi/undodb.py
@@ -51,7 +51,7 @@ from sqlalchemy import (
     inspect,
     text,
 )
-from sqlalchemy.exc import OperationalError
+
 from sqlalchemy.orm import DeclarativeBase, mapped_column, relationship, sessionmaker
 from sqlalchemy.sql import func
 
@@ -222,11 +222,7 @@ class DbUndoSQL(DbUndo):
 
     def _ensure_schema(self) -> None:
         """Create the undo DB tables if not already present."""
-        try:
-            Base.metadata.create_all(self.engine)
-        except OperationalError as e:
-            if "already exists" not in str(e):
-                raise
+        Base.metadata.create_all(self.engine)
         self._schema_initialized = True
 
     def _make_connection_id(self) -> int:

--- a/gramps_webapi/undodb.py
+++ b/gramps_webapi/undodb.py
@@ -199,7 +199,6 @@ class DbUndoSQL(DbUndo):
         """Provide a transactional scope around a series of operations."""
         if not self._schema_initialized:
             self._ensure_schema()
-            self._schema_initialized = True
         SQLSession = sessionmaker(self.engine)
         session = SQLSession()
         try:
@@ -228,6 +227,7 @@ class DbUndoSQL(DbUndo):
         except OperationalError as e:
             if "already exists" not in str(e):
                 raise
+        self._schema_initialized = True
 
     def _make_connection_id(self) -> int:
         """Insert a row into the connection table."""

--- a/gramps_webapi/undodb.py
+++ b/gramps_webapi/undodb.py
@@ -218,7 +218,7 @@ class DbUndoSQL(DbUndo):
         return self._connection_id
 
     def open(self, value=None) -> None:
-        """Open the backing storage (no-op: schema is created lazily on first write)."""
+        """Open the backing storage (no-op: schema is created lazily on first DB access)."""
 
     def _ensure_schema(self) -> None:
         """Create the undo DB tables if not already present."""
@@ -300,8 +300,7 @@ class DbUndoSQL(DbUndo):
                 last=last,
                 undo=int(undo),
             )
-        session.add(new_transaction)
-        session.commit()
+            session.add(new_transaction)
 
     def __getitem__(self, index: int) -> bytes:
         """

--- a/gramps_webapi/undodb.py
+++ b/gramps_webapi/undodb.py
@@ -589,15 +589,16 @@ def _add_json_columns(undodb: DbUndoSQL) -> None:
     """
     inspector = inspect(undodb.engine)
     columns = {col["name"] for col in inspector.get_columns("changes")}
-    with undodb.engine.begin() as conn:
-        if "old_json" not in columns:
-            conn.execute(
-                text("ALTER TABLE changes ADD COLUMN old_json TEXT DEFAULT NULL")
-            )
-        if "new_json" not in columns:
-            conn.execute(
-                text("ALTER TABLE changes ADD COLUMN new_json TEXT DEFAULT NULL")
-            )
+    if "old_json" not in columns or "new_json" not in columns:
+        with undodb.engine.begin() as conn:
+            if "old_json" not in columns:
+                conn.execute(
+                    text("ALTER TABLE changes ADD COLUMN old_json TEXT DEFAULT NULL")
+                )
+            if "new_json" not in columns:
+                conn.execute(
+                    text("ALTER TABLE changes ADD COLUMN new_json TEXT DEFAULT NULL")
+                )
 
 
 def migrate(undodb: DbUndoSQL) -> None:
@@ -635,4 +636,3 @@ def migrate(undodb: DbUndoSQL) -> None:
                     new_data = pickle.loads(row.new_data)
                     obj = obj_cls().unserialize(new_data)
                     row.new_json = object_to_string(obj)
-        session.commit()

--- a/tests/test_undodb.py
+++ b/tests/test_undodb.py
@@ -223,3 +223,130 @@ class TestUndoHistory(unittest.TestCase):
         assert string_to_dict(commit["new_json"]) == object_to_dict(person)
         assert string_to_dict(commit["new_json"]) == object_to_dict(new_person)
         assert string_to_dict(commit["old_json"]) == object_to_dict(old_person)
+
+
+class TestMigrate(unittest.TestCase):
+    """Tests for the migrate() function (pre-v3.0 → v3.0 undo DB migration)."""
+
+    def setUp(self):
+        self.dbdir = tempfile.mkdtemp()
+        self.db: DbWriteBase = make_database("sqlite")
+
+        def create_undo_manager():
+            path = self.db.undolog
+            return DbUndoSQL(grampsdb=self.db, dburl=f"sqlite:///{path}")
+
+        self.db._create_undo_manager = create_undo_manager
+        self.db.load(self.dbdir)
+
+        with DbTxn("Add test person", self.db) as trans:
+            person = Person()
+            self.db.add_person(person, trans)
+            self.person_handle = person.handle
+
+    def tearDown(self):
+        self.db.close(update=False)
+        shutil.rmtree(self.dbdir)
+
+    def _get_undodb(self) -> DbUndoSQL:
+        return self.db.get_undodb()
+
+    def _drop_json_columns(self):
+        """Simulate a pre-v3.0 database by dropping the JSON columns."""
+        undodb = self._get_undodb()
+        with undodb.session_scope() as session:
+            session.execute(text("ALTER TABLE changes DROP COLUMN old_json"))
+            session.execute(text("ALTER TABLE changes DROP COLUMN new_json"))
+
+    def _null_json_set_blobs(self):
+        """Simulate pre-v3.0 rows: clear JSON columns and write blob data instead."""
+        person = self.db.get_person_from_handle(self.person_handle)
+        blob = pickle.dumps(person.serialize(), protocol=1)
+        undodb = self._get_undodb()
+        with undodb.session_scope() as session:
+            session.execute(
+                text(
+                    "UPDATE changes SET old_json = NULL, new_json = NULL,"
+                    " new_data = :blob"
+                ),
+                {"blob": blob},
+            )
+
+    def test_migrate_adds_missing_columns(self):
+        """migrate() adds old_json/new_json when they are absent (pre-v3.0 DB)."""
+        from gramps_webapi.undodb import migrate
+        from sqlalchemy import inspect as sa_inspect
+
+        self._drop_json_columns()
+        undodb = self._get_undodb()
+
+        cols_before = {
+            col["name"]
+            for col in sa_inspect(undodb.engine).get_columns("changes")
+        }
+        self.assertNotIn("old_json", cols_before)
+        self.assertNotIn("new_json", cols_before)
+
+        migrate(undodb)
+
+        cols_after = {
+            col["name"]
+            for col in sa_inspect(undodb.engine).get_columns("changes")
+        }
+        self.assertIn("old_json", cols_after)
+        self.assertIn("new_json", cols_after)
+
+    def test_migrate_backfills_blob_data(self):
+        """migrate() fills old_json/new_json from blob columns for pre-v3.0 rows."""
+        from gramps_webapi.undodb import migrate
+
+        self._null_json_set_blobs()
+        undodb = self._get_undodb()
+
+        with undodb.session_scope() as session:
+            nulls: int = session.execute(
+                text("SELECT COUNT(*) FROM changes WHERE new_json IS NULL")
+            ).scalar() or 0
+        self.assertGreater(nulls, 0)
+
+        migrate(undodb)
+
+        with undodb.session_scope() as session:
+            nulls_after = session.execute(
+                text("SELECT COUNT(*) FROM changes WHERE new_json IS NULL")
+            ).scalar()
+        self.assertEqual(nulls_after, 0)
+
+    def test_migrate_idempotent(self):
+        """Calling migrate() twice does not raise and does not corrupt data."""
+        from gramps_webapi.undodb import migrate
+
+        migrate(self._get_undodb())
+        migrate(self._get_undodb())  # second call must not crash
+
+        undodb = self._get_undodb()
+        with undodb.session_scope() as session:
+            count: int = session.execute(
+                text("SELECT COUNT(*) FROM changes")
+            ).scalar() or 0
+        self.assertGreater(count, 0)
+
+    def test_migrate_noop_when_current(self):
+        """migrate() on an already-current DB (all JSON populated) is a no-op."""
+        from gramps_webapi.undodb import migrate
+
+        undodb = self._get_undodb()
+
+        with undodb.session_scope() as session:
+            rows_before = session.execute(
+                text("SELECT id, new_json FROM changes")
+            ).fetchall()
+
+        migrate(undodb)
+
+        with undodb.session_scope() as session:
+            rows_after = session.execute(
+                text("SELECT id, new_json FROM changes")
+            ).fetchall()
+
+        self.assertEqual(rows_before, rows_after)

--- a/tests/test_undodb.py
+++ b/tests/test_undodb.py
@@ -339,14 +339,14 @@ class TestMigrate(unittest.TestCase):
 
         with undodb.session_scope() as session:
             rows_before = session.execute(
-                text("SELECT id, new_json FROM changes")
+                text("SELECT id, new_json FROM changes ORDER BY id")
             ).fetchall()
 
         migrate(undodb)
 
         with undodb.session_scope() as session:
             rows_after = session.execute(
-                text("SELECT id, new_json FROM changes")
+                text("SELECT id, new_json FROM changes ORDER BY id")
             ).fetchall()
 
         self.assertEqual(rows_before, rows_after)


### PR DESCRIPTION
This will speed up requests by skipping the schema check. Pre-3.0 deployments can still be migrated with `python -m gramps_webapi grampsdb migrate-undodb`.