### PR TITLE
feat(api): derive marital_status for family profiles

### DIFF
--- a/gramps_webapi/api/resources/marital_status.py
+++ b/gramps_webapi/api/resources/marital_status.py
@@ -1,0 +1,251 @@
+#
+# Gramps Web API - marital status derivation
+#
+# Copyright (C) 2026  Sergey Sabalevskiy
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+
+"""Marital-status derivation for Gramps Web API family profiles.
+
+Two-layer design:
+
+* ``compute_marital_status`` — pure core, zero Gramps imports.  Holds ALL
+  decision logic and is unit-testable without a Gramps installation.
+
+* ``get_marital_status`` — thin adapter that extracts primitives from Gramps
+  objects and calls the core.  This is the only part that imports Gramps.
+
+The result is one of: ``"married"``, ``"divorced"``, ``"widowed"``,
+``"partners"``, ``"unknown"``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+# ---------------------------------------------------------------------------
+# Pure core — NO Gramps imports below this line
+# ---------------------------------------------------------------------------
+
+
+def compute_marital_status(
+    marriage_sortvals: list[int],
+    divorce_sortvals: list[int],
+    rel_type: int,
+    rel_type_married: int,
+    rel_type_unmarried: int,
+    rel_type_civil_union: int,
+    father_has_death: bool,
+    mother_has_death: bool,
+) -> str:
+    """Derive marital status from pre-extracted primitives.
+
+    Parameters
+    ----------
+    marriage_sortvals:
+        Sort-values (``date.get_sort_value()``) of all marriage-class events
+        (MARRIAGE + fallbacks such as ENGAGEMENT / MARR_ALT) found on the
+        family.  May be empty.  0 means undated.
+    divorce_sortvals:
+        Sort-values of all divorce-class events (DIVORCE, ANNULMENT,
+        DIV_FILING, and other fallbacks).  May be empty.  0 means undated.
+    rel_type:
+        Integer value of the family's ``FamilyRelType``.
+    rel_type_married:
+        The integer value of ``FamilyRelType.MARRIED``.
+    rel_type_unmarried:
+        The integer value of ``FamilyRelType.UNMARRIED``.
+    rel_type_civil_union:
+        The integer value of ``FamilyRelType.CIVIL_UNION``.
+    father_has_death:
+        True when the father's profile (or DB fallback) records a death event
+        with a known date.
+    mother_has_death:
+        Same for the mother.
+
+    Returns
+    -------
+    str
+        One of ``"married"``, ``"divorced"``, ``"widowed"``,
+        ``"partners"``, ``"unknown"``.
+
+    Algorithm
+    ---------
+    1. Base by relationship type:
+       - UNMARRIED or CIVIL_UNION  → ``"partners"``
+       - MARRIED *or* any marriage event present → ``"married"``
+       - otherwise → ``"unknown"``
+
+    2. Divorce wins if it is the latest terminal event by sort-value:
+       if any divorce event exists AND (no marriage events OR
+       ``max(divorce) >= max(marriage)``) → status = ``"divorced"``.
+       This keeps m→d→m correctly as ``"married"`` when the remarriage
+       sort-value is strictly later than the divorce.
+
+       Known limitation: when ALL events are undated (sort-value == 0),
+       ``max(divorce) >= max(marriage)`` is ``0 >= 0`` = True, so a
+       fully-undated m→d→m sequence also yields ``"divorced"`` rather than
+       ``"married"``.  This matches the rest of Gramps Web's behaviour for
+       undated events.
+
+    3. Widowhood applies ONLY to ``"married"`` (not to ``"partners"``):
+       if status == ``"married"`` and either spouse has a recorded death
+       with a date → status = ``"widowed"``.
+    """
+    # Step 1 — base status from relationship type and event presence
+    if rel_type in (rel_type_unmarried, rel_type_civil_union):
+        base = "partners"
+    elif marriage_sortvals or rel_type == rel_type_married:
+        base = "married"
+    else:
+        base = "unknown"
+
+    # Step 2 — divorce wins if it is the latest terminal event.
+    # Only applies to "married" / "unknown" base; "partners" is never
+    # converted to "divorced" (a dissolved civil union stays "partners").
+    if (
+        base != "partners"
+        and divorce_sortvals
+        and (not marriage_sortvals or max(divorce_sortvals) >= max(marriage_sortvals))
+    ):
+        status = "divorced"
+    else:
+        status = base
+
+    # Step 3 — widowhood, but ONLY for "married" (never "partners")
+    if status == "married" and (father_has_death or mother_has_death):
+        status = "widowed"
+
+    return status
+
+
+# ---------------------------------------------------------------------------
+# Gramps adapter — imports Gramps here and nowhere above
+# ---------------------------------------------------------------------------
+
+
+def get_marital_status(
+    db_handle: Any,
+    family: Any,
+    father_profile: dict | None,
+    mother_profile: dict | None,
+) -> str:
+    """Return a marital-status string for *family*.
+
+    Parameters
+    ----------
+    db_handle:
+        Gramps database handle (read-only access suffices).
+    family:
+        A ``gramps.gen.lib.Family`` object.
+    father_profile:
+        The already-computed person profile dict for the father (may be empty
+        dict or None if the father is unknown).  Used to detect death without
+        an extra DB round-trip when the ``"death"`` key is present.
+    mother_profile:
+        Same for the mother.
+
+    Notes
+    -----
+    The death-detection logic uses a two-tier approach:
+
+    * If the profile dict contains a ``"death"`` key (even if its value is
+      empty / ``{}``), that key is authoritative: a non-empty dict with a
+      ``"date"`` sub-key means "has dated death", an empty dict or missing
+      ``"date"`` means "no dated death recorded".
+
+    * If the profile dict does NOT contain a ``"death"`` key at all (e.g.
+      the caller passed ``args=[]`` so death was not included), we fall back
+      to a direct DB look-up via ``get_death_or_fallback``.
+    """
+    # Local Gramps imports — isolated to this function/module section so that
+    # compute_marital_status remains provably Gramps-free.
+    from gramps.gen.errors import HandleError
+    from gramps.gen.lib import EventType, FamilyRelType
+    from gramps.gen.utils.db import PRIMARY_EVENT_ROLES, get_death_or_fallback
+
+    # --- Collect event sort-values -------------------------------------------
+    marriage_sortvals: list[int] = []
+    divorce_sortvals: list[int] = []
+
+    for event_ref in family.get_event_ref_list():
+        if event_ref.get_role() not in PRIMARY_EVENT_ROLES:
+            continue
+        event = db_handle.get_event_from_handle(event_ref.ref)
+        if event is None:
+            continue
+        etype = event.get_type()
+        sortval = event.get_date_object().get_sort_value()
+
+        if etype == EventType.MARRIAGE or etype.is_marriage_fallback():
+            marriage_sortvals.append(sortval)
+        elif etype == EventType.DIVORCE or etype.is_divorce_fallback():
+            divorce_sortvals.append(sortval)
+
+    # --- Relationship type ---------------------------------------------------
+    # NB: Gramps ``Family`` exposes the relationship type via ``get_relationship()``
+    # (there is no ``get_type()`` on Family — that exists on Event). The returned
+    # FamilyRelType is int-coercible via GrampsType.__int__.
+    rel_type = int(family.get_relationship())
+
+    # --- Death flags ---------------------------------------------------------
+    def _has_dated_death(profile: dict | None, handle: Any) -> bool:
+        """True if the person has a recorded death with a known date.
+
+        Two-tier contract:
+        * Tier 1 — profile is not None AND contains a ``"death"`` key:
+          the key is authoritative.  A sub-dict with a ``"date"`` entry
+          means "has dated death"; an empty dict or absent ``"date"``
+          means "no dated death recorded".  No DB look-up is performed.
+        * Tier 2 — profile is None, OR the ``"death"`` key is absent
+          (i.e. caller passed ``args=[]`` so death was not serialised):
+          fall back to a direct DB look-up via ``get_death_or_fallback``.
+
+        Note: an empty profile dict ``{}`` has no ``"death"`` key, so it
+        falls through to Tier 2 — same as None.
+        """
+        if profile is not None and "death" in profile:
+            # Tier 1: profile is authoritative.
+            death = profile["death"]
+            return bool(death and death.get("date"))
+        # Tier 2: profile absent or built without death info — ask the DB.
+        if handle is None:
+            return False
+        try:
+            person = db_handle.get_person_from_handle(handle)
+        except HandleError:
+            return False
+        if person is None:
+            return False
+        event = get_death_or_fallback(db_handle, person)
+        if event is None:
+            return False
+        # Match the Tier 1 convention: an undated death (sort-value 0) does not
+        # count, so both tiers agree regardless of which one a caller hits.
+        return event.get_date_object().get_sort_value() != 0
+
+    father_has_death = _has_dated_death(father_profile, family.get_father_handle())
+    mother_has_death = _has_dated_death(mother_profile, family.get_mother_handle())
+
+    return compute_marital_status(
+        marriage_sortvals=marriage_sortvals,
+        divorce_sortvals=divorce_sortvals,
+        rel_type=rel_type,
+        rel_type_married=int(FamilyRelType.MARRIED),
+        rel_type_unmarried=int(FamilyRelType.UNMARRIED),
+        rel_type_civil_union=int(FamilyRelType.CIVIL_UNION),
+        father_has_death=father_has_death,
+        mother_has_death=mother_has_death,
+    )

--- a/gramps_webapi/api/resources/schemas.py
+++ b/gramps_webapi/api/resources/schemas.py
@@ -431,6 +431,15 @@ class FamilyProfileSchema(_Base):
     handle = fields.Str(
         metadata={"description": "Unique handle for the family."},
     )
+    marital_status = fields.Str(
+        metadata={
+            "description": (
+                "Derived union status of the family: one of 'married', "
+                "'divorced', 'widowed', 'partners' or 'unknown'. A "
+                "locale-neutral enum, not translated."
+            )
+        },
+    )
     marriage = fields.Nested(
         EventProfileSchema,
         metadata={

--- a/gramps_webapi/api/resources/util.py
+++ b/gramps_webapi/api/resources/util.py
@@ -85,6 +85,7 @@ from ..util import (
     get_db_handle,
     get_tree_from_jwt,
 )
+from .marital_status import get_marital_status
 
 pd = PlaceDisplay()
 _ = glocale.translation.gettext
@@ -846,6 +847,9 @@ def get_family_profile_for_object(
             for child_ref in family.child_ref_list
         ],
     }
+    profile["marital_status"] = get_marital_status(
+        db_handle, family, profile["father"], profile["mother"]
+    )
     if profile["father"]:
         if profile["father"]["name_surname"] or profile["father"]["name_given"]:
             profile["family_surname"] = profile["father"]["name_surname"]

--- a/tests/test_endpoints/test_families.py
+++ b/tests/test_endpoints/test_families.py
@@ -553,6 +553,7 @@ class TestFamilies(unittest.TestCase):
                     ]
                 },
                 "relationship": "Married",
+                "marital_status": "widowed",
             },
         )
 
@@ -968,6 +969,7 @@ class TestFamiliesHandle(unittest.TestCase):
                     ]
                 },
                 "relationship": "Married",
+                "marital_status": "married",
             },
         )
 

--- a/tests/test_endpoints/test_people.py
+++ b/tests/test_endpoints/test_people.py
@@ -700,6 +700,7 @@ class TestPeople(unittest.TestCase):
                         },
                         "gramps_id": "F0204",
                         "handle": "R14KQCXMSQYXI2CS6W",
+                        "marital_status": "widowed",
                         "marriage": {
                             "citations": 0,
                             "confidence": 0,
@@ -807,6 +808,7 @@ class TestPeople(unittest.TestCase):
                     },
                     "gramps_id": "F0704",
                     "handle": "DT6KQCOCKIUH1J4OSV",
+                    "marital_status": "widowed",
                     "relationship": "Married",
                 },
                 "references": {
@@ -861,6 +863,7 @@ class TestPeople(unittest.TestCase):
                             },
                             "gramps_id": "F0704",
                             "handle": "DT6KQCOCKIUH1J4OSV",
+                            "marital_status": "widowed",
                             "relationship": "Married",
                         },
                         {
@@ -913,6 +916,7 @@ class TestPeople(unittest.TestCase):
                             },
                             "gramps_id": "F0204",
                             "handle": "R14KQCXMSQYXI2CS6W",
+                            "marital_status": "widowed",
                             "marriage": {
                                 "place": "Loveland, Larimer, CO, USA",
                                 "place_name": "Loveland",

--- a/tests/test_marital_status.py
+++ b/tests/test_marital_status.py
@@ -1,0 +1,265 @@
+#
+# Gramps Web API - A RESTful API for the Gramps genealogy program
+#
+# Copyright (C) 2026  Sergey Sabalevskiy
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+
+"""Pure-core unit tests for ``compute_marital_status``.
+
+Gramps is NOT imported here — these tests run in any plain Python environment.
+
+Representative constants (do NOT hard-code real Gramps values in assertions;
+pass them explicitly so the test is agnostic about the actual integer).
+"""
+
+from gramps_webapi.api.resources.marital_status import compute_marital_status
+
+# Representative FamilyRelType constants, passed explicitly to the function.
+# These match the real Gramps values (MARRIED=0, UNMARRIED=1, CIVIL_UNION=2)
+# but the tests never rely on that fact — they always pass the constants.
+REL_MARRIED = 0
+REL_UNMARRIED = 1
+REL_CIVIL_UNION = 2
+REL_UNKNOWN = 3  # Some "other" int — not any of the three recognised types
+
+
+def call(
+    marriage_sortvals=None,
+    divorce_sortvals=None,
+    rel_type=REL_MARRIED,
+    father_has_death=False,
+    mother_has_death=False,
+):
+    """Helper with sane defaults for brevity in test bodies."""
+    return compute_marital_status(
+        marriage_sortvals=marriage_sortvals or [],
+        divorce_sortvals=divorce_sortvals or [],
+        rel_type=rel_type,
+        rel_type_married=REL_MARRIED,
+        rel_type_unmarried=REL_UNMARRIED,
+        rel_type_civil_union=REL_CIVIL_UNION,
+        father_has_death=father_has_death,
+        mother_has_death=mother_has_death,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Simple married — rel=MARRIED, no events
+# ---------------------------------------------------------------------------
+
+
+def test_married_by_rel_type_no_events():
+    """rel=MARRIED with no events → 'married'."""
+    assert call(rel_type=REL_MARRIED) == "married"
+
+
+# ---------------------------------------------------------------------------
+# Married via event only — rel type is not MARRIED
+# ---------------------------------------------------------------------------
+
+
+def test_married_via_event_unknown_rel():
+    """A marriage event present with a non-MARRIED rel type → 'married'."""
+    assert call(marriage_sortvals=[20010101], rel_type=REL_UNKNOWN) == "married"
+
+
+# ---------------------------------------------------------------------------
+# Divorced — marriage then later divorce
+# ---------------------------------------------------------------------------
+
+
+def test_divorced_later_divorce():
+    """divorce sortval > marriage sortval → 'divorced'."""
+    assert call(marriage_sortvals=[20010101], divorce_sortvals=[20101201]) == "divorced"
+
+
+def test_divorced_same_sortval():
+    """divorce sortval == marriage sortval (edge case) → 'divorced'
+    (>= comparison, so equal counts as divorce winning)."""
+    assert call(marriage_sortvals=[20010101], divorce_sortvals=[20010101]) == "divorced"
+
+
+# ---------------------------------------------------------------------------
+# Marriage → divorce → remarriage: remarriage date later than divorce
+# ---------------------------------------------------------------------------
+
+
+def test_remarriage_after_divorce_stays_married():
+    """m→d→m where remarriage sortval > divorce sortval → 'married'."""
+    # divorce=2010, remarriage=2015 → max(marriage)=2015 > max(divorce)=2010
+    assert (
+        call(marriage_sortvals=[20010101, 20150601], divorce_sortvals=[20101201])
+        == "married"
+    )
+
+
+def test_remarriage_after_divorce_remarriage_earlier_stays_divorced():
+    """m→d→m where remarriage sortval < divorce sortval → 'divorced'.
+
+    This is an unusual / data-entry-error case but the algorithm handles it
+    consistently: the latest event wins.
+    """
+    assert (
+        call(marriage_sortvals=[20010101, 20081201], divorce_sortvals=[20101201])
+        == "divorced"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Widowed — married + a spouse has a death
+# ---------------------------------------------------------------------------
+
+
+def test_widowed_father_death():
+    """married + father death → 'widowed'."""
+    assert call(rel_type=REL_MARRIED, father_has_death=True) == "widowed"
+
+
+def test_widowed_mother_death():
+    """married + mother death → 'widowed'."""
+    assert call(rel_type=REL_MARRIED, mother_has_death=True) == "widowed"
+
+
+def test_widowed_both_spouses_dead():
+    """married + both spouses dead → 'widowed'."""
+    assert (
+        call(rel_type=REL_MARRIED, father_has_death=True, mother_has_death=True)
+        == "widowed"
+    )
+
+
+def test_widowed_via_marriage_event_not_rel_type():
+    """married-via-event (not rel type) + death → 'widowed'."""
+    assert (
+        call(
+            marriage_sortvals=[20010101],
+            rel_type=REL_UNKNOWN,
+            father_has_death=True,
+        )
+        == "widowed"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Partners — rel=UNMARRIED or rel=CIVIL_UNION
+# ---------------------------------------------------------------------------
+
+
+def test_partners_unmarried():
+    """rel=UNMARRIED → 'partners'."""
+    assert call(rel_type=REL_UNMARRIED) == "partners"
+
+
+def test_partners_civil_union():
+    """rel=CIVIL_UNION → 'partners'."""
+    assert call(rel_type=REL_CIVIL_UNION) == "partners"
+
+
+# ---------------------------------------------------------------------------
+# Partners NOT widowed even if a spouse has died
+# ---------------------------------------------------------------------------
+
+
+def test_partners_not_widowed_despite_death():
+    """'partners' is NOT upgraded to 'widowed' even when a spouse died."""
+    assert call(rel_type=REL_UNMARRIED, father_has_death=True) == "partners"
+
+
+def test_partners_civil_union_not_widowed():
+    """Civil union with a death → still 'partners', not 'widowed'."""
+    assert call(rel_type=REL_CIVIL_UNION, mother_has_death=True) == "partners"
+
+
+# ---------------------------------------------------------------------------
+# Unknown — rel is some-other-int, no events
+# ---------------------------------------------------------------------------
+
+
+def test_unknown_no_events_other_rel():
+    """rel is some unrecognised integer, no marriage events → 'unknown'."""
+    assert call(rel_type=REL_UNKNOWN) == "unknown"
+
+
+# ---------------------------------------------------------------------------
+# Fully undated divorce (all sortvals == 0)
+# ---------------------------------------------------------------------------
+
+
+def test_fully_undated_divorce_yields_divorced():
+    """All events undated (sortval=0): 0 >= 0 → divorce wins → 'divorced'.
+
+    Known limitation: an undated m→d→m scenario also yields 'divorced'
+    because the algorithm cannot distinguish event order without dates.
+    This matches the rest of Gramps Web's handling of undated events.
+    """
+    assert call(marriage_sortvals=[0], divorce_sortvals=[0]) == "divorced"
+
+
+def test_fully_undated_divorce_no_marriage_events():
+    """Divorce event present (undated), no marriage events → 'divorced'."""
+    assert call(divorce_sortvals=[0], rel_type=REL_MARRIED) == "divorced"
+
+
+# ---------------------------------------------------------------------------
+# Divorce-only (no marriage event), rel=MARRIED
+# ---------------------------------------------------------------------------
+
+
+def test_divorced_no_marriage_event_rel_married():
+    """Divorce event with a date, no marriage event, rel=MARRIED → 'divorced'.
+
+    max(divorce) >= max(marriage) is trivially True when marriage list is empty.
+    """
+    assert call(divorce_sortvals=[20100601], rel_type=REL_MARRIED) == "divorced"
+
+
+# ---------------------------------------------------------------------------
+# Divorced does NOT trigger widowhood
+# ---------------------------------------------------------------------------
+
+
+def test_divorced_with_death_stays_divorced():
+    """After divorce, a spouse death does NOT change status to 'widowed'."""
+    assert (
+        call(
+            marriage_sortvals=[20010101],
+            divorce_sortvals=[20101201],
+            father_has_death=True,
+        )
+        == "divorced"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Partners with divorce event AND spouse death → still "partners"
+# ---------------------------------------------------------------------------
+
+
+def test_partners_with_divorce_and_death_stays_partners():
+    """rel=UNMARRIED + divorce event + spouse death → still 'partners'.
+
+    Confirms that both the divorce-to-'divorced' path and the
+    death-to-'widowed' path leave 'partners' untouched: partners is never
+    upgraded to 'divorced' or 'widowed' regardless of events or deaths.
+    """
+    assert (
+        call(
+            divorce_sortvals=[20101201],
+            rel_type=REL_UNMARRIED,
+            father_has_death=True,
+        )
+        == "partners"
+    )


### PR DESCRIPTION
## Summary

Derive a locale-neutral **`marital_status`** for each family and expose it on the family profile, so clients (e.g. the relationship chart) can show *what kind* of union a couple has without opening each family page.

Backend half of gramps-project/gramps-web#1287 (also addresses the data side of #554). Frontend PR in `gramps-web` will consume this field.

## What's included

- New `marital_status` module computing a family's union status — `married` / `divorced` / `widowed` / `partners` / `unknown` — from its marriage, divorce and spouse-death events (latest dated event wins; `m → d → m` stays `married`; a civil/unmarried `partners` union is never reclassified as divorced/widowed).
- Expose `marital_status` on every family profile produced by `get_family_profile_for_object`.
- Document the field in `FamilyProfileSchema` (locale-neutral enum).
- Robustness: guard the DB death-fallback against `HandleError` and require a *dated* death event, so corrupt handles can't 500 and the two death-detection tiers agree.

## Design

The logic is split into a pure, Gramps-free core (`compute_marital_status`) and a thin Gramps adapter (`get_marital_status`), so the decision logic is unit-testable without a Gramps installation. The status is derived from event types and dates only and is locale-neutral (localization happens in the frontend).

## Tests

- `tests/test_marital_status.py` — pure-core unit tests for the derivation matrix.
- Extended the family-profile endpoint tests with the new key.

## Not in this PR

- No frontend / chart changes — those come in the `gramps-web` PR.

## Related

- Feature issue: gramps-project/gramps-web#1287
- Related: gramps-project/gramps-web#554
