### PR TITLE
Allow per-tree config

### DIFF
--- a/alembic_users/versions/b2c3d4e5f6a7_add_tree_config_column.py
+++ b/alembic_users/versions/b2c3d4e5f6a7_add_tree_config_column.py
@@ -1,0 +1,29 @@
+"""Add trees.config JSON column
+
+Revision ID: b2c3d4e5f6a7
+Revises: 2082445b0769
+Create Date: 2026-05-01 00:00:00.000000
+
+"""
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.engine.reflection import Inspector
+
+# revision identifiers, used by Alembic.
+revision = "b2c3d4e5f6a7"
+down_revision = "2082445b0769"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    conn = op.get_bind()
+    inspector = Inspector.from_engine(conn)
+    columns = [col["name"] for col in inspector.get_columns("trees")]
+    if "config" in columns:
+        return None
+    op.add_column("trees", sa.Column("config", sa.JSON(), nullable=True))
+
+
+def downgrade():
+    op.drop_column("trees", "config")

--- a/gramps_webapi/api/__init__.py
+++ b/gramps_webapi/api/__init__.py
@@ -110,6 +110,7 @@ from .resources.trees import (
     CheckTreeResource,
     DisableTreeResource,
     EnableTreeResource,
+    TreeConfigResource,
     TreeResource,
     TreesResource,
     UpgradeTreeSchemaResource,
@@ -314,6 +315,12 @@ register_endpt(
     UpgradeTreeSchemaResource,
     "/trees/<string:tree_id>/migrate",
     "migrate_tree",
+    tags=["Trees"],
+)
+register_endpt(
+    TreeConfigResource,
+    "/trees/<string:tree_id>/config",
+    "tree_config",
     tags=["Trees"],
 )
 # Types

--- a/gramps_webapi/api/resources/schemas.py
+++ b/gramps_webapi/api/resources/schemas.py
@@ -2493,3 +2493,7 @@ class TreeSchema(_Base):
             "description": "Minimum user role required to use the AI chat endpoint."
         },
     )
+
+
+class TreeConfigSchema(_Base):
+    """Per-tree configuration blob (arbitrary JSON object of feature flags and UI preferences)."""

--- a/gramps_webapi/api/resources/schemas.py
+++ b/gramps_webapi/api/resources/schemas.py
@@ -2496,4 +2496,4 @@ class TreeSchema(_Base):
 
 
 class TreeConfigSchema(_Base):
-    """Per-tree configuration blob (arbitrary JSON object of feature flags and UI preferences)."""
+    """Per-tree configuration blob (free-form JSON object)."""

--- a/gramps_webapi/api/resources/trees.py
+++ b/gramps_webapi/api/resources/trees.py
@@ -34,9 +34,11 @@ from werkzeug.security import safe_join
 
 from ...auth import (
     disable_enable_tree,
+    get_tree_config,
     get_tree_permissions,
     get_tree_usage,
     is_tree_disabled,
+    set_tree_config,
     set_tree_details,
 )
 from ...auth.const import (
@@ -50,7 +52,7 @@ from ...auth.const import (
     PERM_UPGRADE_TREE_SCHEMA,
     PERM_VIEW_OTHER_TREE,
 )
-from ...const import TREE_MULTI
+from ...const import TREE_CONFIG_MAX_BYTES, TREE_MULTI
 from ...dbmanager import WebDbManager
 from ..auth import has_permissions, require_permissions
 from ..tasks import (
@@ -60,13 +62,15 @@ from ..tasks import (
     run_task,
     upgrade_database_schema,
 )
-from marshmallow import Schema
+import json
+
+from marshmallow import INCLUDE, Schema, ValidationError, validates_schema
 from webargs import fields
 
 from ..blueprint import api_blueprint
 from ..util import abort_with_message, get_tree_from_jwt_or_fail, list_trees
 from . import ProtectedResource
-from .schemas import TreeSchema
+from .schemas import TreeConfigSchema, TreeSchema
 
 # legal tree dirnames
 TREE_ID_REGEX = re.compile(r"^[a-zA-Z0-9_-]+$")
@@ -357,3 +361,51 @@ class UpgradeTreeSchemaResource(ProtectedResource):
         if isinstance(task, AsyncResult):
             return make_task_response(task)
         return jsonify(task), 201
+
+
+class TreeConfigBodyArgs(Schema):
+    """Body arguments for PUT /trees/<tree_id>/config."""
+
+    class Meta:
+        unknown = INCLUDE
+
+    @validates_schema
+    def validate_size(self, data, **kwargs):
+        if len(json.dumps(data).encode()) > TREE_CONFIG_MAX_BYTES:
+            raise ValidationError(
+                f"Config payload exceeds maximum size of {TREE_CONFIG_MAX_BYTES // 1024} KB"
+            )
+
+
+class TreeConfigResource(ProtectedResource):
+    """Resource for reading and writing the per-tree configuration blob."""
+
+    @api_blueprint.response(200, TreeConfigSchema())
+    def get(self, tree_id: str):
+        """Get the per-tree configuration blob."""
+        if tree_id == "-":
+            tree_id = get_tree_from_jwt_or_fail()
+        else:
+            validate_tree_id(tree_id)
+            if not has_permissions([PERM_VIEW_OTHER_TREE]):
+                user_tree_id = get_tree_from_jwt_or_fail()
+                if tree_id != user_tree_id:
+                    abort_with_message(403, "Not authorized to view other trees")
+        return get_tree_config(tree_id)
+
+    @api_blueprint.response(200, TreeConfigSchema())
+    @api_blueprint.arguments(TreeConfigBodyArgs, location="json")
+    def put(self, args, tree_id: str):
+        """Replace the per-tree configuration blob."""
+        if tree_id == "-":
+            tree_id = get_tree_from_jwt_or_fail()
+            require_permissions([PERM_EDIT_TREE])
+        else:
+            user_tree_id = get_tree_from_jwt_or_fail()
+            if tree_id == user_tree_id:
+                require_permissions([PERM_EDIT_TREE])
+            else:
+                require_permissions([PERM_EDIT_OTHER_TREE])
+                validate_tree_id(tree_id)
+        set_tree_config(tree=tree_id, config=args)
+        return args

--- a/gramps_webapi/api/resources/trees.py
+++ b/gramps_webapi/api/resources/trees.py
@@ -29,7 +29,7 @@ from typing import Dict, List, Optional
 from flask import abort, current_app, jsonify, request
 from flask_jwt_extended import get_jwt_identity
 from gramps.gen.config import config
-from marshmallow import INCLUDE, Schema
+from marshmallow import INCLUDE, Schema, ValidationError, validates_schema
 from webargs import fields
 from werkzeug.security import safe_join
 
@@ -363,7 +363,16 @@ class TreeConfigBodyArgs(Schema):
     """Body arguments for PUT /trees/<tree_id>/config."""
 
     class Meta:
+        """Accept any JSON object keys."""
+
         unknown = INCLUDE
+
+    @validates_schema
+    def validate_size(self, data, **kwargs):
+        if len(request.get_data()) > TREE_CONFIG_MAX_BYTES:
+            raise ValidationError(
+                f"Config payload exceeds {TREE_CONFIG_MAX_BYTES // 1024} KB limit"
+            )
 
 
 class TreeConfigResource(ProtectedResource):
@@ -388,8 +397,6 @@ class TreeConfigResource(ProtectedResource):
     @api_blueprint.arguments(TreeConfigBodyArgs, location="json")
     def put(self, args, tree_id: str):
         """Replace the per-tree configuration blob."""
-        if len(request.get_data()) > TREE_CONFIG_MAX_BYTES:
-            abort_with_message(413, "Config payload too large")
         if tree_id == "-":
             tree_id = get_tree_from_jwt_or_fail()
             require_permissions([PERM_EDIT_TREE])

--- a/gramps_webapi/api/resources/trees.py
+++ b/gramps_webapi/api/resources/trees.py
@@ -26,9 +26,10 @@ import re
 import uuid
 from typing import Dict, List, Optional
 
-from flask import abort, current_app, jsonify
+from flask import abort, current_app, jsonify, request
 from flask_jwt_extended import get_jwt_identity
 from gramps.gen.config import config
+from marshmallow import INCLUDE, Schema
 from webargs import fields
 from werkzeug.security import safe_join
 
@@ -62,11 +63,6 @@ from ..tasks import (
     run_task,
     upgrade_database_schema,
 )
-import json
-
-from marshmallow import INCLUDE, Schema, ValidationError, validates_schema
-from webargs import fields
-
 from ..blueprint import api_blueprint
 from ..util import abort_with_message, get_tree_from_jwt_or_fail, list_trees
 from . import ProtectedResource
@@ -369,13 +365,6 @@ class TreeConfigBodyArgs(Schema):
     class Meta:
         unknown = INCLUDE
 
-    @validates_schema
-    def validate_size(self, data, **kwargs):
-        if len(json.dumps(data).encode()) > TREE_CONFIG_MAX_BYTES:
-            raise ValidationError(
-                f"Config payload exceeds maximum size of {TREE_CONFIG_MAX_BYTES // 1024} KB"
-            )
-
 
 class TreeConfigResource(ProtectedResource):
     """Resource for reading and writing the per-tree configuration blob."""
@@ -391,12 +380,16 @@ class TreeConfigResource(ProtectedResource):
                 user_tree_id = get_tree_from_jwt_or_fail()
                 if tree_id != user_tree_id:
                     abort_with_message(403, "Not authorized to view other trees")
-        return get_tree_config(tree_id)
+        if not tree_exists(tree_id):
+            abort(404)
+        return jsonify(get_tree_config(tree_id))
 
     @api_blueprint.response(200, TreeConfigSchema())
     @api_blueprint.arguments(TreeConfigBodyArgs, location="json")
     def put(self, args, tree_id: str):
         """Replace the per-tree configuration blob."""
+        if len(request.get_data()) > TREE_CONFIG_MAX_BYTES:
+            abort_with_message(413, "Config payload too large")
         if tree_id == "-":
             tree_id = get_tree_from_jwt_or_fail()
             require_permissions([PERM_EDIT_TREE])
@@ -407,5 +400,7 @@ class TreeConfigResource(ProtectedResource):
             else:
                 require_permissions([PERM_EDIT_OTHER_TREE])
                 validate_tree_id(tree_id)
+        if not tree_exists(tree_id):
+            abort(404)
         set_tree_config(tree=tree_id, config=args)
-        return args
+        return jsonify(args)

--- a/gramps_webapi/auth/__init__.py
+++ b/gramps_webapi/auth/__init__.py
@@ -469,6 +469,26 @@ def is_tree_disabled(tree: str) -> bool:
     return tree_obj.enabled == 0
 
 
+def get_tree_config(tree: str) -> dict:
+    """Get the tree config blob (returns empty dict if not set)."""
+    query = user_db.session.query(Tree)  # pylint: disable=no-member
+    tree_obj: Tree = query.filter_by(id=tree).scalar()
+    if tree_obj is None:
+        return {}
+    return tree_obj.config or {}
+
+
+def set_tree_config(tree: str, config: dict) -> None:
+    """Replace the tree config blob."""
+    query = user_db.session.query(Tree)  # pylint: disable=no-member
+    tree_obj = query.filter_by(id=tree).scalar()
+    if not tree_obj:
+        tree_obj = Tree(id=tree)
+    tree_obj.config = config
+    user_db.session.add(tree_obj)  # pylint: disable=no-member
+    user_db.session.commit()  # pylint: disable=no-member
+
+
 def create_oidc_account(
     user_id: str, provider_id: str, subject_id: str, email: Optional[str] = None
 ) -> None:
@@ -553,6 +573,7 @@ class Tree(user_db.Model):  # type: ignore
     usage_ai = mapped_column(sa.Integer)
     min_role_ai = mapped_column(sa.Integer)
     enabled = mapped_column(sa.Integer, default=1, server_default="1")
+    config = mapped_column(sa.JSON, nullable=True)
 
     def __repr__(self):
         """Return string representation of instance."""

--- a/gramps_webapi/const.py
+++ b/gramps_webapi/const.py
@@ -31,6 +31,7 @@ from ._version import __version__ as VERSION
 
 # the value of the TREE config option that enables multi-tree support
 TREE_MULTI = "*"
+TREE_CONFIG_MAX_BYTES = 64 * 1024  # 64 KB
 
 # Helper function to get resource file paths with managed cleanup
 _file_manager = ExitStack()

--- a/tests/test_endpoints/test_trees.py
+++ b/tests/test_endpoints/test_trees.py
@@ -321,6 +321,141 @@ class TestTrees(unittest.TestCase):
         assert rv.status_code == 404
 
 
+class TestTreeConfig(unittest.TestCase):
+    """Test cases for the /api/trees/<tree_id>/config endpoint."""
+
+    def setUp(self):
+        self.name = "Test Web API Config"
+        self.dbman = CLIDbManager(DbState())
+        dbpath, _name = self.dbman.create_new_db_cli(self.name, dbid="sqlite")
+        self.tree = os.path.basename(dbpath)
+        with patch.dict("os.environ", {ENV_CONFIG_FILE: TEST_AUTH_CONFIG}):
+            self.app = create_app(
+                config={"TESTING": True, "RATELIMIT_ENABLED": False},
+                config_from_env=False,
+            )
+        self.client = self.app.test_client()
+        with self.app.app_context():
+            user_db.create_all()
+            add_user(
+                name="owner",
+                password="123",
+                email="owner@example.com",
+                role=ROLE_OWNER,
+                tree=self.tree,
+            )
+            add_user(
+                name="admin",
+                password="123",
+                email="admin@example.com",
+                role=ROLE_ADMIN,
+                tree=self.tree,
+            )
+        self.ctx = self.app.test_request_context()
+        self.ctx.push()
+
+    def tearDown(self):
+        self.ctx.pop()
+        self.dbman.remove_database(self.name)
+
+    def _token(self, username):
+        rv = self.client.post(
+            BASE_URL + "/token/", json={"username": username, "password": "123"}
+        )
+        return rv.json["access_token"]
+
+    def test_get_config_empty(self):
+        token = self._token("owner")
+        rv = self.client.get(
+            BASE_URL + "/trees/-/config",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert rv.status_code == 200
+        assert rv.json == {}
+
+    def test_put_and_get_flat_config(self):
+        token = self._token("owner")
+        payload = {"show_sidebar": True, "items_per_page": 25, "theme": "dark"}
+        rv = self.client.put(
+            BASE_URL + "/trees/-/config",
+            headers={"Authorization": f"Bearer {token}"},
+            json=payload,
+        )
+        assert rv.status_code == 200
+        assert rv.json == payload
+        rv = self.client.get(
+            BASE_URL + "/trees/-/config",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert rv.status_code == 200
+        assert rv.json == payload
+
+    def test_put_and_get_nested_config(self):
+        token = self._token("owner")
+        payload = {
+            "ui": {"sidebar": True, "theme": "dark"},
+            "allowed_roles": [1, 2, 3],
+            "feature_flags": {"ai_chat": False, "export": True},
+        }
+        rv = self.client.put(
+            BASE_URL + "/trees/-/config",
+            headers={"Authorization": f"Bearer {token}"},
+            json=payload,
+        )
+        assert rv.status_code == 200
+        assert rv.json == payload
+        rv = self.client.get(
+            BASE_URL + "/trees/-/config",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert rv.status_code == 200
+        assert rv.json == payload
+
+    def test_put_config_replaces_entirely(self):
+        token = self._token("owner")
+        self.client.put(
+            BASE_URL + "/trees/-/config",
+            headers={"Authorization": f"Bearer {token}"},
+            json={"key1": "val1", "key2": "val2"},
+        )
+        rv = self.client.put(
+            BASE_URL + "/trees/-/config",
+            headers={"Authorization": f"Bearer {token}"},
+            json={"key2": "new"},
+        )
+        assert rv.status_code == 200
+        rv = self.client.get(
+            BASE_URL + "/trees/-/config",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert rv.json == {"key2": "new"}
+
+    def test_get_config_other_tree_forbidden_for_owner(self):
+        token = self._token("owner")
+        rv = self.client.get(
+            BASE_URL + "/trees/notexist/config",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert rv.status_code == 403
+
+    def test_get_config_nonexistent_tree_404_for_admin(self):
+        token = self._token("admin")
+        rv = self.client.get(
+            BASE_URL + "/trees/notexist/config",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert rv.status_code == 404
+
+    def test_put_config_nonexistent_tree_404_for_admin(self):
+        token = self._token("admin")
+        rv = self.client.put(
+            BASE_URL + "/trees/notexist/config",
+            headers={"Authorization": f"Bearer {token}"},
+            json={"key": "val"},
+        )
+        assert rv.status_code == 404
+
+
 class TestTreesSingleTreeRename(unittest.TestCase):
     """Test tree rename in single-tree mode using TREE_ID config."""
 


### PR DESCRIPTION
This pull request introduces a new per-tree configuration feature, allowing each tree to store and manage an arbitrary JSON configuration blob (such as feature flags or UI preferences). The implementation includes database schema changes, API endpoints for reading and updating the config, size validation, and backend logic for storing/retrieving the config.

The most important changes are:

**Database and Model Changes:**
* Added a new nullable JSON column `config` to the `trees` table via Alembic migration, and updated the `Tree` model to include this column. [[1]](diffhunk://#diff-e965b4caac0cd7070fd0a26d7873e722b77c4e713c8a69406d3e7e9c66782b77R1-R29) [[2]](diffhunk://#diff-cd561b43f4c66e7ca81e3106b4ab50f3b2bd14f0bcfe2d2f48cd8419bfcfc1f1R576)

**API Endpoints:**
* Introduced a new `TreeConfigResource` with GET and PUT endpoints at `/trees/<tree_id>/config` for retrieving and updating the per-tree configuration blob. [[1]](diffhunk://#diff-500210dd9dbafab902766bc955bf4fab2bec4e5cff470ae18a2ffb49a0600012R113) [[2]](diffhunk://#diff-500210dd9dbafab902766bc955bf4fab2bec4e5cff470ae18a2ffb49a0600012R320-R325) [[3]](diffhunk://#diff-002a4eb88efdde6fa9621a34e7f85be67a9f369c66d351081935e6820e021047R364-R411)

**Validation and Limits:**
* Enforced a maximum config payload size of 64 KB using the `TREE_CONFIG_MAX_BYTES` constant and schema validation. [[1]](diffhunk://#diff-45569bf9eb664a01f86ff36410f921ca69bb31e1abc803b54a850e18a4ecfc4cR34) [[2]](diffhunk://#diff-002a4eb88efdde6fa9621a34e7f85be67a9f369c66d351081935e6820e021047L53-R55) [[3]](diffhunk://#diff-002a4eb88efdde6fa9621a34e7f85be67a9f369c66d351081935e6820e021047R364-R411)

**Backend Logic:**
* Added `get_tree_config` and `set_tree_config` functions to handle retrieving and updating the config in the database, defaulting to an empty dict if not set. [[1]](diffhunk://#diff-002a4eb88efdde6fa9621a34e7f85be67a9f369c66d351081935e6820e021047R37-R41) [[2]](diffhunk://#diff-cd561b43f4c66e7ca81e3106b4ab50f3b2bd14f0bcfe2d2f48cd8419bfcfc1f1R472-R491)

**Schema Definitions:**
* Added a new `TreeConfigSchema` for API documentation and validation.