### PR TITLE
tasks: split reindex tasks by type; add user_name to task endpoints; …

### DIFF
--- a/gramps_webapi/api/resources/search.py
+++ b/gramps_webapi/api/resources/search.py
@@ -48,7 +48,9 @@ from ..tasks import (
     make_task_response,
     run_task,
     search_reindex_full,
+    search_reindex_full_semantic,
     search_reindex_incremental,
+    search_reindex_incremental_semantic,
 )
 from ..util import (
     get_db_handle,
@@ -291,12 +293,18 @@ class SearchIndexResource(ProtectedResource):
         tree = get_tree_from_jwt_or_fail()
         user_id = get_jwt_identity()
         if args["full"]:
-            task_func = search_reindex_full
+            task_func = (
+                search_reindex_full_semantic
+                if args["semantic"]
+                else search_reindex_full
+            )
         else:
-            task_func = search_reindex_incremental
-        task = run_task(
-            task_func, tree=tree, user_id=user_id, semantic=args["semantic"]
-        )
+            task_func = (
+                search_reindex_incremental_semantic
+                if args["semantic"]
+                else search_reindex_incremental
+            )
+        task = run_task(task_func, tree=tree, user_id=user_id)
         if isinstance(task, AsyncResult):
             return make_task_response(task)
         return Response(status=201)

--- a/gramps_webapi/api/resources/tasks.py
+++ b/gramps_webapi/api/resources/tasks.py
@@ -19,10 +19,8 @@
 
 """Background task resources."""
 
-from datetime import datetime, timedelta, timezone
 from http import HTTPStatus
 
-from celery import current_app as current_celery_app
 from celery.result import AsyncResult
 from flask import abort
 from flask_jwt_extended import get_jwt_identity
@@ -34,6 +32,7 @@ from ...auth import TaskTree, User, user_db
 from ...auth.const import PERM_VIEW_OTHER_USER
 from ..auth import has_permissions
 from ..blueprint import api_blueprint
+from ..tasks import get_task_result_cutoff
 from ..util import get_tree_from_jwt_or_fail
 from . import ProtectedResource
 
@@ -188,12 +187,7 @@ class TaskListResource(ProtectedResource):
         ViewOtherUser permission (Owner+) can see all tasks for the tree.
         """
         tree = get_tree_from_jwt_or_fail()
-        ttl = getattr(current_celery_app.conf, "result_expires", None)
-        if ttl is None:
-            ttl = timedelta(seconds=86400)
-        elif not isinstance(ttl, timedelta):
-            ttl = timedelta(seconds=int(ttl))
-        cutoff = datetime.now(timezone.utc).replace(tzinfo=None) - ttl
+        cutoff = get_task_result_cutoff()
         query = user_db.session.query(TaskTree).filter(
             TaskTree.tree == tree,
             TaskTree.created_at >= cutoff,

--- a/gramps_webapi/api/resources/tasks.py
+++ b/gramps_webapi/api/resources/tasks.py
@@ -28,7 +28,7 @@ from gramps.gen.lib.json_utils import object_to_string
 from marshmallow import Schema
 from webargs import fields
 
-from ...auth import TaskTree, get_name, user_db
+from ...auth import TaskTree, User, user_db
 from ...auth.const import PERM_VIEW_OTHER_USER
 from ..auth import has_permissions
 from ..blueprint import api_blueprint
@@ -166,9 +166,10 @@ class TaskResource(ProtectedResource):
             result["name"] = row.name
             result["created_at"] = row.created_at
             result["user_id"] = row.user_id
-            try:
-                result["user_name"] = get_name(row.user_id) if row.user_id else None
-            except ValueError:
+            if row.user_id:
+                user_row = user_db.session.get(User, row.user_id)
+                result["user_name"] = user_row.name if user_row else None
+            else:
                 result["user_name"] = None
         return result
 
@@ -190,13 +191,16 @@ class TaskListResource(ProtectedResource):
             query = query.filter(TaskTree.user_id == get_jwt_identity())
         rows = query.order_by(TaskTree.created_at.desc()).limit(args["limit"]).all()
 
-        def _user_name(user_id):
-            if not user_id:
-                return None
-            try:
-                return get_name(user_id)
-            except ValueError:
-                return None
+        # Batch-resolve user names: one query for all distinct user IDs.
+        distinct_ids = {row.user_id for row in rows if row.user_id}
+        user_name_map: dict = {}
+        if distinct_ids:
+            user_rows = (
+                user_db.session.query(User.id, User.name)
+                .filter(User.id.in_(distinct_ids))
+                .all()
+            )
+            user_name_map = {str(r.id): r.name for r in user_rows}
 
         return [
             {
@@ -204,7 +208,7 @@ class TaskListResource(ProtectedResource):
                 "name": row.name,
                 "created_at": row.created_at,
                 "user_id": row.user_id,
-                "user_name": _user_name(row.user_id),
+                "user_name": user_name_map.get(row.user_id) if row.user_id else None,
                 "state": (
                     (AsyncResult(row.task_id).state or "PENDING")
                     if args["include_state"]

--- a/gramps_webapi/api/resources/tasks.py
+++ b/gramps_webapi/api/resources/tasks.py
@@ -19,8 +19,10 @@
 
 """Background task resources."""
 
+from datetime import datetime, timedelta, timezone
 from http import HTTPStatus
 
+from celery import current_app as current_celery_app
 from celery.result import AsyncResult
 from flask import abort
 from flask_jwt_extended import get_jwt_identity
@@ -186,7 +188,16 @@ class TaskListResource(ProtectedResource):
         ViewOtherUser permission (Owner+) can see all tasks for the tree.
         """
         tree = get_tree_from_jwt_or_fail()
-        query = user_db.session.query(TaskTree).filter(TaskTree.tree == tree)
+        ttl = getattr(current_celery_app.conf, "result_expires", None)
+        if ttl is None:
+            ttl = timedelta(seconds=86400)
+        elif not isinstance(ttl, timedelta):
+            ttl = timedelta(seconds=int(ttl))
+        cutoff = datetime.now(timezone.utc).replace(tzinfo=None) - ttl
+        query = user_db.session.query(TaskTree).filter(
+            TaskTree.tree == tree,
+            TaskTree.created_at >= cutoff,
+        )
         if not has_permissions([PERM_VIEW_OTHER_USER]):
             query = query.filter(TaskTree.user_id == get_jwt_identity())
         rows = query.order_by(TaskTree.created_at.desc()).limit(args["limit"]).all()

--- a/gramps_webapi/api/resources/tasks.py
+++ b/gramps_webapi/api/resources/tasks.py
@@ -28,7 +28,7 @@ from gramps.gen.lib.json_utils import object_to_string
 from marshmallow import Schema
 from webargs import fields
 
-from ...auth import TaskTree, user_db
+from ...auth import TaskTree, get_name, user_db
 from ...auth.const import PERM_VIEW_OTHER_USER
 from ..auth import has_permissions
 from ..blueprint import api_blueprint
@@ -71,6 +71,10 @@ class TaskStatusSchema(Schema):
         dump_default=None,
         metadata={"description": "UUID of the user who dispatched the task."},
     )
+    user_name = fields.Str(
+        dump_default=None,
+        metadata={"description": "Username of the user who dispatched the task."},
+    )
 
 
 class TaskListItemSchema(Schema):
@@ -88,6 +92,10 @@ class TaskListItemSchema(Schema):
     user_id = fields.Str(
         dump_default=None,
         metadata={"description": "UUID of the user who dispatched the task."},
+    )
+    user_name = fields.Str(
+        dump_default=None,
+        metadata={"description": "Username of the user who dispatched the task."},
     )
     state = fields.Str(
         dump_default=None,
@@ -158,6 +166,10 @@ class TaskResource(ProtectedResource):
             result["name"] = row.name
             result["created_at"] = row.created_at
             result["user_id"] = row.user_id
+            try:
+                result["user_name"] = get_name(row.user_id) if row.user_id else None
+            except ValueError:
+                result["user_name"] = None
         return result
 
 
@@ -176,18 +188,28 @@ class TaskListResource(ProtectedResource):
         query = user_db.session.query(TaskTree).filter(TaskTree.tree == tree)
         if not has_permissions([PERM_VIEW_OTHER_USER]):
             query = query.filter(TaskTree.user_id == get_jwt_identity())
-        rows = (
-            query.order_by(TaskTree.created_at.desc()).limit(args["limit"]).all()
-        )
+        rows = query.order_by(TaskTree.created_at.desc()).limit(args["limit"]).all()
+
+        def _user_name(user_id):
+            if not user_id:
+                return None
+            try:
+                return get_name(user_id)
+            except ValueError:
+                return None
+
         return [
             {
                 "task_id": row.task_id,
                 "name": row.name,
                 "created_at": row.created_at,
                 "user_id": row.user_id,
-                "state": (AsyncResult(row.task_id).state or "PENDING")
-                if args["include_state"]
-                else None,
+                "user_name": _user_name(row.user_id),
+                "state": (
+                    (AsyncResult(row.task_id).state or "PENDING")
+                    if args["include_state"]
+                    else None
+                ),
             }
             for row in rows
         ]

--- a/gramps_webapi/api/resources/user.py
+++ b/gramps_webapi/api/resources/user.py
@@ -118,31 +118,45 @@ class UserChangeBase(ProtectedResource):
         return user_name, other_tree
 
 
+class UsersListArgsSchema(Schema):
+    """Query args for GET /users/."""
+
+    user_id = fields.Str(
+        load_default=None,
+        metadata={"description": "Filter to a single user by their UUID."},
+    )
+
+
 class UsersResource(ProtectedResource):
     """Resource for all users."""
 
     @api_blueprint.response(200, Schema(many=True))
-    def get(self):
+    @api_blueprint.arguments(UsersListArgsSchema, location="query")
+    def get(self, args):
         """Get users' details."""
         # Always include OIDC account information if OIDC is enabled
         include_oidc = is_oidc_enabled()
 
         if has_permissions([PERM_VIEW_OTHER_TREE_USER]):
             # return all users from all trees
-            return (
-                jsonify(
-                    get_all_user_details(tree=None, include_oidc_accounts=include_oidc)
-                ),
-                200,
+            details = get_all_user_details(tree=None, include_oidc_accounts=include_oidc)
+        else:
+            require_permissions([PERM_VIEW_OTHER_USER])
+            tree = get_tree_from_jwt()
+            # return only this tree's users
+            # only include treeless users in single-tree setup
+            is_single = current_app.config["TREE"] != TREE_MULTI
+            details = get_all_user_details(
+                tree=tree, include_treeless=is_single, include_oidc_accounts=include_oidc
             )
-        require_permissions([PERM_VIEW_OTHER_USER])
-        tree = get_tree_from_jwt()
-        # return only this tree's users
-        # only include treeless users in single-tree setup
-        is_single = current_app.config["TREE"] != TREE_MULTI
-        details = get_all_user_details(
-            tree=tree, include_treeless=is_single, include_oidc_accounts=include_oidc
-        )
+
+        if args["user_id"] is not None:
+            try:
+                user_name = get_name(args["user_id"])
+                details = [d for d in details if d.get("name") == user_name]
+            except ValueError:
+                details = []
+
         return (
             jsonify(details),
             200,

--- a/gramps_webapi/api/resources/user.py
+++ b/gramps_webapi/api/resources/user.py
@@ -30,6 +30,7 @@ from marshmallow import Schema
 from webargs import fields
 
 from ...auth import (
+    User,
     add_user,
     add_users,
     authorized,
@@ -42,6 +43,7 @@ from ...auth import (
     get_user_details,
     get_user_oidc_accounts,
     modify_user,
+    user_db,
 )
 from ...auth.oidc_helpers import is_oidc_enabled
 from ...auth.const import (
@@ -139,7 +141,9 @@ class UsersResource(ProtectedResource):
 
         if has_permissions([PERM_VIEW_OTHER_TREE_USER]):
             # return all users from all trees
-            details = get_all_user_details(tree=None, include_oidc_accounts=include_oidc)
+            details = get_all_user_details(
+                tree=None, include_oidc_accounts=include_oidc
+            )
         else:
             require_permissions([PERM_VIEW_OTHER_USER])
             tree = get_tree_from_jwt()
@@ -147,15 +151,19 @@ class UsersResource(ProtectedResource):
             # only include treeless users in single-tree setup
             is_single = current_app.config["TREE"] != TREE_MULTI
             details = get_all_user_details(
-                tree=tree, include_treeless=is_single, include_oidc_accounts=include_oidc
+                tree=tree,
+                include_treeless=is_single,
+                include_oidc_accounts=include_oidc,
             )
 
         if args["user_id"] is not None:
-            try:
-                user_name = get_name(args["user_id"])
-                details = [d for d in details if d.get("name") == user_name]
-            except ValueError:
+            # Filter in Python against the already permission-scoped list so
+            # tree/permission boundaries are always respected.
+            target = user_db.session.get(User, args["user_id"])
+            if target is None:
                 details = []
+            else:
+                details = [d for d in details if d.get("name") == target.name]
 
         return (
             jsonify(details),

--- a/gramps_webapi/api/resources/user.py
+++ b/gramps_webapi/api/resources/user.py
@@ -123,7 +123,7 @@ class UserChangeBase(ProtectedResource):
 class UsersListArgsSchema(Schema):
     """Query args for GET /users/."""
 
-    user_id = fields.Str(
+    user_id = fields.UUID(
         load_default=None,
         metadata={"description": "Filter to a single user by their UUID."},
     )

--- a/gramps_webapi/api/tasks.py
+++ b/gramps_webapi/api/tasks.py
@@ -89,8 +89,8 @@ def _record_task(task_id: str, task: Task, kwargs: dict) -> None:
     user_db.session.commit()
 
 
-def _purge_expired_task_rows() -> None:
-    """Delete task_tree rows older than the Celery result TTL."""
+def get_task_result_cutoff() -> datetime:
+    """Return the earliest ``created_at`` that is still within the Celery result TTL."""
     from celery import current_app as celery_app
 
     ttl = getattr(celery_app.conf, "result_expires", None)
@@ -98,7 +98,12 @@ def _purge_expired_task_rows() -> None:
         ttl = timedelta(seconds=86400)
     elif not isinstance(ttl, timedelta):
         ttl = timedelta(seconds=int(ttl))
-    cutoff = datetime.now(timezone.utc).replace(tzinfo=None) - ttl
+    return datetime.now(timezone.utc).replace(tzinfo=None) - ttl
+
+
+def _purge_expired_task_rows() -> None:
+    """Delete task_tree rows older than the Celery result TTL."""
+    cutoff = get_task_result_cutoff()
     user_db.session.query(TaskTree).filter(TaskTree.created_at < cutoff).delete(
         synchronize_session=False
     )

--- a/gramps_webapi/api/tasks.py
+++ b/gramps_webapi/api/tasks.py
@@ -238,7 +238,7 @@ def set_progress_title(self, title: str = "", message: str = "") -> None:
 
 @shared_task(bind=True)
 def search_reindex_full(self, tree: str, user_id: str, semantic: bool = False) -> None:
-    """Rebuild the full-text search index.
+    """Rebuild the full-text search index (or the semantic index if ``semantic=True``).
 
     The ``semantic`` parameter is accepted for backward compatibility with
     jobs that were enqueued before this task was split into separate
@@ -289,7 +289,7 @@ def _search_reindex_incremental(
 def search_reindex_incremental(
     self, tree: str, user_id: str, semantic: bool = False
 ) -> None:
-    """Run an incremental reindex of the full-text search index.
+    """Run an incremental reindex of the full-text search index (or the semantic index if ``semantic=True``).
 
     The ``semantic`` parameter is accepted for backward compatibility with
     jobs that were enqueued before this task was split into separate

--- a/gramps_webapi/api/tasks.py
+++ b/gramps_webapi/api/tasks.py
@@ -237,13 +237,26 @@ def set_progress_title(self, title: str = "", message: str = "") -> None:
 
 
 @shared_task(bind=True)
-def search_reindex_full(self, tree: str, user_id: str, semantic: bool) -> None:
-    """Rebuild the search index."""
+def search_reindex_full(self, tree: str, user_id: str) -> None:
+    """Rebuild the full-text search index."""
     return _search_reindex_full(
         tree=tree,
         user_id=user_id,
-        semantic=semantic,
+        semantic=False,
         progress_cb=progress_callback_count(self, title="Updating search index..."),
+    )
+
+
+@shared_task(bind=True)
+def search_reindex_full_semantic(self, tree: str, user_id: str) -> None:
+    """Rebuild the semantic search index."""
+    return _search_reindex_full(
+        tree=tree,
+        user_id=user_id,
+        semantic=True,
+        progress_cb=progress_callback_count(
+            self, title="Updating semantic search index..."
+        ),
     )
 
 
@@ -267,13 +280,26 @@ def _search_reindex_incremental(
 
 
 @shared_task(bind=True)
-def search_reindex_incremental(self, tree: str, user_id: str, semantic: bool) -> None:
-    """Run an incremental reindex of the search index."""
+def search_reindex_incremental(self, tree: str, user_id: str) -> None:
+    """Run an incremental reindex of the full-text search index."""
     return _search_reindex_incremental(
         tree=tree,
         user_id=user_id,
-        semantic=semantic,
+        semantic=False,
         progress_cb=progress_callback_count(self, title="Updating search index..."),
+    )
+
+
+@shared_task(bind=True)
+def search_reindex_incremental_semantic(self, tree: str, user_id: str) -> None:
+    """Run an incremental reindex of the semantic search index."""
+    return _search_reindex_incremental(
+        tree=tree,
+        user_id=user_id,
+        semantic=True,
+        progress_cb=progress_callback_count(
+            self, title="Updating semantic search index..."
+        ),
     )
 
 
@@ -475,7 +501,6 @@ def upgrade_database_schema(self, tree: str, user_id: str):
         close_db(db_handle)
 
 
-
 @shared_task(bind=True)
 def delete_objects(
     self, tree: str, user_id: str, namespaces: Optional[List[str]] = None
@@ -515,7 +540,12 @@ def delete_objects(
 
 @shared_task(bind=True)
 def process_transactions(
-    self, tree: str, user_id: str, payload: list[dict], force: bool, message: str = "Raw transaction"
+    self,
+    tree: str,
+    user_id: str,
+    payload: list[dict],
+    force: bool,
+    message: str = "Raw transaction",
 ):
     """Process a set of database transactions, updating search indices as needed."""
     num_people_deleted = sum(
@@ -728,7 +758,9 @@ def process_chat(
     response_text = sanitize_answer(result.response.text or "")
     response_dict: dict[str, Any] = {
         "response": response_text,
-        "message_history_raw": ModelMessagesTypeAdapter.dump_json(result.all_messages()).decode(),
+        "message_history_raw": ModelMessagesTypeAdapter.dump_json(
+            result.all_messages()
+        ).decode(),
     }
 
     if verbose:

--- a/gramps_webapi/api/tasks.py
+++ b/gramps_webapi/api/tasks.py
@@ -237,12 +237,18 @@ def set_progress_title(self, title: str = "", message: str = "") -> None:
 
 
 @shared_task(bind=True)
-def search_reindex_full(self, tree: str, user_id: str) -> None:
-    """Rebuild the full-text search index."""
+def search_reindex_full(self, tree: str, user_id: str, semantic: bool = False) -> None:
+    """Rebuild the full-text search index.
+
+    The ``semantic`` parameter is accepted for backward compatibility with
+    jobs that were enqueued before this task was split into separate
+    full-text / semantic variants.  New callers should use
+    ``search_reindex_full_semantic`` for semantic reindexing.
+    """
     return _search_reindex_full(
         tree=tree,
         user_id=user_id,
-        semantic=False,
+        semantic=semantic,
         progress_cb=progress_callback_count(self, title="Updating search index..."),
     )
 
@@ -280,12 +286,20 @@ def _search_reindex_incremental(
 
 
 @shared_task(bind=True)
-def search_reindex_incremental(self, tree: str, user_id: str) -> None:
-    """Run an incremental reindex of the full-text search index."""
+def search_reindex_incremental(
+    self, tree: str, user_id: str, semantic: bool = False
+) -> None:
+    """Run an incremental reindex of the full-text search index.
+
+    The ``semantic`` parameter is accepted for backward compatibility with
+    jobs that were enqueued before this task was split into separate
+    full-text / semantic variants.  New callers should use
+    ``search_reindex_incremental_semantic`` for semantic reindexing.
+    """
     return _search_reindex_incremental(
         tree=tree,
         user_id=user_id,
-        semantic=False,
+        semantic=semantic,
         progress_cb=progress_callback_count(self, title="Updating search index..."),
     )
 

--- a/tests/test_endpoints/test_tasks.py
+++ b/tests/test_endpoints/test_tasks.py
@@ -390,6 +390,36 @@ class TestTaskEndpoints(unittest.TestCase):
         assert rv.status_code == 200
         assert rv.json["user_name"] is None
 
+    def test_list_excludes_expired_tasks(self):
+        """Tasks older than the result TTL are excluded from the list."""
+        fresh_id = str(uuid.uuid4())
+        expired_id = str(uuid.uuid4())
+        with self.app.app_context():
+            user_db.session.add(
+                TaskTree(
+                    task_id=fresh_id,
+                    tree=self.tree,
+                    user_id=self.owner_id,
+                    name="task",
+                    created_at=datetime.utcnow() - timedelta(hours=1),
+                )
+            )
+            user_db.session.add(
+                TaskTree(
+                    task_id=expired_id,
+                    tree=self.tree,
+                    user_id=self.owner_id,
+                    name="task",
+                    created_at=datetime.utcnow() - timedelta(hours=25),
+                )
+            )
+            user_db.session.commit()
+        rv = self.client.get("/api/tasks/", headers=self._auth("owner"))
+        assert rv.status_code == 200
+        returned_ids = [t["task_id"] for t in rv.json]
+        assert fresh_id in returned_ids
+        assert expired_id not in returned_ids
+
 
 class TestSearchIndexDispatch(unittest.TestCase):
     """Tests that POST /api/search/index/ dispatches the correct task (Copilot issue #7)."""

--- a/tests/test_endpoints/test_tasks.py
+++ b/tests/test_endpoints/test_tasks.py
@@ -351,3 +351,111 @@ class TestTaskEndpoints(unittest.TestCase):
         assert rv.status_code == 200
         assert rv.json["state"] == "PENDING"
         assert rv.json["task_id"] == task_id
+
+    # --- user_name field (Copilot issue #4) ---
+
+    def test_list_user_name_populated(self):
+        """user_name is resolved from user_id in the task list."""
+        task_id = str(uuid.uuid4())
+        self._insert_row(task_id, name="export_db", user_id=self.owner_id)
+        rv = self.client.get("/api/tasks/", headers=self._auth("owner"))
+        assert rv.status_code == 200
+        task = next((t for t in rv.json if t["task_id"] == task_id), None)
+        assert task is not None
+        assert task["user_name"] == "ep_owner"
+
+    def test_list_user_name_none_for_system_task(self):
+        """System tasks (null user_id) have user_name=None in the task list."""
+        task_id = str(uuid.uuid4())
+        self._insert_row(task_id, name="send_telemetry_task", user_id=None)
+        rv = self.client.get("/api/tasks/", headers=self._auth("owner"))
+        assert rv.status_code == 200
+        task = next((t for t in rv.json if t["task_id"] == task_id), None)
+        assert task is not None
+        assert task["user_name"] is None
+
+    def test_get_task_user_name_populated(self):
+        """user_name is resolved from user_id in the task detail response."""
+        task_id = str(uuid.uuid4())
+        self._insert_row(task_id, name="export_db", user_id=self.member_id)
+        rv = self.client.get(f"/api/tasks/{task_id}", headers=self._auth("member"))
+        assert rv.status_code == 200
+        assert rv.json["user_name"] == "ep_member"
+
+    def test_get_task_user_name_none_for_system_task(self):
+        """System tasks (null user_id) have user_name=None in the task detail."""
+        task_id = str(uuid.uuid4())
+        self._insert_row(task_id, name="send_telemetry_task", user_id=None)
+        rv = self.client.get(f"/api/tasks/{task_id}", headers=self._auth("owner"))
+        assert rv.status_code == 200
+        assert rv.json["user_name"] is None
+
+
+class TestSearchIndexDispatch(unittest.TestCase):
+    """Tests that POST /api/search/index/ dispatches the correct task (Copilot issue #7)."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.app, cls.dbman, cls.tree = _make_app("TestSearchIndexDispatch")
+        cls.client = cls.app.test_client()
+        with cls.app.app_context():
+            user_db.create_all()
+            if not user_db.session.query(User).filter_by(name="si_owner").scalar():
+                add_user(name="si_owner", password="pw", role=ROLE_OWNER, tree=cls.tree)
+            cls.owner_id = str(
+                user_db.session.query(User).filter_by(name="si_owner").scalar().id
+            )
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.dbman.remove_database("TestSearchIndexDispatch")
+
+    def _token(self):
+        rv = self.client.post(
+            "/api/token/", json={"username": "si_owner", "password": "pw"}
+        )
+        return rv.json["access_token"]
+
+    def _auth(self):
+        return {"Authorization": f"Bearer {self._token()}"}
+
+    def _post_index(self, full: bool, semantic: bool):
+        with patch("gramps_webapi.api.resources.search.run_task") as mock_run_task:
+            mock_run_task.return_value = None  # synchronous path → 201
+            rv = self.client.post(
+                f"/api/search/index/?full={str(full).lower()}&semantic={str(semantic).lower()}",
+                headers=self._auth(),
+            )
+            return rv, mock_run_task
+
+    def test_full_nonsemantic_dispatches_search_reindex_full(self):
+        from gramps_webapi.api.tasks import search_reindex_full
+
+        rv, mock_run_task = self._post_index(full=True, semantic=False)
+        assert rv.status_code == 201
+        mock_run_task.assert_called_once()
+        assert mock_run_task.call_args[0][0] is search_reindex_full
+
+    def test_full_semantic_dispatches_search_reindex_full_semantic(self):
+        from gramps_webapi.api.tasks import search_reindex_full_semantic
+
+        rv, mock_run_task = self._post_index(full=True, semantic=True)
+        assert rv.status_code == 201
+        mock_run_task.assert_called_once()
+        assert mock_run_task.call_args[0][0] is search_reindex_full_semantic
+
+    def test_incremental_nonsemantic_dispatches_search_reindex_incremental(self):
+        from gramps_webapi.api.tasks import search_reindex_incremental
+
+        rv, mock_run_task = self._post_index(full=False, semantic=False)
+        assert rv.status_code == 201
+        mock_run_task.assert_called_once()
+        assert mock_run_task.call_args[0][0] is search_reindex_incremental
+
+    def test_incremental_semantic_dispatches_search_reindex_incremental_semantic(self):
+        from gramps_webapi.api.tasks import search_reindex_incremental_semantic
+
+        rv, mock_run_task = self._post_index(full=False, semantic=True)
+        assert rv.status_code == 201
+        mock_run_task.assert_called_once()
+        assert mock_run_task.call_args[0][0] is search_reindex_incremental_semantic

--- a/tests/test_endpoints/test_user.py
+++ b/tests/test_endpoints/test_user.py
@@ -32,6 +32,7 @@ from gramps.gen.dbstate import DbState
 
 from gramps_webapi.app import create_app
 from gramps_webapi.auth import (
+    User,
     add_user,
     create_oidc_account,
     delete_user,
@@ -419,6 +420,55 @@ class TestUser(unittest.TestCase):
             set(user["name"] for user in rv.json),
             {"admin", "user", "owner"},
         )
+
+    def test_show_users_filter_by_user_id(self):
+        """GET /api/users/?user_id=<id> returns only that user."""
+        with self.app.app_context():
+            target = user_db.session.query(User).filter_by(name="user").scalar()
+            target_id = str(target.id)
+        rv = self.client.post(
+            BASE_URL + "/token/", json={"username": "owner", "password": "123"}
+        )
+        token_owner = rv.json["access_token"]
+        rv = self.client.get(
+            BASE_URL + f"/users/?user_id={target_id}",
+            headers={"Authorization": f"Bearer {token_owner}"},
+        )
+        assert rv.status_code == 200
+        assert len(rv.json) == 1
+        assert rv.json[0]["name"] == "user"
+
+    def test_show_users_filter_by_unknown_user_id(self):
+        """GET /api/users/?user_id=<nonexistent> returns empty list."""
+        rv = self.client.post(
+            BASE_URL + "/token/", json={"username": "owner", "password": "123"}
+        )
+        token_owner = rv.json["access_token"]
+        rv = self.client.get(
+            BASE_URL + "/users/?user_id=00000000-0000-0000-0000-000000000000",
+            headers={"Authorization": f"Bearer {token_owner}"},
+        )
+        assert rv.status_code == 200
+        assert rv.json == []
+
+    def test_show_users_filter_by_user_id_cross_tree(self):
+        """owner of tree1 cannot retrieve a user from tree2 via user_id filter."""
+        with self.app.app_context():
+            other_tree_user = (
+                user_db.session.query(User).filter_by(name="user2").scalar()
+            )
+            other_id = str(other_tree_user.id)
+        rv = self.client.post(
+            BASE_URL + "/token/", json={"username": "owner", "password": "123"}
+        )
+        token_owner = rv.json["access_token"]
+        rv = self.client.get(
+            BASE_URL + f"/users/?user_id={other_id}",
+            headers={"Authorization": f"Bearer {token_owner}"},
+        )
+        assert rv.status_code == 200
+        # user2 belongs to tree2; owner of tree1 must not see them
+        assert all(u["name"] != "user2" for u in rv.json)
 
     def test_edit_user(self):
         rv = self.client.post(

--- a/tests/test_endpoints/test_user.py
+++ b/tests/test_endpoints/test_user.py
@@ -451,6 +451,18 @@ class TestUser(unittest.TestCase):
         assert rv.status_code == 200
         assert rv.json == []
 
+    def test_show_users_filter_by_invalid_user_id_returns_422(self):
+        """GET /api/users/?user_id=<invalid> is rejected by UUID validation."""
+        rv = self.client.post(
+            BASE_URL + "/token/", json={"username": "owner", "password": "123"}
+        )
+        token_owner = rv.json["access_token"]
+        rv = self.client.get(
+            BASE_URL + "/users/?user_id=not-a-uuid",
+            headers={"Authorization": f"Bearer {token_owner}"},
+        )
+        assert rv.status_code == 422
+
     def test_show_users_filter_by_user_id_cross_tree(self):
         """owner of tree1 cannot retrieve a user from tree2 via user_id filter."""
         with self.app.app_context():

--- a/tests/test_endpoints/test_user.py
+++ b/tests/test_endpoints/test_user.py
@@ -480,7 +480,7 @@ class TestUser(unittest.TestCase):
         )
         assert rv.status_code == 200
         # user2 belongs to tree2; owner of tree1 must not see them
-        assert all(u["name"] != "user2" for u in rv.json)
+        assert rv.json == []
 
     def test_edit_user(self):
         rv = self.client.post(


### PR DESCRIPTION
…add user_id filter to /api/users/

- Split search_reindex_full(semantic: bool) into search_reindex_full and search_reindex_full_semantic, and similarly for search_reindex_incremental, so the task name alone identifies whether a full-text or semantic reindex is running (visible via the task list endpoint)
- Add user_name field to GET /api/tasks/ and GET /api/tasks/<id> responses, resolved at query time from the stored user_id, so frontends can display the initiating username without a separate lookup
- Add optional ?user_id=<uuid> filter to GET /api/users/ to allow direct lookup of a user by their UUID; permissions are enforced before filtering so no new data is exposed