### PR TITLE
Make MAX_THUMBNAIL_FILE_BYTES configurable

### DIFF
--- a/gramps_webapi/api/file.py
+++ b/gramps_webapi/api/file.py
@@ -92,7 +92,8 @@ class FileHandler:
 
     def _abort_if_too_large(self) -> None:
         """Abort with 413 if the file exceeds the thumbnail size limit."""
-        if self.get_file_size() > current_app.config.get("MAX_THUMBNAIL_FILE_BYTES"):
+        max_bytes = int(current_app.config.get("MAX_THUMBNAIL_FILE_BYTES", 0))
+        if self.get_file_size() > max_bytes:
             abort_with_message(413, "File too large for thumbnailing")
 
     def get_face_regions(self, etag: Optional[str] = None):

--- a/gramps_webapi/api/file.py
+++ b/gramps_webapi/api/file.py
@@ -92,7 +92,8 @@ class FileHandler:
 
     def _abort_if_too_large(self) -> None:
         """Abort with 413 if the file exceeds the thumbnail size limit."""
-        max_bytes = int(current_app.config.get("MAX_THUMBNAIL_FILE_BYTES", 0))
+        max_bytes = current_app.config.get("MAX_THUMBNAIL_FILE_BYTES")
+        assert max_bytes is not None  # for type checker
         if self.get_file_size() > max_bytes:
             abort_with_message(413, "File too large for thumbnailing")
 

--- a/gramps_webapi/api/file.py
+++ b/gramps_webapi/api/file.py
@@ -26,14 +26,14 @@ from pathlib import Path
 from typing import Any, BinaryIO, Optional, Tuple, Union
 
 import pytesseract
-from flask import jsonify, make_response, send_file, send_from_directory
+from flask import jsonify, make_response, send_file, send_from_directory, current_app
 from gramps.gen.db.base import DbReadBase
 from gramps.gen.errors import HandleError
 from gramps.gen.lib import Media
 from PIL import Image
 from werkzeug.datastructures import FileStorage
 
-from gramps_webapi.const import MIME_AVIF, MAX_THUMBNAIL_FILE_BYTES
+from gramps_webapi.const import MIME_AVIF
 
 from ..types import FilenameOrPath
 from .image import LocalFileThumbnailHandler, detect_faces
@@ -92,7 +92,7 @@ class FileHandler:
 
     def _abort_if_too_large(self) -> None:
         """Abort with 413 if the file exceeds the thumbnail size limit."""
-        if self.get_file_size() > MAX_THUMBNAIL_FILE_BYTES:
+        if self.get_file_size() > current_app.config.get("MAX_THUMBNAIL_FILE_BYTES"):
             abort_with_message(413, "File too large for thumbnailing")
 
     def get_face_regions(self, etag: Optional[str] = None):

--- a/gramps_webapi/config.py
+++ b/gramps_webapi/config.py
@@ -107,6 +107,7 @@ class DefaultConfig(object):
     OIDC_USERNAME_CLAIM = "preferred_username"
     OIDC_NAME = "OIDC"
     PILLOW_MAX_IMAGE_PIXELS = MAX_IMAGE_PIXELS
+    MAX_THUMBNAIL_FILE_BYTES = 50 * 1024 * 1024  # 50 MB
 
 
 class DefaultConfigJWT(object):

--- a/gramps_webapi/const.py
+++ b/gramps_webapi/const.py
@@ -32,7 +32,6 @@ from ._version import __version__ as VERSION
 # the value of the TREE config option that enables multi-tree support
 TREE_MULTI = "*"
 TREE_CONFIG_MAX_BYTES = 64 * 1024  # 64 KB
-MAX_THUMBNAIL_FILE_BYTES = 50 * 1024 * 1024  # 50 MB
 
 # Helper function to get resource file paths with managed cleanup
 _file_manager = ExitStack()

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -57,12 +57,12 @@ def test_pdf_thumbnail_returns_first_page_only():
     # Center pixel should match the first page's color, not the second's.
     # Allow ±2 tolerance for PDF/rasterization rounding.
     center = img.getpixel((img.width // 2, img.height // 2))[:3]
-    assert all(abs(a - b) <= 2 for a, b in zip(center, RED)), (
-        f"Expected first-page color {RED}, got {center}"
-    )
-    assert not all(abs(a - b) <= 2 for a, b in zip(center, BLUE)), (
-        "Got second-page color — first_page/last_page limit not working"
-    )
+    assert all(
+        abs(a - b) <= 2 for a, b in zip(center, RED)
+    ), f"Expected first-page color {RED}, got {center}"
+    assert not all(
+        abs(a - b) <= 2 for a, b in zip(center, BLUE)
+    ), "Got second-page color — first_page/last_page limit not working"
 
 
 def test_pdf_render_size_capped():
@@ -77,15 +77,29 @@ def test_abort_if_too_large_returns_413():
     """_abort_if_too_large must raise HTTPException with code 413 when over the limit."""
     from werkzeug.exceptions import HTTPException
     from gramps_webapi.api.file import FileHandler
-    from gramps_webapi.const import MAX_THUMBNAIL_FILE_BYTES
+    from gramps_webapi.config import DefaultConfig
 
     class _BigFileHandler(FileHandler):
         def get_file_size(self):
-            return MAX_THUMBNAIL_FILE_BYTES + 1
+            return DefaultConfig.MAX_THUMBNAIL_FILE_BYTES + 1
+
+    opts = {
+        "TREE": "test",
+        "SECRET_KEY": "test",
+        "USER_DB_URI": "sqlite:///:memory:",
+        "MAX_THUMBNAIL_FILE_BYTES": DefaultConfig.MAX_THUMBNAIL_FILE_BYTES,
+    }
+    app = (
+        create_app(  # create app for test setup of parameter PIL.Image.MAX_IMAGE_PIXELS
+            config=opts,
+            config_from_env=False,
+        )
+    )
 
     handler = object.__new__(_BigFileHandler)
-    with pytest.raises(HTTPException) as exc_info:
-        handler._abort_if_too_large()
+    with app.app_context():
+        with pytest.raises(HTTPException) as exc_info:
+            handler._abort_if_too_large()
     assert exc_info.value.code == 413
 
 
@@ -95,6 +109,7 @@ def setup_and_teardown():
     # save PIL.Image.MAX_IMAGE_PIXELS and ENV_CONFIG_FILE before tests
     saved_max_image_pixels = Image.MAX_IMAGE_PIXELS
     from gramps_webapi.const import ENV_CONFIG_FILE
+
     # set it to None to prevent the config from loading
     old = os.environ.pop(ENV_CONFIG_FILE, None)
 
@@ -117,7 +132,7 @@ def test_file_max_pillow_image_pixels_greater_or_equal():
         "USER_DB_URI": "sqlite:///:memory:",
         "PILLOW_MAX_IMAGE_PIXELS": 500 * 500,
     }
-    create_app( # create app for test setup of parameter PIL.Image.MAX_IMAGE_PIXELS
+    create_app(  # create app for test setup of parameter PIL.Image.MAX_IMAGE_PIXELS
         config=opts,
         config_from_env=False,
     )
@@ -134,7 +149,7 @@ def test_file_max_pillow_image_pixels_lower():
         "TREE": "test",
         "SECRET_KEY": "test",
         "USER_DB_URI": "sqlite:///:memory:",
-        "PILLOW_MAX_IMAGE_PIXELS": width*height//2-1,
+        "PILLOW_MAX_IMAGE_PIXELS": width * height // 2 - 1,
         # set width*height-1=10*10-1=49 cause PIL throw warning if
         # width*height < PILLOW_MAX_IMAGE_PIXELS and
         # width*height/2 > PILLOW_MAX_IMAGE_PIXELS;
@@ -146,6 +161,7 @@ def test_file_max_pillow_image_pixels_lower():
     )
     with pytest.raises(DecompressionBombError):
         fh.get_image()
+
 
 # Tests negative and None values of PILLOW_MAX_IMAGE_PIXELS
 def test_file_max_pillow_image_pixels_incorrect():


### PR DESCRIPTION
Expose `MAX_THUMBNAIL_FILE_BYTES`as a configurable app setting as propsed [here](https://github.com/gramps-project/gramps-web/issues/1186#issuecomment-4529159837).

If this is accepted, I would add a corresponding update to the Gramps Web documentation.
