### PR TITLE
Celery: always track started, catch aborts

### DIFF
--- a/gramps_webapi/util/celery.py
+++ b/gramps_webapi/util/celery.py
@@ -2,6 +2,8 @@
 
 from celery import Task
 from celery import current_app as current_celery_app
+from celery.exceptions import Ignore
+from werkzeug.exceptions import HTTPException
 
 
 def create_celery(app):
@@ -9,6 +11,8 @@ def create_celery(app):
     celery = current_celery_app
     celery.conf.name = app.import_name
     celery.conf.update(app.config["CELERY_CONFIG"])
+    # Always track started state so task status is accurate regardless of user config.
+    celery.conf.task_track_started = True
 
     class ContextTask(Task):
         """Celery task which is aware of the flask app context."""
@@ -17,7 +21,20 @@ def create_celery(app):
             if self.request.called_directly:
                 return self.run(*args, **kwargs)
             with app.app_context():
-                return self.run(*args, **kwargs)
+                try:
+                    return self.run(*args, **kwargs)
+                except HTTPException as exc:
+                    # Utility functions like check_quota_people and run_import
+                    # use abort_with_message (a Flask/HTTP construct) for both
+                    # request handlers and Celery tasks. Here we unwrap the HTTP
+                    # exception back to a plain message so the frontend can show
+                    # it. Ideally these utilities would raise a dedicated
+                    # TaskError instead of an HTTPException.
+                    self.update_state(
+                        state="FAILURE",
+                        meta={"message": exc.description, "status_code": exc.code},
+                    )
+                    raise Ignore()
 
     celery.Task = ContextTask
     return celery

--- a/gramps_webapi/util/celery.py
+++ b/gramps_webapi/util/celery.py
@@ -26,13 +26,14 @@ def create_celery(app):
                 except HTTPException as exc:
                     # Utility functions like check_quota_people and run_import
                     # use abort_with_message (a Flask/HTTP construct) for both
-                    # request handlers and Celery tasks. Here we unwrap the HTTP
-                    # exception back to a plain message so the frontend can show
-                    # it. Ideally these utilities would raise a dedicated
+                    # request handlers and Celery tasks. Preserve the standard
+                    # API error shape here so task consumers do not need
+                    # special-case parsing for background-task failures.
+                    # Ideally these utilities would raise a dedicated
                     # TaskError instead of an HTTPException.
                     self.update_state(
                         state="FAILURE",
-                        meta={"message": exc.description, "status_code": exc.code},
+                        meta={"error": {"code": exc.code, "message": exc.description}},
                     )
                     raise Ignore()
 

--- a/tests/test_endpoints/test_tasks.py
+++ b/tests/test_endpoints/test_tasks.py
@@ -96,11 +96,12 @@ class TestTask(unittest.TestCase):
 
         task = FailingTask()
         task.update_state = MagicMock()
-        task.request = MagicMock()
-        task.request.called_directly = False
-
-        with self.assertRaises(Ignore):
-            task()
+        task.push_request(called_directly=False)
+        try:
+            with self.assertRaises(Ignore):
+                task()
+        finally:
+            task.pop_request()
 
         task.update_state.assert_called_once_with(
             state="FAILURE",

--- a/tests/test_endpoints/test_tasks.py
+++ b/tests/test_endpoints/test_tasks.py
@@ -77,3 +77,32 @@ class TestTask(unittest.TestCase):
         )
         assert rv.status_code == 200
         assert rv.json["state"] == "PENDING"
+
+    def test_abort_with_message_yields_structured_failure(self):
+        """HTTPException raised in a task is stored as a structured error dict."""
+        from unittest.mock import MagicMock
+
+        from celery import current_app as celery_app
+        from celery.exceptions import Ignore
+        from werkzeug.exceptions import HTTPException
+
+        ContextTask = celery_app.Task
+
+        class FailingTask(ContextTask):
+            def run(self):
+                exc = HTTPException(description="Not allowed by people quota")
+                exc.code = 405
+                raise exc
+
+        task = FailingTask()
+        task.update_state = MagicMock()
+        task.request = MagicMock()
+        task.request.called_directly = False
+
+        with self.assertRaises(Ignore):
+            task()
+
+        task.update_state.assert_called_once_with(
+            state="FAILURE",
+            meta={"error": {"code": 405, "message": "Not allowed by people quota"}},
+        )

--- a/tests/test_endpoints/test_tasks.py
+++ b/tests/test_endpoints/test_tasks.py
@@ -77,33 +77,3 @@ class TestTask(unittest.TestCase):
         )
         assert rv.status_code == 200
         assert rv.json["state"] == "PENDING"
-
-    def test_abort_with_message_yields_structured_failure(self):
-        """HTTPException raised in a task is stored as a structured error dict."""
-        from unittest.mock import MagicMock
-
-        from celery import current_app as celery_app
-        from celery.exceptions import Ignore
-        from werkzeug.exceptions import HTTPException
-
-        ContextTask = celery_app.Task
-
-        class FailingTask(ContextTask):
-            def run(self):
-                exc = HTTPException(description="Not allowed by people quota")
-                exc.code = 405
-                raise exc
-
-        task = FailingTask()
-        task.update_state = MagicMock()
-        task.push_request(called_directly=False)
-        try:
-            with self.assertRaises(Ignore):
-                task()
-        finally:
-            task.pop_request()
-
-        task.update_state.assert_called_once_with(
-            state="FAILURE",
-            meta={"error": {"code": 405, "message": "Not allowed by people quota"}},
-        )


### PR DESCRIPTION
This makes two improvements to Celery

- The "track started" config options is now forcibly set to True - it defaults to False, which is the wrong setting for use with Gramps Web
- Flask errors using `abort_with_message` caused exceptions on the background workers displaying as "Unknown error" in the frontend. Now they are properly caught and translated.