### PR TITLE
Merge ID-token claims into OIDC userinfo so role mapping works with Microsoft Entra

### DIFF
--- a/gramps_webapi/api/resources/oidc.py
+++ b/gramps_webapi/api/resources/oidc.py
@@ -220,9 +220,13 @@ class OIDCCallbackResource(Resource):
                 # claims missing from the userinfo response so that role
                 # mapping via OIDC_ROLE_CLAIM works consistently across
                 # providers. userinfo endpoint values take precedence.
-                id_token_claims = token.get("userinfo") or {}
-                for claim, value in id_token_claims.items():
-                    userinfo.setdefault(claim, value)
+                # Guard against a non-mapping value under "userinfo": an
+                # unexpected shape must be ignored, not turn a successful
+                # login into a 401.
+                id_token_claims = token.get("userinfo")
+                if isinstance(id_token_claims, dict):
+                    for claim, value in id_token_claims.items():
+                        userinfo.setdefault(claim, value)
 
         except Exception:  # pylint: disable=broad-except
             logger.exception("OIDC callback error for provider '%s'", provider_id)

--- a/gramps_webapi/api/resources/oidc.py
+++ b/gramps_webapi/api/resources/oidc.py
@@ -213,7 +213,16 @@ class OIDCCallbackResource(Resource):
                 userinfo = resp.json()
             else:
                 # Standard OIDC - get userinfo from userinfo endpoint
-                userinfo = oidc_client.userinfo(token=token)
+                userinfo = dict(oidc_client.userinfo(token=token))
+                # Some providers (e.g. Microsoft Entra) return authorization
+                # claims such as app roles or group memberships only in the ID
+                # token, not from the userinfo endpoint. Merge any ID-token
+                # claims missing from the userinfo response so that role
+                # mapping via OIDC_ROLE_CLAIM works consistently across
+                # providers. userinfo endpoint values take precedence.
+                id_token_claims = token.get("userinfo") or {}
+                for claim, value in id_token_claims.items():
+                    userinfo.setdefault(claim, value)
 
         except Exception:  # pylint: disable=broad-except
             logger.exception("OIDC callback error for provider '%s'", provider_id)

--- a/tests/test_endpoints/test_oidc.py
+++ b/tests/test_endpoints/test_oidc.py
@@ -194,6 +194,81 @@ class TestOIDCEndpoints(unittest.TestCase):
     @patch("gramps_webapi.api.resources.oidc.get_tree_id")
     @patch("gramps_webapi.api.resources.oidc.get_permissions")
     @patch("gramps_webapi.api.resources.oidc.is_tree_disabled", return_value=False)
+    @patch("gramps_webapi.api.resources.oidc.is_oidc_enabled", return_value=True)
+    @patch(
+        "gramps_webapi.api.resources.oidc.get_available_oidc_providers",
+        return_value=["custom"],
+    )
+    @patch("gramps_webapi.api.resources.oidc.create_or_update_oidc_user")
+    @patch("gramps_webapi.api.resources.oidc.get_name")
+    @patch("gramps_webapi.api.resources.oidc.get_tree_id")
+    @patch("gramps_webapi.api.resources.oidc.get_permissions")
+    @patch("gramps_webapi.api.resources.oidc.is_tree_disabled", return_value=False)
+    @patch("gramps_webapi.api.resources.oidc.get_tokens")
+    def test_oidc_callback_merges_id_token_claims(
+        self,
+        mock_get_tokens,
+        mock_tree_disabled,
+        mock_get_permissions,
+        mock_get_tree_id,
+        mock_get_name,
+        mock_create_user,
+        mock_providers,
+        mock_oidc_enabled,
+    ):
+        """ID-token claims (e.g. roles) missing from userinfo are merged in.
+
+        Providers such as Microsoft Entra return app roles / group memberships
+        only in the ID token, not from the userinfo endpoint. They must still
+        reach role mapping.
+        """
+        mock_oauth = MagicMock()
+        mock_oidc_client = MagicMock()
+        mock_oauth.gramps_custom = mock_oidc_client
+
+        # userinfo endpoint response lacks the roles claim...
+        mock_userinfo = {
+            "sub": "user123",
+            "preferred_username": "testuser",
+            "email": "test@example.com",
+            "name": "Test User",
+        }
+        # ...but the ID token (parsed by Authlib into token["userinfo"]) has it.
+        mock_token = {
+            "access_token": "test_token",
+            "userinfo": {"sub": "user123", "roles": ["admin"]},
+        }
+        mock_oidc_client.authorize_access_token.return_value = mock_token
+        mock_oidc_client.userinfo.return_value = mock_userinfo
+
+        mock_create_user.return_value = "user-guid-123"
+        mock_get_name.return_value = "testuser"
+        mock_get_tree_id.return_value = "test_tree"
+        mock_get_permissions.return_value = {"ViewPrivate"}
+        mock_get_tokens.return_value = {
+            "access_token": "jwt_access_token",
+            "refresh_token": "jwt_refresh_token",
+        }
+
+        with patch.dict(
+            self.client.application.extensions,
+            {"authlib.integrations.flask_client": mock_oauth},
+            clear=False,
+        ):
+            with patch.dict(self.client.application.config, {"TREE": "test_tree"}):
+                rv = self.client.get(
+                    BASE_URL
+                    + "/oidc/callback/?code=auth_code&state=abc123&provider=custom"
+                )
+                self.assertEqual(rv.status_code, 302)
+
+                # The merged userinfo passed to user creation must include the
+                # roles claim that only existed in the ID token.
+                passed_userinfo = mock_create_user.call_args.args[0]
+                self.assertEqual(passed_userinfo.get("roles"), ["admin"])
+                # userinfo endpoint values are preserved.
+                self.assertEqual(passed_userinfo.get("email"), "test@example.com")
+
     @patch("gramps_webapi.api.resources.oidc.get_tokens")
     def test_oidc_callback_success(
         self,

--- a/tests/test_endpoints/test_oidc.py
+++ b/tests/test_endpoints/test_oidc.py
@@ -224,9 +224,15 @@ class TestOIDCEndpoints(unittest.TestCase):
             "name": "Test User",
         }
         # ...but the ID token (parsed by Authlib into token["userinfo"]) has it.
+        # It also carries a conflicting email to prove the userinfo endpoint
+        # value takes precedence over the ID-token claim.
         mock_token = {
             "access_token": "test_token",
-            "userinfo": {"sub": "user123", "roles": ["admin"]},
+            "userinfo": {
+                "sub": "user123",
+                "roles": ["admin"],
+                "email": "idtoken@example.com",
+            },
         }
         mock_oidc_client.authorize_access_token.return_value = mock_token
         mock_oidc_client.userinfo.return_value = mock_userinfo
@@ -256,7 +262,8 @@ class TestOIDCEndpoints(unittest.TestCase):
                 # roles claim that only existed in the ID token.
                 passed_userinfo = mock_create_user.call_args.args[0]
                 self.assertEqual(passed_userinfo.get("roles"), ["admin"])
-                # userinfo endpoint values are preserved.
+                # userinfo endpoint values take precedence over a conflicting
+                # ID-token claim (endpoint email wins, not idtoken@example.com).
                 self.assertEqual(passed_userinfo.get("email"), "test@example.com")
 
     @patch("gramps_webapi.api.resources.oidc.is_oidc_enabled", return_value=True)

--- a/tests/test_endpoints/test_oidc.py
+++ b/tests/test_endpoints/test_oidc.py
@@ -194,16 +194,6 @@ class TestOIDCEndpoints(unittest.TestCase):
     @patch("gramps_webapi.api.resources.oidc.get_tree_id")
     @patch("gramps_webapi.api.resources.oidc.get_permissions")
     @patch("gramps_webapi.api.resources.oidc.is_tree_disabled", return_value=False)
-    @patch("gramps_webapi.api.resources.oidc.is_oidc_enabled", return_value=True)
-    @patch(
-        "gramps_webapi.api.resources.oidc.get_available_oidc_providers",
-        return_value=["custom"],
-    )
-    @patch("gramps_webapi.api.resources.oidc.create_or_update_oidc_user")
-    @patch("gramps_webapi.api.resources.oidc.get_name")
-    @patch("gramps_webapi.api.resources.oidc.get_tree_id")
-    @patch("gramps_webapi.api.resources.oidc.get_permissions")
-    @patch("gramps_webapi.api.resources.oidc.is_tree_disabled", return_value=False)
     @patch("gramps_webapi.api.resources.oidc.get_tokens")
     def test_oidc_callback_merges_id_token_claims(
         self,
@@ -269,6 +259,16 @@ class TestOIDCEndpoints(unittest.TestCase):
                 # userinfo endpoint values are preserved.
                 self.assertEqual(passed_userinfo.get("email"), "test@example.com")
 
+    @patch("gramps_webapi.api.resources.oidc.is_oidc_enabled", return_value=True)
+    @patch(
+        "gramps_webapi.api.resources.oidc.get_available_oidc_providers",
+        return_value=["custom"],
+    )
+    @patch("gramps_webapi.api.resources.oidc.create_or_update_oidc_user")
+    @patch("gramps_webapi.api.resources.oidc.get_name")
+    @patch("gramps_webapi.api.resources.oidc.get_tree_id")
+    @patch("gramps_webapi.api.resources.oidc.get_permissions")
+    @patch("gramps_webapi.api.resources.oidc.is_tree_disabled", return_value=False)
     @patch("gramps_webapi.api.resources.oidc.get_tokens")
     def test_oidc_callback_success(
         self,


### PR DESCRIPTION
## Problem

For standard OIDC providers, `OIDCCallbackResource` reads user claims from the
userinfo endpoint (`oidc_client.userinfo(token=token)`). Some providers —
notably **Microsoft Entra ID** — return authorization claims such as app roles
(`roles`) and group memberships (`groups`) **only in the ID token**, never from
the userinfo endpoint.

Because `get_role_from_claims` (driven by `OIDC_ROLE_CLAIM` / `OIDC_GROUP_*`)
only sees the userinfo response, those claims are invisible, so it returns
`ROLE_DISABLED`. Since role mapping runs on every login, an Entra user with an
assigned app role is repeatedly forced to the disabled role and can never be
auto-assigned — they're stuck at "account created, an administrator will review
it."

## Fix

Merge the ID token's claims (Authlib's already-validated `token["userinfo"]`)
into the userinfo dict, filling only claims the userinfo endpoint did not
return (userinfo values take precedence). Role/group mapping then works
consistently across providers, and providers that already return these claims
from userinfo are unaffected.

## Test

Adds `test_oidc_callback_merges_id_token_claims`: a `roles` claim present only
in the ID token reaches user creation, while userinfo-endpoint values are
preserved.

## Notes

- Backwards compatible: when the ID token carries no extra claims (or the
  provider already returns them from userinfo), behavior is unchanged.
- Verified `py_compile` and `black`; I was unable to run the full test suite
  locally (heavy `gramps` / PyGObject native deps), so relying on CI for the
  complete run.
