### PR TITLE
Make ModifiedPrivateProxyDb work with shared Postgres, too

### DIFF
--- a/gramps_webapi/api/util.py
+++ b/gramps_webapi/api/util.py
@@ -55,7 +55,6 @@ from gramps.gen.db.dbconst import (
     DBBACKEND,
     EVENT_KEY,
     FAMILY_KEY,
-    KEY_TO_NAME_MAP,
     MEDIA_KEY,
     NOTE_KEY,
     PERSON_KEY,
@@ -81,7 +80,6 @@ from gramps.gen.proxy.private import (
 from gramps.gen.proxy.proxybase import ProxyDbBase
 from gramps.gen.user import UserBase
 from gramps.gen.utils.grampslocale import GrampsLocale
-from gramps.plugins.db.dbapi.dbapi import DBAPI
 from marshmallow import RAISE
 from webargs.flaskparser import FlaskParser
 from werkzeug.exceptions import HTTPException
@@ -133,7 +131,6 @@ class ModifiedPrivateProxyDb(PrivateProxyDb):
         """Initialize self."""
         super().__init__(*args, **kwargs)
         self.name_formats = self.db.name_formats
-        self.is_dbapi = isinstance(self.basedb, DBAPI)
 
     def get_dbname(self):
         """Get the name of the database."""
@@ -180,95 +177,77 @@ class ModifiedPrivateProxyDb(PrivateProxyDb):
 
     def _iter_handles(self, obj_key):
         """
-        Return an iterator over handles in the database
+        Return an iterator over the handles of all non-private objects.
         """
-        table = KEY_TO_NAME_MAP[obj_key]
-        sql = "SELECT handle FROM %s WHERE private=0" % table
-        self.basedb.dbapi.execute(sql)
-        rows = self.basedb.dbapi.fetchall()
-        for row in rows:
-            yield row[0]
+        # faster than the include_* predicates, which instantiate every object.
+        # _iter_raw_data is implemented by every backend, so no assumptions
+        # about the storage schema (or the tree scoping) are needed here.
+        for handle, data in self.basedb._iter_raw_data(obj_key):
+            if not data.private:
+                yield handle
 
     def iter_person_handles(self):
         """
         Return an iterator over database handles, one handle for each Person in
         the database.
         """
-        if self.is_dbapi:
-            return self._iter_handles(PERSON_KEY)
-        return filter(self.include_person, self.db.iter_person_handles())
+        return self._iter_handles(PERSON_KEY)
 
     def iter_family_handles(self):
         """
         Return an iterator over database handles, one handle for each Family in
         the database.
         """
-        if self.is_dbapi:
-            return self._iter_handles(FAMILY_KEY)
-        return filter(self.include_family, self.db.iter_family_handles())
+        return self._iter_handles(FAMILY_KEY)
 
     def iter_event_handles(self):
         """
         Return an iterator over database handles, one handle for each Event in
         the database.
         """
-        if self.is_dbapi:
-            return self._iter_handles(EVENT_KEY)
-        return filter(self.include_event, self.db.iter_event_handles())
+        return self._iter_handles(EVENT_KEY)
 
     def iter_source_handles(self):
         """
         Return an iterator over database handles, one handle for each Source in
         the database.
         """
-        if self.is_dbapi:
-            return self._iter_handles(SOURCE_KEY)
-        return filter(self.include_source, self.db.iter_source_handles())
+        return self._iter_handles(SOURCE_KEY)
 
     def iter_citation_handles(self):
         """
         Return an iterator over database handles, one handle for each Citation
         in the database.
         """
-        if self.is_dbapi:
-            return self._iter_handles(CITATION_KEY)
-        return filter(self.include_citation, self.db.iter_citation_handles())
+        return self._iter_handles(CITATION_KEY)
 
     def iter_place_handles(self):
         """
         Return an iterator over database handles, one handle for each Place in
         the database.
         """
-        if self.is_dbapi:
-            return self._iter_handles(PLACE_KEY)
-        return filter(self.include_place, self.db.iter_place_handles())
+        return self._iter_handles(PLACE_KEY)
 
     def iter_media_handles(self):
         """
         Return an iterator over database handles, one handle for each Media
         Object in the database.
         """
-        if self.is_dbapi:
-            return self._iter_handles(MEDIA_KEY)
-        return filter(self.include_media, self.db.iter_media_handles())
+        return self._iter_handles(MEDIA_KEY)
 
     def iter_repository_handles(self):
         """
         Return an iterator over database handles, one handle for each
         Repository in the database.
         """
-        if self.is_dbapi:
-            return self._iter_handles(REPOSITORY_KEY)
-        return filter(self.include_repository, self.db.iter_repository_handles())
+        return self._iter_handles(REPOSITORY_KEY)
 
     def iter_note_handles(self):
         """
         Return an iterator over database handles, one handle for each Note in
         the database.
         """
-        if self.is_dbapi:
-            return self._iter_handles(NOTE_KEY)
-        return filter(self.include_note, self.db.iter_note_handles())
+        return self._iter_handles(NOTE_KEY)
 
     def iter_people(self):
         """Return an iterator over Person objects, filtered and sanitized."""

--- a/tests/test_private_proxy.py
+++ b/tests/test_private_proxy.py
@@ -316,3 +316,47 @@ def test_iter_notes_includes_public_note(db_handles, proxy):
     _db, handles = db_handles
     note_handles = {n.handle for n in proxy.iter_notes()}
     assert handles["public_note"] in note_handles
+
+
+# ---------------------------------------------------------------------------
+# iter_*_handles
+# ---------------------------------------------------------------------------
+
+ITER_HANDLE_METHODS = [
+    ("iter_person_handles", "include_person"),
+    ("iter_family_handles", "include_family"),
+    ("iter_event_handles", "include_event"),
+    ("iter_source_handles", "include_source"),
+    ("iter_citation_handles", "include_citation"),
+    ("iter_place_handles", "include_place"),
+    ("iter_media_handles", "include_media"),
+    ("iter_repository_handles", "include_repository"),
+    ("iter_note_handles", "include_note"),
+]
+
+
+@pytest.mark.parametrize("method,predicate", ITER_HANDLE_METHODS)
+def test_iter_handles_agrees_with_include_predicate(
+    db_handles, proxy, method, predicate
+):
+    """The raw data based fast path must agree with the stock include_* filtering."""
+    db, _handles = db_handles
+    assert set(getattr(proxy, method)()) == set(
+        filter(getattr(proxy, predicate), getattr(db, method)())
+    )
+
+
+def test_iter_note_handles_excludes_private_note(db_handles, proxy):
+    """Private note must be absent from, public note present in iter_note_handles()."""
+    _db, handles = db_handles
+    note_handles = set(proxy.iter_note_handles())
+    assert handles["private_note"] not in note_handles
+    assert handles["public_note"] in note_handles
+
+
+def test_iter_event_handles_excludes_private_event(db_handles, proxy):
+    """Private event must be absent from, public event present in iter_event_handles()."""
+    _db, handles = db_handles
+    event_handles = set(proxy.iter_event_handles())
+    assert handles["private_event"] not in event_handles
+    assert handles["public_event"] in event_handles


### PR DESCRIPTION
See https://github.com/gramps-project/gramps-web-api/pull/911 for the issue this would solve.

@dsblank here is a version that would not require scary raw SQL queries to make `ModifiedPrivateProxyDb` work with SharedPostgreSQL. It's around 8 times slower than the existing version on normal `DBAPI` backends, but still ~5 times faster than the "slow" version.

Honestly, I think a really fast and simple iterator over non-private database handles would be the addition of something like a 3-line method in Gramps core, this would be the much safer long term option.

What do you think?