### PR TITLE
chore (security): Docker non-root hardening, Dependabot groups & CI baselines

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -132,3 +132,12 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# Development files
+.specify/
+CLAUDE.md
+tests/
+tasks.md
+hardening-plan.md
+security-hardening.spec.md
+

--- a/.dockerignore
+++ b/.dockerignore
@@ -137,7 +137,3 @@ dmypy.json
 .specify/
 CLAUDE.md
 tests/
-tasks.md
-hardening-plan.md
-security-hardening.spec.md
-

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,38 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+      - "python"
+    open-pull-requests-limit: 10
+    groups:
+      dev-dependencies:
+        patterns:
+          - "pytest*"
+          - "black"
+          - "flake8"
+          - "mypy"
+          - "pylint"
+          - "pre-commit"
+      flask-stack:
+        patterns:
+          - "Flask*"
+      minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    labels:
+      - "dependencies"
+      - "github-actions"
+    groups:
+      action-updates:
+        patterns:
+          - "*"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,41 @@
+name: "CodeQL Analysis"
+
+on:
+  push:
+    branches: [ "master", "main" ]
+  pull_request:
+    branches: [ "master", "main" ]
+  schedule:
+    - cron: '30 2 * * 1' # Runs at 02:30 UTC every Monday
+
+jobs:
+  analyze:
+    name: Code Scanning
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [ 'python' ]
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v3
+      with:
+        languages: ${{ matrix.language }}
+        # If you wish to specify custom queries, you can do so here or in a config file.
+        # By default, queries listed here will override any specified in a config file.
+        # Prefix the list here with "+" to use these queries and those in the config file.
+        # queries: ./path/to/local/query, your-org/your-repo/queries@main
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v3
+      with:
+        category: "/language:${{matrix.language}}"

--- a/.gitignore
+++ b/.gitignore
@@ -148,3 +148,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# Spec-Kit related files
+.specify

--- a/Dockerfile.slim
+++ b/Dockerfile.slim
@@ -1,9 +1,43 @@
-FROM ghcr.io/gramps-project/gramps-web-base:latest
+FROM python:3.11-slim as builder
 
-ENV GRAMPS_API_CONFIG=/app/config/config.cfg
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    gcc \
+    libpq-dev \
+    python3-dev \
+    pkg-config \
+    libcairo2-dev \
+    libgirepository1.0-dev \
+    gir1.2-glib-2.0 \
+    libicu-dev \
+    git \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN python -m venv /opt/venv
+ENV PATH="/opt/venv/bin:$PATH"
+
+COPY . /app/src
+# Install gunicorn and CPU-only PyTorch to save significant space
+RUN pip install --no-cache-dir torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cpu \
+    && pip install --no-cache-dir /app/src[ai] gunicorn
+
+FROM python:3.11-slim
+
+# Install runtime system dependencies for PyGObject and Gramps
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libcairo2 \
+    libgirepository-1.0-1 \
+    gir1.2-glib-2.0 \
+    gir1.2-pango-1.0 \
+    gir1.2-gtk-3.0 \
+    libicu76 \
+    libpq5 \
+    && rm -rf /var/lib/apt/lists/*
 
 # Create unprivileged user (UID/GID 1000)
 RUN groupadd -g 1000 gramps && useradd -u 1000 -g gramps -m -s /bin/bash gramps
+
+ENV GRAMPS_API_CONFIG=/app/config/config.cfg
 
 # create directories
 RUN mkdir -p /app/src /app/config /app/static /app/db /app/media /app/indexdir /app/users \
@@ -11,6 +45,10 @@ RUN mkdir -p /app/src /app/config /app/static /app/db /app/media /app/indexdir /
     /app/cache/persistent_cache /app/tmp /app/persist \
     && touch /app/config/config.cfg /app/static/index.html \
     && chown -R 1000:1000 /app
+
+# Copy virtual env from builder
+COPY --from=builder --chown=1000:1000 /opt/venv /opt/venv
+ENV PATH="/opt/venv/bin:$PATH"
 
 ENV GRAMPSWEB_USER_DB_URI=sqlite:////app/users/users.sqlite
 ENV GRAMPSWEB_MEDIA_BASE_DIR=/app/media
@@ -27,13 +65,11 @@ ENV GRAMPS_DATABASE_PATH=${GRAMPSHOME}/.gramps/grampsdb
 # Create remaining dir
 RUN mkdir -p ${GRAMPSHOME}/.gramps/grampsdb && chown -R 1000:1000 ${GRAMPSHOME}
 
-# copy package source and install
+# copy package source and entrypoint
 COPY --chown=1000:1000 . /app/src
-RUN pip install --no-cache-dir /app/src[ai]
+COPY --chown=1000:1000 docker-entrypoint.sh /
 
 EXPOSE 5000
-
-COPY --chown=1000:1000 docker-entrypoint.sh /
 
 USER gramps
 

--- a/README.md
+++ b/README.md
@@ -15,3 +15,10 @@ Gramps Web API is the backend of [Gramps Web](https://www.grampsweb.org/), a gen
 ## Related projects
 
 - Gramps Web frontend repository: https://github.com/gramps-project/gramps-web
+
+## Security & Docker Migration
+Following a security hardening process, the Gramps Web API container now runs as an unprivileged non-root user (`gramps`, UID 1000).
+If you are upgrading an existing installation using Docker Compose and have mounted host directories, you must change their ownership before starting the new container to avert permission errors:
+```bash
+sudo chown -R 1000:1000 /path/to/your/mounted/volumes
+```

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,15 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported |
+| ------- | --------- |
+| Latest  | ✅        |
+| Older   | ❌        |
+
+## Reporting a Vulnerability
+
+Do **not** open public issues for security vulnerabilities.
+
+1. **Preferred:** Use the **Security** tab on this repository and select **Report a vulnerability**.
+2. **Alternative:** Email `straub@protonmail.com`.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,41 @@
+version: "3.8"
+
+services:
+  grampsweb:
+    build: .
+    image: grampsweb:latest
+    ports:
+      - "5000:5000"
+    environment:
+      GRAMPSWEB_CELERY_CONFIG__broker_url: redis://redis:6379/0
+      GRAMPSWEB_CELERY_CONFIG__result_backend: redis://redis:6379/0
+      GRAMPSWEB_RATELIMIT_STORAGE_URI: redis://redis:6379/1
+      GRAMPSWEB_TREE: "my_tree"
+    depends_on:
+      - redis
+    volumes:
+      - gramps_db:/home/gramps/.gramps/grampsdb
+      - gramps_media:/app/media
+      - gramps_users:/app/users
+      - gramps_index:/app/indexdir
+      - gramps_cache:/app/cache
+      - gramps_persist:/app/persist
+      - gramps_tmp:/app/tmp
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
+
+  redis:
+    image: redis:alpine
+    ports:
+      - "6379:6379"
+
+volumes:
+  gramps_db:
+  gramps_media:
+  gramps_users:
+  gramps_index:
+  gramps_cache:
+  gramps_persist:
+  gramps_tmp:


### PR DESCRIPTION
## Motivation
Currently, the Docker container runs as `root`. To follow minimum security best practices and mitigate the impact of potential container escapes or Remote Code Execution (RCE) vulnerabilities, the application must run as a restricted, unprivileged user. 
Furthermore, this PR introduces automated CI/CD security checks (CodeQL & Dependabot) to establish a modern security baseline for the repository.

## Core Changes (BREAKING)
* **Docker Hardening:** The container now runs as a dedicated non-root user (`gramps`, UID/GID 1000). Added `no-new-privileges:true` and `cap_drop: [ALL]` to the sample `docker-compose.yml`. -> UID can be changed if necessary.
* **`docker-compose.yml`**: Updated the example configuration to reflect the new internal volume paths (`/home/gramps/...`). Applied strict security boundaries (`no-new-privileges:true`, `cap_drop: [ALL]`) and added required environment variables (e.g., `GRAMPSWEB_TREE`).
* **Dependabot:** Configured weekly/monthly scans. Added groups (`dev-dependencies`, ...) to prevent PR spam.
* **CodeQL (SAST):** Added GitHub's CodeQL workflow to catch potential Python vulnerabilities on CI/CD.
* **Vulnerability Reporting:** Added a standard `SECURITY.md`.

## Discussion & Review

**1. Vulnerability Disclosure (SECURITY.md)**
The current policy is a bare-minimum standard. To improve it, we should consider adding:

* A **PGP Key** for the security contact to ensure encrypted communication for researchers.
* A **Disclosure SLA/Timeline** (e.g., *"We aim to respond to reports within 48 hours and release patches within 30 days"*).

**2. Image Size vs. Maintainability (`Dockerfile.slim`)**
The current official base image results in a ~ 4.5GB payload (mostly due to heavy AI/CUDA and GTK dependencies). 
During development, I built a `Dockerfile.slim` PoC (included for review) that reduces the footprint to **~1.5GB** by utilizing `python:3.11-slim` and forcing CPU-only ML libraries.
However, manually maintaining the `PyGObject` / `cairo` C-headers introduced too much complexity. Therefore, the main `Dockerfile` in this PR still relies on `ghcr.io/gramps-project/gramps-web-base:latest` for stability. Let me know your thoughts on reducing the image size.

**3. `docker-compose.yml` location**
How the new compose file would be shared with users

## Upgrade Instructions for Existing Users
Because the container no longer runs as `root`, existing host directories mounted as volumes will throw `Permission Denied` errors. Users upgrading to this image **must** change the ownership of their local data directories to match the new `gramps` user (UID 1000):

```bash
# Update ownership of mounted volumes to UID:GID 1000
sudo chown -R 1000:1000 /path/to/your/gramps/volumes