### PR TITLE
Parse DNA match cM values with mixed thousands and decimal separators

### DIFF
--- a/gramps_webapi/api/dna.py
+++ b/gramps_webapi/api/dna.py
@@ -68,11 +68,19 @@ def cast_int(value: str) -> int:
 def cast_float(value: str) -> float:
     """Cast a string to a float."""
     value = value.replace(" ", "")
-    if value.count(".") > 1:
+    if value.count(".") >= 1 and value.count(",") >= 1:
+        # Both separators are present (e.g. "1.234,56" or "1,234.56"). The
+        # rightmost one is the decimal separator; the other groups thousands
+        # and is removed.
+        if value.rfind(",") > value.rfind("."):
+            value = value.replace(".", "").replace(",", ".")
+        else:
+            value = value.replace(",", "")
+    elif value.count(".") > 1:
         value = value.replace(".", "")
-    if value.count(",") > 1:
+    elif value.count(",") > 1:
         value = value.replace(",", "")
-    if value.count(",") == 1 and value.count(".") == 0:
+    elif value.count(",") == 1 and value.count(".") == 0:
         value = value.replace(",", ".")
     try:
         return float(value)

--- a/tests/test_dna_match_parser.py
+++ b/tests/test_dna_match_parser.py
@@ -1,6 +1,6 @@
 """Test the DNA match parser."""
 
-from gramps_webapi.api.dna import parse_raw_dna_match_string
+from gramps_webapi.api.dna import cast_float, parse_raw_dna_match_string
 
 
 def test_gramplet_form():
@@ -247,6 +247,48 @@ def test_non_castable_float():
         "stop": 64247327,
         "side": "U",
         "cM": 0,
+        "SNPs": 0,
+        "comment": "",
+    }
+
+
+def test_cast_float_mixed_separators():
+    """Test cast_float with mixed thousands and decimal separators.
+
+    A value combining a thousands separator and a decimal separator (e.g.
+    the European "1.234,56" or the US "1,234.56") was not handled by any of
+    the existing branches and silently fell back to 0.0. The rightmost
+    separator is the decimal separator; the other groups thousands.
+    """
+    # European grouping: "." thousands, "," decimal
+    assert cast_float("1.234,56") == 1234.56
+    assert cast_float("1.234.567,89") == 1234567.89
+    # US/UK grouping: "," thousands, "." decimal
+    assert cast_float("1,234.56") == 1234.56
+    assert cast_float("1,234,567.89") == 1234567.89
+    # Existing single-separator behaviour must be preserved
+    assert cast_float("15,5") == 15.5
+    assert cast_float("38.64") == 38.64
+    assert cast_float("1.234.567") == 1234567.0
+    assert cast_float("1,234,567") == 1234567.0
+
+
+def test_mixed_separator_centimorgans():
+    """Test parsing a table whose centimorgans use mixed separators.
+
+    Guards against the regression where a centimorgans value formatted with
+    both a thousands and a decimal separator was parsed as 0.0.
+    """
+    string = """Chromosome;Start Location;End Location;Centimorgans
+3;56950055;64247327;1.234,56"""
+    segments = parse_raw_dna_match_string(string)
+    assert len(segments) == 1
+    assert segments[0] == {
+        "chromosome": "3",
+        "start": 56950055,
+        "stop": 64247327,
+        "side": "U",
+        "cM": 1234.56,
         "SNPs": 0,
         "comment": "",
     }


### PR DESCRIPTION
## Summary

The DNA match parser's `cast_float` helper (`gramps_webapi/api/dna.py`) handles values that use a single locale separator — e.g. `"15,5"` (German decimal comma) or `"1.234.567"` (dot thousands grouping). But a value that combines **both** a thousands separator and a decimal separator was not matched by any branch and silently fell back to `0.0`:

| Input | Before | After |
|---|---|---|
| `1.234,56` (EU: `.` thousands, `,` decimal) | `0.0` | `1234.56` |
| `1,234.56` (US/UK: `,` thousands, `.` decimal) | `0.0` | `1234.56` |
| `1.234.567,89` | `0.0` | `1234567.89` |
| `1,234,567.89` | `0.0` | `1234567.89` |

For the centimorgans field this means a validly formatted value could be dropped to `0.0`.

## Root cause

`cast_float` had three independent `if` branches: multi-dot → strip dots, multi-comma → strip commas, single comma + no dot → comma is decimal. The mixed *one-dot-and-one-comma* case fell through all of them, so `float("1.234,56")` raised `ValueError` and returned `0.0`.

## Fix

Add a branch for when both `.` and `,` are present: the **rightmost** separator is treated as the decimal separator and the other is removed as a thousands separator. The remaining branches are made mutually exclusive (`elif`) but their behaviour for single-separator inputs is unchanged. This continues the locale-tolerance work from the more permissive parser (#599).

## Verification

Tests run in isolation (the full suite requires PyGObject, but `dna.py` only depends on the `MatchSegment` TypedDict, so it is exercised directly):

- Against **unfixed** code: the two new tests **fail**, all 12 existing tests pass.
- Against the **fix**: all 14 tests pass.
- `black --check` clean on both changed files.
- `mypy` introduces no new errors in `dna.py` (the function signature is unchanged).

Two regression tests are added to `tests/test_dna_match_parser.py`: one exercising `cast_float` directly across both groupings (and asserting the existing single-separator cases still hold), and one end-to-end parse asserting a mixed-separator centimorgans value yields `1234.56` rather than `0.0`.

Issue #599.

> Opened as a draft: this edge case was found while reviewing the parser rather than from a filed report, and per CONTRIBUTING I'd welcome a maintainer's call on whether mixed-separator cM values are worth handling. The fix is small and the existing tests are preserved.