### PR TITLE
Initialise new trees when they are created

### DIFF
--- a/gramps_webapi/dbmanager.py
+++ b/gramps_webapi/dbmanager.py
@@ -76,8 +76,11 @@ class WebDbManager:
         self.create_if_missing = create_if_missing
         self.create_backend = create_backend
         self.ignore_lock = ignore_lock
+        self._created = False  # set by _create() via _get_path()
         self.path = self._get_path()
         self._check_backend()
+        if self._created:
+            self._initialize_db()
 
     @property
     def dbdir(self) -> str:
@@ -138,18 +141,19 @@ class WebDbManager:
             raise ValueError("Cannot create database if name not specified.")
         os.mkdir(path)
 
+        # create database
+        make_database(self.create_backend)
+
+        # create dbid file before the name file, which is what makes the tree
+        # discoverable: without it, get_dbid_from_path falls back to 'bsddb'
+        backend_path = os.path.join(path, DBBACKEND)
+        with open(backend_path, "w", encoding="utf8") as backend_file:
+            backend_file.write(self.create_backend)
+
         # create name file
         path_name = os.path.join(path, NAME_FILE)
         with open(path_name, "w", encoding="utf8") as name_file:
             name_file.write(self.name)
-
-        # create database
-        make_database(self.create_backend)
-
-        # create dbid file
-        backend_path = os.path.join(path, DBBACKEND)
-        with open(backend_path, "w", encoding="utf8") as backend_file:
-            backend_file.write(self.create_backend)
 
         # cache the name written to disk so get_db() doesn't re-read name.txt
         self._name_from_file = self.name
@@ -160,6 +164,19 @@ class WebDbManager:
         except OSError:
             backend_mtime = 0
         _backend_cache[path] = (backend_mtime, self.create_backend)
+        self._created = True
+
+    def _initialize_db(self) -> None:
+        """Create the database schema and metadata of a newly created tree."""
+        # Gramps does this on the first load() of the tree instead, where
+        # concurrent workers race and can leave the metadata half-written,
+        # which breaks the tree permanently.  Here there is no concurrency yet.
+        dbstate = self.get_db(readonly=False)
+        try:
+            # closing a writable database rewrites all metadata
+            dbstate.db.close()
+        finally:
+            dbstate.db.undodb.close()
 
     def _check_backend(self) -> None:
         """Check that the backend is among the allowed backends."""

--- a/gramps_webapi/dbmanager.py
+++ b/gramps_webapi/dbmanager.py
@@ -81,6 +81,7 @@ class WebDbManager:
         self._check_backend()
         if self._created:
             self._initialize_db()
+            self._publish()
 
     @property
     def dbdir(self) -> str:
@@ -144,21 +145,14 @@ class WebDbManager:
         # create database
         make_database(self.create_backend)
 
-        # create dbid file before the name file, which is what makes the tree
-        # discoverable: without it, get_dbid_from_path falls back to 'bsddb'
+        # create dbid file.  The name file is deliberately not written here:
+        # it is what makes the tree discoverable, and a tree must not be
+        # discoverable before its database has been initialized.
         backend_path = os.path.join(path, DBBACKEND)
         with open(backend_path, "w", encoding="utf8") as backend_file:
             backend_file.write(self.create_backend)
 
-        # create name file
-        path_name = os.path.join(path, NAME_FILE)
-        with open(path_name, "w", encoding="utf8") as name_file:
-            name_file.write(self.name)
-
-        # cache the name written to disk so get_db() doesn't re-read name.txt
-        self._name_from_file = self.name
         # populate module-level caches so subsequent requests skip disk reads
-        _name_cache[path] = self.name
         try:
             backend_mtime = os.stat(backend_path).st_mtime_ns
         except OSError:
@@ -177,6 +171,15 @@ class WebDbManager:
             dbstate.db.close()
         finally:
             dbstate.db.undodb.close()
+
+    def _publish(self) -> None:
+        """Write the name file of a newly created tree, making it discoverable."""
+        path_name = os.path.join(self.path, NAME_FILE)
+        with open(path_name, "w", encoding="utf8") as name_file:
+            name_file.write(self.name)
+        # cache the name written to disk so get_db() doesn't re-read name.txt
+        self._name_from_file = self.name
+        _name_cache[self.path] = self.name
 
     def _check_backend(self) -> None:
         """Check that the backend is among the allowed backends."""


### PR DESCRIPTION
Fixes #906. Should fix #880 for newly created trees.

Description by Claude:

## Problem

Gramps creates the schema of a new tree and writes its metadata lazily, on the
first call to `DbGeneric.load()`. Nothing serialises that across processes, and
gramps-web-api defers it: `WebDbManager._create()` writes `name.txt` and
`database.txt` but leaves the database itself to whichever request arrives
first. On a fresh installation several arrive at once — the container runs
`gunicorn -w 8` by default, plus the celery container — and they race. Note
this happens even for read-only requests, since `read_file()` loads with
`DBMODE_R` but `need_to_set_metadata` still writes.

Three failures come out of that race:

- whichever process loses the race to `_create_schema` raises
  `sqlite3.OperationalError: table person already exists`;
- the others contend for the write lock and time out with
  `sqlite3.OperationalError: database is locked`;
- a writer interrupted part-way through leaves `metadata` rows whose
  `json_data` was never filled in. Every later open of that tree then fails on
  `orjson.JSONDecodeError: Input must be bytes, bytearray, memoryview, or str`,
  permanently.

The last one dates from gramps-project/gramps@3e0e1da ("Avoid empty metadata
fields", first released in Gramps 6.0.1), which fixed #631 by writing metadata
in two passes — JSON after blob — and in doing so opened a window in which rows
exist with `json_data` still NULL.

A rarer outcome of the same race is a tree whose schema exists but whose
`version` metadata row does not. It reads fine, so the installation looks
healthy, and then every write fails with `DbUpgradeRequiredError` — surfaced as
"The Gramps database needs a schema upgrade" — because `get_schema_version()`
returns 0 when the row is missing.

## Fix

Create the database in the process that creates the tree directory. By the time
any other process can see the tree, there is nothing left to initialise, so the
race cannot start. Closing the database writable also rewrites all metadata,
which guarantees the tree is complete even if `load()` itself wrote it
partially.

`database.txt` is now written before `name.txt`. A tree is discovered by its
name file, so a concurrent process that found the tree while `database.txt` was
still missing fell back to the default `bsddb` backend and rejected it — which
in single-tree mode kills the worker during `create_app()` with
`ValueError: Database backend 'bsddb' of tree '…' not supported`.

## Evidence

Eight processes opening the same freshly created tree simultaneously, ten trees
per run:

| | open errors | trees left incomplete |
|---|---|---|
| before | 78 / 80 | 8 / 10 |
| after | **0 / 80** | **0 / 10** |

The errors before the change are 62× `database is locked` and 16×
`table person already exists`, and the incomplete trees are the permanent
`orjson.JSONDecodeError` and missing-`version` states described above.

## Scope

Two related problems are deliberately not addressed here.

**Trees that already exist but were never opened** — restored backups,
directories created by an earlier version — are still initialised on first
access and can still race. gramps-project/gramps#2383 is the fix for that; it
makes the metadata write JSON-first so no row is ever left with NULL
`json_data`. Measured on the same test, that PR alone takes corrupted trees
from 8/10 to 0/10 but leaves the open errors at 79/80, because it does not
address two processes racing into `_create_schema`. The two changes are
complementary.

**`database is locked` during a long import** is a separate cause with the same
symptom, and survives this change. With initialisation fully serialised, a
20,000-person import still fails roughly 1.5 % of concurrent read requests:
ordinary `SELECT`s in the read-only open path (`table_exists`,
`get_gender_stats`) time out after SQLite's default five-second busy timeout
while the importer holds `EXCLUSIVE` during a commit. Raising the busy timeout
only trades errors for multi-second stalls. WAL fixes it completely — in the
same test, 0 failures and 2.9× the read throughput — but it requires working
shared memory on the filesystem holding the database, so it cannot be the
default for deployments on S3-FUSE or NFS mounts. Batched commits upstream
would be the real fix.

## Note for #880 reporters

The corrupting write only runs when the schema does not yet exist, and a
corrupted tree can never be opened again, so an affected tree never held any
data. Deleting the tree directory and letting it be recreated loses nothing —
worth confirming against the `person` table row count first.
