### PR TITLE
Security: JWT passed in URL query parameter during password reset

### DIFF
--- a/gramps_webapi/templates/reset_password.html
+++ b/gramps_webapi/templates/reset_password.html
@@ -21,10 +21,11 @@
     const pw = inputPw.value;
     const urlParams = new URLSearchParams(window.location.search);
     const jwt = urlParams.get('jwt');
-    fetch(`/api/users/-/password/reset/?jwt=${jwt}`, {
+    fetch(`/api/users/-/password/reset/`, {
       method: 'POST',
       headers: {
-        'Content-Type': 'application/json'
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${jwt}`
       },
       body: JSON.stringify({ new_password: pw })
     })


### PR DESCRIPTION
## Summary

Security: JWT passed in URL query parameter during password reset

## Problem

**Severity**: `High` | **File**: `gramps_webapi/templates/reset_password.html:L59`

In `gramps_webapi/templates/reset_password.html`, the JWT token is passed via URL query parameter (`?jwt=${jwt}`). This can leak via browser history, referrer headers, and server logs.

## Solution

Pass the JWT in the Authorization header instead of URL query parameter, or use a POST request with the token in the body.

## Changes

- `gramps_webapi/templates/reset_password.html` (modified)