### PR TITLE
Properly handle deletion of default person in all cases

### DIFF
--- a/gramps_webapi/api/resources/base.py
+++ b/gramps_webapi/api/resources/base.py
@@ -321,8 +321,6 @@ class GrampsObjectResource(GrampsObjectResourceHelper, Resource):
         )
         # update usage
         if self.gramps_class_name == "Person":
-            if handle == self.db_handle_writable.get_default_handle():
-                self.db_handle_writable.set_default_person_handle(None)
             update_usage_people()
         # update search index
         tree = get_tree_from_jwt_or_fail()

--- a/gramps_webapi/api/resources/base.py
+++ b/gramps_webapi/api/resources/base.py
@@ -321,6 +321,8 @@ class GrampsObjectResource(GrampsObjectResourceHelper, Resource):
         )
         # update usage
         if self.gramps_class_name == "Person":
+            if handle == self.db_handle_writable.get_default_handle():
+                self.db_handle_writable.set_default_person_handle(None)
             update_usage_people()
         # update search index
         tree = get_tree_from_jwt_or_fail()

--- a/gramps_webapi/api/resources/delete.py
+++ b/gramps_webapi/api/resources/delete.py
@@ -569,10 +569,13 @@ def delete_object(
         method = delete_methods[key]
     except KeyError:
         raise NotImplementedError(gramps_class_name)
-    if gramps_class_name == "Person" and handle == db_handle.get_default_handle():
-        db_handle.set_default_person_handle(None)
+    unset_default_person = (
+        gramps_class_name == "Person" and handle == db_handle.get_default_handle()
+    )
     with DbTxn(f"Delete {gramps_class_name}", db_handle) as trans:
         method(db_handle, handle, trans=trans)
+        if unset_default_person:
+            db_handle.set_default_person_handle(None)
         trans_dict = transaction_to_json(trans)
     return trans_dict
 
@@ -607,10 +610,13 @@ def delete_all_objects(
             # Materialize handles before opening the transaction to avoid cursor
             # conflicts with the deletions that follow.
             handles = list(iter_handles())
-            if class_name == "Person" and db_handle.get_default_handle() is not None:
-                db_handle.set_default_person_handle(None)
+            unset_default_person = (
+                class_name == "Person" and db_handle.get_default_handle() is not None
+            )
             remove = getattr(db_handle, f"remove_{class_name.lower()}")
             with DbTxn(f"Delete {class_name}", db_handle, batch=True) as trans:
+                if unset_default_person:
+                    db_handle.set_default_person_handle(None)
                 for handle in handles:
                     if progress_cb:
                         progress_cb(current=i, total=total)
@@ -618,9 +624,12 @@ def delete_all_objects(
                     remove(handle, trans)
         else:
             del_method = delete_methods[class_name.lower()]
-            if class_name == "Person" and db_handle.get_default_handle() is not None:
-                db_handle.set_default_person_handle(None)
+            unset_default_person = (
+                class_name == "Person" and db_handle.get_default_handle() is not None
+            )
             with DbTxn(f"Delete {namespaces}", db_handle) as trans:
+                if unset_default_person:
+                    db_handle.set_default_person_handle(None)
                 for handle in iter_handles():
                     if progress_cb:
                         progress_cb(current=i, total=total)

--- a/gramps_webapi/api/resources/delete.py
+++ b/gramps_webapi/api/resources/delete.py
@@ -416,7 +416,7 @@ def delete_source(db_handle: DbWriteBase, handle: str, trans: DbTxn) -> None:
     # Citation. Then we remove the Citations. (We don't need to
     # remove the source_handle references to the Source, because we are
     # removing the whole Citation). Then we can remove the Source
-    (citation_list, citation_referents_list) = get_source_and_citation_referents(
+    citation_list, citation_referents_list = get_source_and_citation_referents(
         handle, db_handle
     )
 
@@ -569,6 +569,8 @@ def delete_object(
         method = delete_methods[key]
     except KeyError:
         raise NotImplementedError(gramps_class_name)
+    if gramps_class_name == "Person" and handle == db_handle.get_default_handle():
+        db_handle.set_default_person_handle(None)
     with DbTxn(f"Delete {gramps_class_name}", db_handle) as trans:
         method(db_handle, handle, trans=trans)
         trans_dict = transaction_to_json(trans)
@@ -605,6 +607,8 @@ def delete_all_objects(
             # Materialize handles before opening the transaction to avoid cursor
             # conflicts with the deletions that follow.
             handles = list(iter_handles())
+            if class_name == "Person" and db_handle.get_default_handle() is not None:
+                db_handle.set_default_person_handle(None)
             remove = getattr(db_handle, f"remove_{class_name.lower()}")
             with DbTxn(f"Delete {class_name}", db_handle, batch=True) as trans:
                 for handle in handles:
@@ -614,6 +618,8 @@ def delete_all_objects(
                     remove(handle, trans)
         else:
             del_method = delete_methods[class_name.lower()]
+            if class_name == "Person" and db_handle.get_default_handle() is not None:
+                db_handle.set_default_person_handle(None)
             with DbTxn(f"Delete {namespaces}", db_handle) as trans:
                 for handle in iter_handles():
                     if progress_cb:

--- a/tests/test_endpoints/test_delete.py
+++ b/tests/test_endpoints/test_delete.py
@@ -227,6 +227,99 @@ class TestObjectDeletion(unittest.TestCase):
         self.assertEqual(len(rv.json), 0)
 
 
+class TestDefaultPersonDeletion(unittest.TestCase):
+    """Test that deleting the default/home person clears the default handle."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.name = "Test Default Person"
+        cls.dbman = CLIDbManager(DbState())
+        dirpath, _name = cls.dbman.create_new_db_cli(cls.name, dbid="sqlite")
+        cls.tree = os.path.basename(dirpath)
+        with patch.dict("os.environ", {ENV_CONFIG_FILE: TEST_AUTH_CONFIG}):
+            cls.app = create_app(config_from_env=False)
+        cls.app.config["TESTING"] = True
+        cls.client = cls.app.test_client()
+        with cls.app.app_context():
+            user_db.create_all()
+            add_user(name="owner_dp", password="123", role=ROLE_OWNER, tree=cls.tree)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.dbman.remove_database(cls.name)
+
+    def _headers(self):
+        return get_headers(self.client, "owner_dp", "123")
+
+    def _set_default_person(self, handle: str) -> None:
+        """Set the default person via the db directly."""
+        from gramps_webapi.dbmanager import WebDbManager
+
+        dbmgr = WebDbManager(name=self.name, create_if_missing=False)
+        dbstate = dbmgr.get_db(force_unlock=True)
+        dbstate.db.set_default_person_handle(handle)
+        dbstate.db.close()
+
+    def test_delete_default_person_via_endpoint(self):
+        """DELETE /api/people/<handle> on the default person clears default_person."""
+        headers = self._headers()
+        handle = make_handle()
+        rv = self.client.post(
+            "/api/people/",
+            json={"_class": "Person", "handle": handle},
+            headers=headers,
+        )
+        self.assertEqual(rv.status_code, 201)
+        self._set_default_person(handle)
+        # verify metadata shows it as default
+        rv = self.client.get("/api/metadata/", headers=headers)
+        self.assertEqual(rv.json["default_person"], handle)
+        # delete the default person
+        rv = self.client.delete(f"/api/people/{handle}", headers=headers)
+        self.assertEqual(rv.status_code, 200)
+        # default_person must now be null
+        rv = self.client.get("/api/metadata/", headers=headers)
+        self.assertIsNone(rv.json["default_person"])
+
+    def test_delete_all_people_clears_default_person(self):
+        """POST /api/objects/delete/?namespaces=people clears default_person."""
+        headers = self._headers()
+        handle = make_handle()
+        rv = self.client.post(
+            "/api/people/",
+            json={"_class": "Person", "handle": handle},
+            headers=headers,
+        )
+        self.assertEqual(rv.status_code, 201)
+        self._set_default_person(handle)
+        rv = self.client.get("/api/metadata/", headers=headers)
+        self.assertEqual(rv.json["default_person"], handle)
+        # delete all people
+        rv = self.client.post("/api/objects/delete/?namespaces=people", headers=headers)
+        self.assertEqual(rv.status_code, 200)
+        rv = self.client.get("/api/metadata/", headers=headers)
+        self.assertIsNone(rv.json["default_person"])
+
+    def test_delete_all_objects_clears_default_person(self):
+        """POST /api/objects/delete/ (all) clears default_person."""
+        headers = self._headers()
+        handle = make_handle()
+        rv = self.client.post(
+            "/api/people/",
+            json={"_class": "Person", "handle": handle},
+            headers=headers,
+        )
+        self.assertEqual(rv.status_code, 201)
+        self._set_default_person(handle)
+        rv = self.client.get("/api/metadata/", headers=headers)
+        self.assertEqual(rv.json["default_person"], handle)
+        # delete everything
+        rv = self.client.post("/api/objects/delete/", headers=headers)
+        self.assertEqual(rv.status_code, 200)
+        rv = self.client.get("/api/metadata/", headers=headers)
+        self.assertIsNone(rv.json["default_person"])
+
+
 class TestDeleteAllObjects(unittest.TestCase):
     @classmethod
     def setUpClass(cls):


### PR DESCRIPTION
This pull request updates the deletion logic for `Person` objects to ensure that the default person handle is properly unset when the default person is deleted, or when all `Person` objects are deleted. This prevents dangling references to non-existent default persons in the database. Additionally, there is a small code style fix in the variable assignment for citation referents.

**Handling of default person on deletion:**

* When deleting a `Person` by handle, if the handle matches the current default person, the default is unset by calling `set_default_person_handle(None)`. (`gramps_webapi/api/resources/base.py`, `gramps_webapi/api/resources/delete.py`) [[1]](diffhunk://#diff-56840781bd46323628e72402f3c77faff27e17132bd2ca104ec108fbf60306f6R324-R325) [[2]](diffhunk://#diff-52b967cf5d8cd99f2e35f12ef4dca9f3ac6c79e5dc8b1667fb8f94464fdee7ddR572-R573)
* When deleting all `Person` objects, the default person handle is also unset if it was set. (`gramps_webapi/api/resources/delete.py`) [[1]](diffhunk://#diff-52b967cf5d8cd99f2e35f12ef4dca9f3ac6c79e5dc8b1667fb8f94464fdee7ddR610-R611) [[2]](diffhunk://#diff-52b967cf5d8cd99f2e35f12ef4dca9f3ac6c79e5dc8b1667fb8f94464fdee7ddR621-R622)

**Code style improvements:**

* Simplified tuple unpacking in the `delete_source` function for clarity. (`gramps_webapi/api/resources/delete.py`)