### PR TITLE
Handle FileNotFoundError when checking thumbnail file size

### DIFF
--- a/gramps_webapi/api/file.py
+++ b/gramps_webapi/api/file.py
@@ -117,7 +117,11 @@ class FileHandler:
         """Abort with 413 if the file exceeds the thumbnail size limit."""
         max_bytes = current_app.config.get("MAX_THUMBNAIL_FILE_BYTES")
         assert max_bytes is not None  # for type checker
-        if self.get_file_size() > max_bytes:
+        try:
+            size = self.get_file_size()
+        except FileNotFoundError:
+            return  # file doesn't exist; thumbnail handler will return 404
+        if size > max_bytes:
             abort_with_message(413, "File too large for thumbnailing")
 
     def get_face_regions(self, etag: Optional[str] = None):

--- a/gramps_webapi/api/file.py
+++ b/gramps_webapi/api/file.py
@@ -114,19 +114,13 @@ class FileHandler:
         raise NotImplementedError
 
     def _abort_if_too_large(self) -> None:
-        """Abort with 413 if the file exceeds the thumbnail size limit.
-
-        If the file does not exist, returns `None` without aborting. Callers
-        are expected to attempt to read the file afterwards and handle the
-        resulting `FileNotFoundError` (e.g. `LocalFileThumbnailHandler`
-        aborts with 404 in that case).
-        """
+        """Abort with 404 if the file is missing, or 413 if it is too large."""
         max_bytes = current_app.config.get("MAX_THUMBNAIL_FILE_BYTES")
         assert max_bytes is not None  # for type checker
         try:
             size = self.get_file_size()
         except FileNotFoundError:
-            return
+            abort_with_message(404, "Media file not found")
         if size > max_bytes:
             abort_with_message(413, "File too large for thumbnailing")
 

--- a/gramps_webapi/api/file.py
+++ b/gramps_webapi/api/file.py
@@ -114,13 +114,19 @@ class FileHandler:
         raise NotImplementedError
 
     def _abort_if_too_large(self) -> None:
-        """Abort with 413 if the file exceeds the thumbnail size limit."""
+        """Abort with 413 if the file exceeds the thumbnail size limit.
+
+        If the file does not exist, returns `None` without aborting. Callers
+        are expected to attempt to read the file afterwards and handle the
+        resulting `FileNotFoundError` (e.g. `LocalFileThumbnailHandler`
+        aborts with 404 in that case).
+        """
         max_bytes = current_app.config.get("MAX_THUMBNAIL_FILE_BYTES")
         assert max_bytes is not None  # for type checker
         try:
             size = self.get_file_size()
         except FileNotFoundError:
-            return  # file doesn't exist; thumbnail handler will return 404
+            return
         if size > max_bytes:
             abort_with_message(413, "File too large for thumbnailing")
 


### PR DESCRIPTION
## Summary

- When `check_thumbnail_size_limit` calls `get_file_size()` for a file that doesn't exist, it now catches `FileNotFoundError` and returns early
- This allows the thumbnail handler to proceed and return a proper 404, rather than raising an unhandled exception

## Test plan

- [ ] Request a thumbnail for a media object whose file is missing — should return 404, not 500
- [ ] Request a thumbnail for an oversized file — should still return 413
- [ ] Request a thumbnail for a normal file — should return the thumbnail as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)