### PR TITLE
Recompute Date sortval on write (fixes #869)

### DIFF
--- a/gramps_webapi/api/util.py
+++ b/gramps_webapi/api/util.py
@@ -877,9 +877,40 @@ def complete_gramps_object_dict(data: dict[str, Any]):
     return data
 
 
+def recalc_date_sortvals(data: Any) -> Any:
+    """Recompute the ``sortval`` of every embedded ``Date`` in an object dict.
+
+    Gramps Web stores whatever a client sends, and ``Date`` deserialization does not
+    recalculate ``sortval`` from ``dateval`` — so a stale, zero, or missing ``sortval``
+    is persisted verbatim and silently breaks date sorting (gramps-project/gramps-web-api#869).
+    This walks the dict and, for every serialized ``Date``, lets Gramps recompute
+    ``sortval`` from ``dateval`` (correct across calendars, modifiers, and BCE dates).
+    Modifies ``data`` in place and returns it.
+    """
+    if isinstance(data, dict):
+        if data.get("_class") == "Date" and "dateval" in data:
+            try:
+                date = data_to_object(data)
+                date.recalc_sort_value()
+                data["sortval"] = date.sortval
+            except Exception:  # pragma: no cover - never block a write on one bad date
+                pass
+        else:
+            for value in data.values():
+                recalc_date_sortvals(value)
+    elif isinstance(data, list):
+        for value in data:
+            recalc_date_sortvals(value)
+    return data
+
+
 def gramps_object_from_dict(data: dict[str, Any]):
     """Instantiate a Gramps object from a dictionary.
 
     The dictionary can be incomplete, i.e. not contain all properties of
     the object class."""
-    return data_to_object(complete_gramps_object_dict(data))
+    completed = complete_gramps_object_dict(data)
+    # Keep Date sortval authoritative on write (gramps-web-api#869): the client's
+    # value is not to be trusted, since sorting depends on it.
+    recalc_date_sortvals(completed)
+    return data_to_object(completed)

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -262,7 +262,9 @@ def test_send_email_ssl_false_starttls_true(mock_smtp, mock_smtp_ssl, mock_get_c
 
 @patch("gramps_webapi.api.util.smtplib.SMTP_SSL")
 @patch("gramps_webapi.api.util.smtplib.SMTP")
-def test_send_email_legacy_use_tls_false_deprecation_warning(mock_smtp, mock_smtp_ssl, mock_get_config):
+def test_send_email_legacy_use_tls_false_deprecation_warning(
+    mock_smtp, mock_smtp_ssl, mock_get_config
+):
     """Test that legacy EMAIL_USE_TLS=false logs deprecation warning."""
     mock_get_config["EMAIL_USE_TLS"] = False
     mock_get_config["EMAIL_PORT"] = "587"
@@ -277,3 +279,47 @@ def test_send_email_legacy_use_tls_false_deprecation_warning(mock_smtp, mock_smt
     mock_smtp.assert_called_once()
     mock_smtp_instance.starttls.assert_called_once()
     mock_smtp_ssl.assert_not_called()
+
+
+def test_recalc_date_sortvals_fixes_stale_sortval():
+    """gramps-web-api#869: a client-supplied stale/zero sortval must be recomputed."""
+    from gramps.gen.lib import Date
+    from gramps.gen.lib.json_utils import object_to_dict
+
+    from gramps_webapi.api.util import gramps_object_from_dict, recalc_date_sortvals
+
+    date = Date()
+    date.set_yr_mon_day(1922, 5, 3)
+    correct = date.sortval
+    assert correct  # 2423178, computed by gramps
+
+    # an Event whose embedded Date arrives with a corrupted sortval
+    event = {
+        "_class": "Event",
+        "type": {"_class": "EventType", "value": 12, "string": "Birth"},
+        "date": object_to_dict(date),
+    }
+    event["date"]["sortval"] = 0
+    recalc_date_sortvals(event)
+    assert event["date"]["sortval"] == correct
+
+    # and end-to-end through the deserializer used by the write endpoints
+    event["date"]["sortval"] = 1
+    obj = gramps_object_from_dict(event)
+    assert obj.get_date_object().sortval == correct
+
+
+def test_recalc_date_sortvals_year_only():
+    """Year-only dates (no month/day) also get a correct sortval."""
+    from gramps.gen.lib import Date
+    from gramps.gen.lib.json_utils import object_to_dict
+
+    from gramps_webapi.api.util import recalc_date_sortvals
+
+    date = Date()
+    date.set_yr_mon_day(1827, 0, 0)
+    correct = date.sortval
+    date_dict = object_to_dict(date)
+    date_dict["sortval"] = 0
+    recalc_date_sortvals({"_class": "Event", "date": date_dict})
+    assert date_dict["sortval"] == correct


### PR DESCRIPTION
Fixes #869.

## Problem

On write, the API stored a client-supplied `Date.sortval` verbatim. `Date` deserialization does not recompute `sortval` from `dateval` (recalculation normally happens in `Date.set(...)`, not on unserialize), so a stale, zero, or missing `sortval` was persisted as-is. Because date sorting is driven by `sortval`, this silently mis-orders events/people while the date still *displays* correctly — hard to trace back to the write.

Repro (before this change): `PUT` an event whose `date.sortval` is `0` (with a valid `dateval`) → `GET` returns `sortval: 0`.

## Fix

`gramps_object_from_dict()` — the single deserialization chokepoint used by both the create (`/api/objects/`) and update (`PUT /api/.../{handle}`) paths — now runs the completed object dict through a new `recalc_date_sortvals()` helper before instantiation. The helper walks the dict, and for every embedded serialized `Date` lets Gramps recompute `sortval` from `dateval` via `Date.recalc_sort_value()`, so it stays correct across calendars, modifiers, and BCE dates. It covers all object types and all nested dates (event/citation/name/address/LDS-ord/place names, …), and never blocks a write on a single malformed date.

## Tests

Adds `test_recalc_date_sortvals_fixes_stale_sortval` (full date, including end-to-end through `gramps_object_from_dict`) and `test_recalc_date_sortvals_year_only`.

Verified against the running Gramps version: a zeroed `sortval` for `3 May 1922` is recomputed to `2423178`, and a year-only `1827` to `2388358` — both matching `Date.recalc_sort_value()`.

## Notes

`black` + `isort` clean. The change is confined to `gramps_object_from_dict()` plus the new helper, so existing read paths are untouched (the API GET output is unchanged; only writes now normalize `sortval`).
