### PR TITLE
Fix GEDCOM7 import error handling to use appropriate HTTP status codes

### DIFF
--- a/gramps_webapi/api/resources/util.py
+++ b/gramps_webapi/api/resources/util.py
@@ -1717,16 +1717,14 @@ def run_import(
             gramps_gedcom7.import_gedcom(input_file=file_name, db=db_handle)
         except ValueError as e:
             # ValueError indicates invalid file format or encoding (e.g., not UTF-8)
-            if delete:
-                os.remove(file_name)
             abort_with_message(422, f"Invalid GEDCOM file: {e}")
         except Exception as e:
-            # Unexpected errors
+            # Unexpected errors - log for debugging
+            current_app.logger.exception("GEDCOM7 import failed with unexpected error")
+            abort_with_message(500, f"Import failed: {e}")
+        finally:
             if delete:
                 os.remove(file_name)
-            abort_with_message(500, f"Import failed: {e}")
-        if delete:
-            os.remove(file_name)
         return
     if extension.lower() == "gramps":
         # Remove mediapath tag from Gramps XML files before import

--- a/gramps_webapi/api/resources/util.py
+++ b/gramps_webapi/api/resources/util.py
@@ -1724,7 +1724,13 @@ def run_import(
             abort_with_message(500, f"Import failed: {e}")
         finally:
             if delete:
-                os.remove(file_name)
+                try:
+                    os.remove(file_name)
+                except OSError as e:
+                    # Log but don't let cleanup failures mask the import error
+                    current_app.logger.warning(
+                        f"Failed to delete temporary file {file_name}: {e}"
+                    )
         return
     if extension.lower() == "gramps":
         # Remove mediapath tag from Gramps XML files before import

--- a/gramps_webapi/api/resources/util.py
+++ b/gramps_webapi/api/resources/util.py
@@ -1715,11 +1715,18 @@ def run_import(
     if extension.lower() == "ged" and detect_gedcom_major_version(str(file_name)) == 7:
         try:
             gramps_gedcom7.import_gedcom(input_file=file_name, db=db_handle)
-        except Exception as e:
-            abort_with_message(500, f"Import failed: {e}")
-        finally:
+        except ValueError as e:
+            # ValueError indicates invalid file format or encoding (e.g., not UTF-8)
             if delete:
                 os.remove(file_name)
+            abort_with_message(422, f"Invalid GEDCOM file: {e}")
+        except Exception as e:
+            # Unexpected errors
+            if delete:
+                os.remove(file_name)
+            abort_with_message(500, f"Import failed: {e}")
+        if delete:
+            os.remove(file_name)
         return
     if extension.lower() == "gramps":
         # Remove mediapath tag from Gramps XML files before import

--- a/tests/test_import_util.py
+++ b/tests/test_import_util.py
@@ -31,6 +31,12 @@ from gramps_webapi.api.resources.util import (
     remove_mediapath_from_gramps_xml,
     run_import,
 )
+from gramps_webapi.app import create_app
+
+APP = create_app(
+    {"TREE": "test", "SECRET_KEY": "test", "USER_DB_URI": "sqlite://"},
+    config_from_env=False,
+)
 
 
 class TestRemoveMediapathFromGrampsXml(unittest.TestCase):
@@ -307,10 +313,6 @@ class TestRemoveMediapathFromGrampsXml(unittest.TestCase):
             os.unlink(temp_file)
 
 
-if __name__ == "__main__":
-    unittest.main()
-
-
 class TestGedcom7ErrorHandling(unittest.TestCase):
     """Test cases for GEDCOM7 import error handling."""
 
@@ -334,10 +336,7 @@ class TestGedcom7ErrorHandling(unittest.TestCase):
             mock_db = MagicMock()
 
             # Create Flask app context for current_app
-            from gramps_webapi.app import create_app
-
-            app = create_app()
-            with app.app_context():
+            with APP.app_context():
                 with self.assertRaises(HTTPException) as cm:
                     run_import(
                         db_handle=mock_db,
@@ -378,10 +377,7 @@ class TestGedcom7ErrorHandling(unittest.TestCase):
             mock_db = MagicMock()
 
             # Create Flask app context
-            from gramps_webapi.app import create_app
-
-            app = create_app()
-            with app.app_context():
+            with APP.app_context():
                 with self.assertRaises(HTTPException) as cm:
                     run_import(
                         db_handle=mock_db,
@@ -425,10 +421,7 @@ class TestGedcom7ErrorHandling(unittest.TestCase):
             mock_db = MagicMock()
 
             # Create Flask app context
-            from gramps_webapi.app import create_app
-
-            app = create_app()
-            with app.app_context():
+            with APP.app_context():
                 with self.assertRaises(HTTPException) as cm:
                     run_import(
                         db_handle=mock_db,
@@ -469,10 +462,7 @@ class TestGedcom7ErrorHandling(unittest.TestCase):
             mock_db = MagicMock()
 
             # Create Flask app context
-            from gramps_webapi.app import create_app
-
-            app = create_app()
-            with app.app_context():
+            with APP.app_context():
                 with self.assertRaises(HTTPException):
                     run_import(
                         db_handle=mock_db,

--- a/tests/test_import_util.py
+++ b/tests/test_import_util.py
@@ -23,8 +23,14 @@ import gzip
 import os
 import tempfile
 import unittest
+from unittest.mock import MagicMock, patch
 
-from gramps_webapi.api.resources.util import remove_mediapath_from_gramps_xml
+from werkzeug.exceptions import HTTPException
+
+from gramps_webapi.api.resources.util import (
+    remove_mediapath_from_gramps_xml,
+    run_import,
+)
 
 
 class TestRemoveMediapathFromGrampsXml(unittest.TestCase):
@@ -303,3 +309,181 @@ class TestRemoveMediapathFromGrampsXml(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class TestGedcom7ErrorHandling(unittest.TestCase):
+    """Test cases for GEDCOM7 import error handling."""
+
+    @patch("gramps_webapi.api.resources.util.detect_gedcom_major_version")
+    @patch("gramps_webapi.api.resources.util.gramps_gedcom7")
+    def test_gedcom7_valueerror_returns_422(
+        self, mock_gedcom7, mock_detect_version
+    ):
+        """Test that ValueError during GEDCOM7 import returns 422."""
+        mock_detect_version.return_value = 7
+        mock_gedcom7.import_gedcom.side_effect = ValueError("File is not UTF-8 encoded")
+
+        # Create temporary file
+        with tempfile.NamedTemporaryFile(
+            mode="wb", suffix=".ged", delete=False
+        ) as f:
+            temp_file = f.name
+            f.write(b"dummy content")
+
+        try:
+            mock_db = MagicMock()
+
+            # Create Flask app context for current_app
+            from gramps_webapi.app import create_app
+
+            app = create_app()
+            with app.app_context():
+                with self.assertRaises(HTTPException) as cm:
+                    run_import(
+                        db_handle=mock_db,
+                        file_name=temp_file,
+                        extension="ged",
+                        delete=True,
+                    )
+
+                # Verify 422 status code and message
+                self.assertEqual(cm.exception.code, 422)
+                self.assertIn("Invalid GEDCOM file", str(cm.exception.description))
+                self.assertIn("UTF-8", str(cm.exception.description))
+
+            # Verify file was deleted
+            self.assertFalse(os.path.exists(temp_file))
+        finally:
+            # Clean up if test failed
+            if os.path.exists(temp_file):
+                os.unlink(temp_file)
+
+    @patch("gramps_webapi.api.resources.util.detect_gedcom_major_version")
+    @patch("gramps_webapi.api.resources.util.gramps_gedcom7")
+    def test_gedcom7_unexpected_error_returns_500(
+        self, mock_gedcom7, mock_detect_version
+    ):
+        """Test that unexpected Exception during GEDCOM7 import returns 500."""
+        mock_detect_version.return_value = 7
+        mock_gedcom7.import_gedcom.side_effect = RuntimeError("Unexpected error")
+
+        # Create temporary file
+        with tempfile.NamedTemporaryFile(
+            mode="wb", suffix=".ged", delete=False
+        ) as f:
+            temp_file = f.name
+            f.write(b"dummy content")
+
+        try:
+            mock_db = MagicMock()
+
+            # Create Flask app context
+            from gramps_webapi.app import create_app
+
+            app = create_app()
+            with app.app_context():
+                with self.assertRaises(HTTPException) as cm:
+                    run_import(
+                        db_handle=mock_db,
+                        file_name=temp_file,
+                        extension="ged",
+                        delete=True,
+                    )
+
+                # Verify 500 status code and message
+                self.assertEqual(cm.exception.code, 500)
+                self.assertIn("Import failed", str(cm.exception.description))
+                self.assertIn("Unexpected error", str(cm.exception.description))
+
+            # Verify file was deleted
+            self.assertFalse(os.path.exists(temp_file))
+        finally:
+            # Clean up if test failed
+            if os.path.exists(temp_file):
+                os.unlink(temp_file)
+
+    @patch("gramps_webapi.api.resources.util.detect_gedcom_major_version")
+    @patch("gramps_webapi.api.resources.util.gramps_gedcom7")
+    @patch("gramps_webapi.api.resources.util.os.remove")
+    def test_gedcom7_cleanup_failure_doesnt_mask_error(
+        self, mock_remove, mock_gedcom7, mock_detect_version
+    ):
+        """Test that file cleanup failures don't mask the original import error."""
+        mock_detect_version.return_value = 7
+        mock_gedcom7.import_gedcom.side_effect = ValueError("Invalid file")
+        # Simulate file deletion failure
+        mock_remove.side_effect = OSError("Permission denied")
+
+        # Create temporary file
+        with tempfile.NamedTemporaryFile(
+            mode="wb", suffix=".ged", delete=False
+        ) as f:
+            temp_file = f.name
+            f.write(b"dummy content")
+
+        try:
+            mock_db = MagicMock()
+
+            # Create Flask app context
+            from gramps_webapi.app import create_app
+
+            app = create_app()
+            with app.app_context():
+                with self.assertRaises(HTTPException) as cm:
+                    run_import(
+                        db_handle=mock_db,
+                        file_name=temp_file,
+                        extension="ged",
+                        delete=True,
+                    )
+
+                # Verify original 422 error is preserved, not OSError
+                self.assertEqual(cm.exception.code, 422)
+                self.assertIn("Invalid GEDCOM file", str(cm.exception.description))
+                self.assertNotIn("Permission denied", str(cm.exception.description))
+
+            # Verify os.remove was attempted
+            mock_remove.assert_called_once_with(temp_file)
+        finally:
+            # Clean up
+            if os.path.exists(temp_file):
+                os.unlink(temp_file)
+
+    @patch("gramps_webapi.api.resources.util.detect_gedcom_major_version")
+    @patch("gramps_webapi.api.resources.util.gramps_gedcom7")
+    def test_gedcom7_no_delete_preserves_file(
+        self, mock_gedcom7, mock_detect_version
+    ):
+        """Test that file is preserved when delete=False."""
+        mock_detect_version.return_value = 7
+        mock_gedcom7.import_gedcom.side_effect = ValueError("Invalid file")
+
+        # Create temporary file
+        with tempfile.NamedTemporaryFile(
+            mode="wb", suffix=".ged", delete=False
+        ) as f:
+            temp_file = f.name
+            f.write(b"dummy content")
+
+        try:
+            mock_db = MagicMock()
+
+            # Create Flask app context
+            from gramps_webapi.app import create_app
+
+            app = create_app()
+            with app.app_context():
+                with self.assertRaises(HTTPException):
+                    run_import(
+                        db_handle=mock_db,
+                        file_name=temp_file,
+                        extension="ged",
+                        delete=False,  # Don't delete
+                    )
+
+            # Verify file was NOT deleted
+            self.assertTrue(os.path.exists(temp_file))
+        finally:
+            # Clean up
+            if os.path.exists(temp_file):
+                os.unlink(temp_file)


### PR DESCRIPTION
- Use 422 Unprocessable Entity for ValueError (e.g., non-UTF-8 encoding)
- Reserve 500 Internal Server Error for unexpected exceptions
- Ensure proper file cleanup in both error cases