### PR TITLE
Fast, structured POST .../query/ endpoints for every object type

### DIFF
--- a/gramps_webapi/api/__init__.py
+++ b/gramps_webapi/api/__init__.py
@@ -2,6 +2,7 @@
 # Gramps Web API - A RESTful API for the Gramps genealogy program
 #
 # Copyright (C) 2020-2026      David Straub
+# Copyright (C) 2026           Douglas Blank
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as published by
@@ -26,15 +27,16 @@ from webargs import fields, validate
 
 from ..const import API_PREFIX
 from .auth import jwt_required
+from .blueprint import api_blueprint
 from .cache import thumbnail_cache_decorator, tile_cache_decorator
 from .media import get_media_handler
+from .resources.access_tokens import UserAccessTokenResource
 from .resources.base import Resource
 from .resources.bookmarks import (
     BookmarkEditResource,
     BookmarkResource,
     BookmarksResource,
 )
-from .resources.access_tokens import UserAccessTokenResource
 from .resources.chat import ChatResource
 from .resources.citations import CitationResource, CitationsResource
 from .resources.config import ConfigResource, ConfigsResource
@@ -54,8 +56,8 @@ from .resources.file import MediaFileResource
 from .resources.filters import FilterResource, FiltersResource, FiltersResources
 from .resources.history import (
     TransactionHistoryResource,
-    TransactionUndoResource,
     TransactionsHistoryResource,
+    TransactionUndoResource,
 )
 from .resources.holidays import HolidayResource, HolidaysResource
 from .resources.import_media import MediaUploadZipResource
@@ -67,9 +69,6 @@ from .resources.importers import (
 )
 from .resources.living import LivingDatesResource, LivingResource
 from .resources.media import MediaObjectResource, MediaObjectsResource
-from .resources.metadata import MetadataResource, MetadataResearcherResource
-from .resources.name_formats import NameFormatsResource
-from .resources.name_groups import NameGroupsResource
 from .resources.merge import (
     MergeCitationResource,
     MergeEventResource,
@@ -81,13 +80,35 @@ from .resources.merge import (
     MergeRepositoryResource,
     MergeSourceResource,
 )
+from .resources.metadata import MetadataResearcherResource, MetadataResource
+from .resources.name_formats import NameFormatsResource
+from .resources.name_groups import NameGroupsResource
 from .resources.notes import NoteResource, NotesResource
+from .resources.object_query import (
+    CitationQueryResource,
+    EventQueryResource,
+    FamilyQueryResource,
+    MediaQueryResource,
+    NoteQueryResource,
+    PersonQueryResource,
+    PlaceQueryResource,
+    RepositoryQueryResource,
+    SourceQueryResource,
+    TagQueryResource,
+)
 from .resources.objects import (
     CreateObjectsResource,
     DeleteObjectsByHandleResource,
     DeleteObjectsResource,
 )
 from .resources.ocr import MediaOcrResource
+from .resources.oidc import (
+    OIDCCallbackResource,
+    OIDCConfigResource,
+    OIDCLoginResource,
+    OIDCLogoutResource,
+    OIDCTokenExchangeResource,
+)
 from .resources.people import PeopleResource, PersonResource
 from .resources.places import PlaceResource, PlacesResource
 from .resources.relations import RelationResource, RelationsResource
@@ -112,13 +133,6 @@ from .resources.token import (
     TokenCreateOwnerResource,
     TokenRefreshResource,
     TokenResource,
-)
-from .resources.oidc import (
-    OIDCCallbackResource,
-    OIDCConfigResource,
-    OIDCLoginResource,
-    OIDCLogoutResource,
-    OIDCTokenExchangeResource,
 )
 from .resources.transactions import TransactionsResource
 from .resources.translations import TranslationResource, TranslationsResource
@@ -149,9 +163,8 @@ from .resources.user import (
     UsersResource,
     UserTriggerResetPasswordResource,
 )
-from .resources.ydna import PersonYDnaResource
 from .resources.verify import VerifyResource
-from .blueprint import api_blueprint
+from .resources.ydna import PersonYDnaResource
 from .util import abort_with_message, get_db_handle, get_tree_from_jwt, parser, use_args
 
 
@@ -253,6 +266,7 @@ register_endpt(
     PersonYDnaResource, "/people/<string:handle>/ydna", "person-ydna", tags=["DNA"]
 )
 register_endpt(PeopleResource, "/people/", "people", tags=["People"])
+register_endpt(PersonQueryResource, "/people/query/", "people-query", tags=["People"])
 register_endpt(
     MergePersonResource,
     "/people/<string:phoenix_handle>/merge/<string:titanic_handle>",
@@ -269,6 +283,9 @@ register_endpt(
 register_endpt(FamilyResource, "/families/<string:handle>", "family", tags=["Families"])
 register_endpt(FamiliesResource, "/families/", "families", tags=["Families"])
 register_endpt(
+    FamilyQueryResource, "/families/query/", "families-query", tags=["Families"]
+)
+register_endpt(
     MergeFamilyResource,
     "/families/<string:phoenix_handle>/merge/<string:titanic_handle>",
     "merge-family",
@@ -283,6 +300,7 @@ register_endpt(
 )
 register_endpt(EventResource, "/events/<string:handle>", "event", tags=["Events"])
 register_endpt(EventsResource, "/events/", "events", tags=["Events"])
+register_endpt(EventQueryResource, "/events/query/", "events-query", tags=["Events"])
 register_endpt(
     MergeEventResource,
     "/events/<string:phoenix_handle>/merge/<string:titanic_handle>",
@@ -302,6 +320,7 @@ register_endpt(
 # Places
 register_endpt(PlaceResource, "/places/<string:handle>", "place", tags=["Places"])
 register_endpt(PlacesResource, "/places/", "places", tags=["Places"])
+register_endpt(PlaceQueryResource, "/places/query/", "places-query", tags=["Places"])
 register_endpt(
     MergePlaceResource,
     "/places/<string:phoenix_handle>/merge/<string:titanic_handle>",
@@ -314,6 +333,9 @@ register_endpt(
 )
 register_endpt(CitationsResource, "/citations/", "citations", tags=["Citations"])
 register_endpt(
+    CitationQueryResource, "/citations/query/", "citations-query", tags=["Citations"]
+)
+register_endpt(
     MergeCitationResource,
     "/citations/<string:phoenix_handle>/merge/<string:titanic_handle>",
     "merge-citation",
@@ -322,6 +344,9 @@ register_endpt(
 # Sources
 register_endpt(SourceResource, "/sources/<string:handle>", "source", tags=["Sources"])
 register_endpt(SourcesResource, "/sources/", "sources", tags=["Sources"])
+register_endpt(
+    SourceQueryResource, "/sources/query/", "sources-query", tags=["Sources"]
+)
 register_endpt(
     MergeSourceResource,
     "/sources/<string:phoenix_handle>/merge/<string:titanic_handle>",
@@ -339,6 +364,12 @@ register_endpt(
     RepositoriesResource, "/repositories/", "repositories", tags=["Repositories"]
 )
 register_endpt(
+    RepositoryQueryResource,
+    "/repositories/query/",
+    "repositories-query",
+    tags=["Repositories"],
+)
+register_endpt(
     MergeRepositoryResource,
     "/repositories/<string:phoenix_handle>/merge/<string:titanic_handle>",
     "merge-repository",
@@ -349,6 +380,7 @@ register_endpt(
     MediaObjectResource, "/media/<string:handle>", "media_object", tags=["Media"]
 )
 register_endpt(MediaObjectsResource, "/media/", "media_objects", tags=["Media"])
+register_endpt(MediaQueryResource, "/media/query/", "media-query", tags=["Media"])
 register_endpt(
     MergeMediaResource,
     "/media/<string:phoenix_handle>/merge/<string:titanic_handle>",
@@ -358,6 +390,7 @@ register_endpt(
 # Notes
 register_endpt(NoteResource, "/notes/<string:handle>", "note", tags=["Notes"])
 register_endpt(NotesResource, "/notes/", "notes", tags=["Notes"])
+register_endpt(NoteQueryResource, "/notes/query/", "notes-query", tags=["Notes"])
 register_endpt(
     MergeNoteResource,
     "/notes/<string:phoenix_handle>/merge/<string:titanic_handle>",
@@ -367,6 +400,7 @@ register_endpt(
 # Tags
 register_endpt(TagResource, "/tags/<string:handle>", "tag", tags=["Tags"])
 register_endpt(TagsResource, "/tags/", "tags", tags=["Tags"])
+register_endpt(TagQueryResource, "/tags/query/", "tags-query", tags=["Tags"])
 # Trees
 register_endpt(TreeResource, "/trees/<string:tree_id>", "tree", tags=["Trees"])
 register_endpt(TreesResource, "/trees/", "trees", tags=["Trees"])

--- a/gramps_webapi/api/resources/object_query.py
+++ b/gramps_webapi/api/resources/object_query.py
@@ -35,18 +35,14 @@ the same pattern `GrampsObjectResourceHelper` subclasses already use with
 """
 
 import json
-from typing import Any, Callable, Optional, Sequence, Tuple, Union, cast
+from typing import Any, Optional, Sequence, Tuple, Union, cast
 
 from gramps.gen.proxy.proxybase import ProxyDbBase
 from gramps.plugins.db.dbapi.sqlite import SQLite
 from marshmallow import Schema, validate
 from webargs import fields as wf
 
-from gramps_object_query_language.evaluator import (
-    GETTER_BY_TABLE,
-    get_flat_column,
-    resolve_column_ref,
-)
+from gramps_object_query_language.evaluator import GETTER_BY_TABLE, resolve_column_ref
 from gramps_object_query_language.proxied_query import run_query
 from gramps_object_query_language.query import (
     CITATION,
@@ -337,32 +333,6 @@ def _check_no_duplicate_keys(parsed_select: Sequence[Tuple[SelectRef, str]]) -> 
         seen.add(key)
 
 
-def _sort_key(value: Any) -> Tuple[bool, Any]:
-    """Sort key treating `None` (missing/masked) as sorting first in
-    ascending order -- `(False, ...) < (True, ...)` regardless of `value`'s
-    own type, and two `None`s compare equal without ever needing `value`
-    itself to support `<` against `None`. Used only by `_post_proxied`;
-    the SQL path's `ORDER BY` has its own (backend-native) NULL ordering.
-    """
-    return (value is not None, value)
-
-
-def _sort_key_for_column(
-    column: str, spec: ObjectTypeSpec
-) -> Callable[[Any], Tuple[bool, Any]]:
-    """A `list.sort(key=...)` callable for `column`, bound via closure rather
-    than a lambda's default-argument trick -- mypy can't infer the type of a
-    `lambda obj, c=column: ...` used as a sort key ("Cannot infer type of
-    lambda"), since the extra defaulted parameter breaks its unification
-    with `list.sort`'s expected single-argument callable.
-    """
-
-    def key(obj: Any) -> Tuple[bool, Any]:
-        return _sort_key(get_flat_column(obj, column, spec))
-
-    return key
-
-
 def _terminal_is_json_path(ref: ColumnRef) -> bool:
     """Does `ref` ultimately extract via a `JsonPath` (as opposed to a
     plain flat column)? Recurses through a `RelatedObject` chain to its
@@ -508,6 +478,28 @@ def _resolve_after(
     if row is None:
         abort_with_message(422, "Invalid 'after' cursor")
     return tuple(row)
+
+
+def _resolve_after_proxied(
+    db: Any, spec: ObjectTypeSpec, order_by: Sequence[OrderBy], after_handle: str
+) -> Tuple[Any, ...]:
+    """`_resolve_after`'s evaluator-path counterpart: resolves a client-
+    supplied `after=<handle>` cursor into the same value-tuple shape
+    (`after_columns(order_by)`), but by fetching the real (possibly
+    proxied) object through `db` and reading its columns via
+    `resolve_column_ref`, rather than a raw SQL lookup -- so a masked/
+    sanitized value is used the same way it would be for any other row
+    `run_query` evaluates, consistent with this path never running a
+    second, unproxied query behind the caller's back.
+    """
+    getter = getattr(db, GETTER_BY_TABLE[spec.table])
+    after_obj = getter(after_handle)
+    if after_obj is None:
+        abort_with_message(422, "Invalid 'after' cursor")
+    return tuple(
+        resolve_column_ref(db, after_obj, column, spec)
+        for column in after_columns(order_by)
+    )
 
 
 def _resolve_collation(basedb: Any, locale: Any) -> Optional[str]:
@@ -728,19 +720,18 @@ class ObjectQueryResource(ProtectedResource):
 
     def _post_proxied(self, db: Any, args: dict) -> Any:
         """Same request/response contract as `_post_sql`, but for a proxied
-        `db` -- runs through Gramps' own `Filter`/`Rule` machinery
-        (`proxied_query.run_query`) instead of SQL. Every candidate is
-        deserialized and tested in Python (no SQL push-down, no keyset
-        narrowing before that happens), so this is intentionally not fast --
-        see `proxied_query.py`'s module docstring.
+        `db` -- delegates directly to `proxied_query.run_query`'s own
+        `order_by`/`limit`/`after`/`select` support rather than
+        reimplementing sort/seek/limit here: every candidate is still
+        deserialized and tested in Python (no SQL push-down), so this is
+        intentionally not fast -- see `proxied_query.py`'s module docstring.
 
         `order_by` is only ever a flat top-level column (`OrderBy.column`
-        never carries a `JsonPath`/`RelatedObject` -- see `query.py`), so
-        sorting real objects here needs only `evaluator.get_flat_column`,
-        never the full `resolve_column_ref` recursion `select` needs.
-        Locale-aware `COLLATE` sorting (the SQL path's `locale` param) has
-        no equivalent here yet -- this path always sorts in plain Python
-        `<` order, regardless of `locale`.
+        never carries a `JsonPath`/`RelatedObject` -- see `query.py`),
+        matching `run_query`'s own scope cap. Locale-aware `COLLATE`
+        sorting (the SQL path's `locale` param) has no equivalent here --
+        `run_query` always sorts in plain, NULL-safe Python `<` order
+        (matching SQLite's own default), regardless of `locale`.
         """
         order_by = [
             OrderBy(item["column"], item.get("direction", "asc"))
@@ -765,52 +756,34 @@ class ObjectQueryResource(ProtectedResource):
             fetch_keys = fetch_keys + ["handle"]
         requested_keys = {key for _, key in parsed_select}
 
-        matches = run_query(db, self.spec, where)
-
-        sort_columns = after_columns(order_by)  # tie-broken with 'handle'
-        directions = {ob.column: ob.direction for ob in order_by}
-        for column in reversed(sort_columns):
-            matches.sort(
-                key=_sort_key_for_column(column, self.spec),
-                reverse=directions.get(column, "asc") == "desc",
-            )
-
-        total_count = len(matches)
-
-        start = 0
+        after = None
         if args.get("after"):
-            getter = getattr(db, GETTER_BY_TABLE[self.spec.table])
-            after_obj = getter(args["after"])
-            if after_obj is None:
-                abort_with_message(422, "Invalid 'after' cursor")
-            for index, obj in enumerate(matches):
-                if obj.handle == after_obj.handle:
-                    start = index + 1
-                    break
-            else:
-                # The cursor handle exists (through `db`) but isn't a member
-                # of this exact `matches` set -- e.g. `where` narrowed since
-                # the cursor was issued. Same "invalid" outcome as a handle
-                # that doesn't resolve at all; a stale cursor isn't a
-                # resumable position either way.
-                abort_with_message(422, "Invalid 'after' cursor")
+            after = _resolve_after_proxied(db, self.spec, order_by, args["after"])
 
-        limit = args["limit"]
-        page = matches[start : start + limit]
-        next_after = page[-1].handle if len(page) == limit else None
+        rows = run_query(
+            db,
+            self.spec,
+            where,
+            order_by=order_by,
+            limit=args["limit"],
+            after=after,
+            select=fetch_refs,
+        )
 
         headers = {}
         if args["count"]:
-            headers["X-Total-Count"] = str(total_count)
+            # `limit`/`after` narrow `rows` to one page; the total needs
+            # every `where`-match independent of both -- same "costs a
+            # second query, opt-in" tradeoff `_post_sql` already makes for
+            # its own `count_sql`, not a new cost this path introduces.
+            headers["X-Total-Count"] = str(len(run_query(db, self.spec, where)))
 
+        handle_index = fetch_refs.index("handle")
         items = [
-            {
-                key: resolve_column_ref(db, obj, ref, self.spec)
-                for ref, key in zip(fetch_refs, fetch_keys)
-                if key in requested_keys
-            }
-            for obj in page
+            {key: val for key, val in zip(fetch_keys, row) if key in requested_keys}
+            for row in rows
         ]
+        next_after = rows[-1][handle_index] if len(rows) == args["limit"] else None
 
         return {"items": items, "next_after": next_after}, 200, headers
 

--- a/gramps_webapi/api/resources/object_query.py
+++ b/gramps_webapi/api/resources/object_query.py
@@ -1,0 +1,788 @@
+#
+# Gramps Web API - A RESTful API for the Gramps genealogy program
+#
+# Copyright (C) 2026      Douglas Blank
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+#
+
+"""Structured query endpoints, one per object type.
+
+Two execution paths, dispatched on whether `get_db_handle()` returns a
+proxy (`ObjectQueryResource.post`): unproxied requests get `query.py`'s
+fast, SQL-pushed-down compiler (`_post_sql`); proxied requests run through
+Gramps' own `Filter`/`Rule` machinery instead (`_post_proxied`, see
+`proxied_query.py`) so privacy (or any other proxy-applied rule, current or
+future) comes from the proxy itself rather than a second, SQL-side
+reimplementation of it. Both share the same request/response shape.
+
+`Person` was the first type wired up; every other type shares the exact same
+wiring (`ObjectQueryResource`), differing only in which
+`query.ObjectTypeSpec` a subclass binds to via its `spec` class attribute --
+the same pattern `GrampsObjectResourceHelper` subclasses already use with
+`gramps_class_name` (see `resources/people.py`/`families.py`).
+"""
+
+import json
+from typing import Any, Optional, Sequence, Tuple
+
+from gramps.gen.proxy.proxybase import ProxyDbBase
+from gramps.plugins.db.dbapi.sqlite import SQLite
+from marshmallow import Schema, validate
+from webargs import fields as wf
+
+from gramps_object_query_language.evaluator import (
+    GETTER_BY_TABLE,
+    get_flat_column,
+    resolve_column_ref,
+)
+from gramps_object_query_language.proxied_query import run_query
+from gramps_object_query_language.query import (
+    CITATION,
+    EVENT,
+    FAMILY,
+    MEDIA,
+    NOTE,
+    PERSON,
+    PLACE,
+    REPOSITORY,
+    SOURCE,
+    TAG,
+    And,
+    ColumnRef,
+    Dialect,
+    Eq,
+    Gt,
+    Gte,
+    In,
+    JsonPath,
+    Like,
+    Lt,
+    Lte,
+    Ne,
+    ObjectTypeSpec,
+    OrderBy,
+    Query,
+    QueryError,
+    RelatedObject,
+    SelectRef,
+    after_columns,
+    check_columns,
+    compile_count_query,
+    compile_query,
+    resolve_column_path,
+)
+from gramps_object_query_language.query_lang import QueryLangError, parse_expr_for_spec
+
+from ..blueprint import api_blueprint
+from ..util import abort_with_message, get_db_handle, get_locale_for_language
+from . import ProtectedResource
+from .schemas import ObjectQueryResponseSchema
+
+_OP_TO_EXPR = {
+    "eq": Eq,
+    "ne": Ne,
+    "lt": Lt,
+    "lte": Lte,
+    "gt": Gt,
+    "gte": Gte,
+    "like": Like,
+}
+
+
+class QueryWhereConditionArgs(Schema):
+    """A single WHERE leaf condition."""
+
+    column = wf.Raw(
+        required=True,
+        metadata={
+            "description": "Column to compare: either a plain column name (e.g. "
+            "'gramps_id'), or {'json_path': [...]} for a path, e.g. "
+            "{'json_path': ['primary_name', 'first_name']}. A path may cross a "
+            "relationship (Family->Person, Person->Event, Event->Place, ...), "
+            "e.g. {'json_path': ['father', 'surname']} or "
+            "{'json_path': ['birth', 'date', 'sortval']}."
+        },
+    )
+    op = wf.Str(
+        required=True,
+        validate=validate.OneOf(list(_OP_TO_EXPR) + ["in"]),
+        metadata={
+            "description": "Comparison operator: eq, ne, lt, lte, gt, gte, like, or in."
+        },
+    )
+    value = wf.Raw(
+        required=False,
+        metadata={
+            "description": "Value to compare against. Must be a list when op is "
+            "'in'. Mutually exclusive with 'value_column'; exactly one is required."
+        },
+    )
+    value_column = wf.Raw(
+        required=False,
+        metadata={
+            "description": "Alternative to 'value': compare 'column' against "
+            "another column/path instead of a literal, e.g. families where the "
+            "mother died before the father -- column: {'json_path': ['mother', "
+            "'death', 'date', 'sortval']}, op: 'lt', value_column: {'json_path': "
+            "['father', 'death', 'date', 'sortval']}. Same shape as 'column' "
+            "(plain name or {'json_path': [...]}). Not supported for 'in'/'like'."
+        },
+    )
+
+
+class QueryOrderByArgs(Schema):
+    """A single ORDER BY column."""
+
+    column = wf.Str(required=True, metadata={"description": "Column to sort by."})
+    direction = wf.Str(
+        load_default="asc",
+        validate=validate.OneOf(["asc", "desc"]),
+        metadata={"description": "Sort direction: 'asc' or 'desc'."},
+    )
+
+
+class QueryBodyArgs(Schema):
+    """Body arguments shared by every `POST .../query/` endpoint."""
+
+    select = wf.List(
+        wf.Raw(),
+        required=False,
+        metadata={
+            "description": "Columns to return. Defaults to all available columns. "
+            "Each entry is either a plain column name, or {'json_path': [...], "
+            "'as': '<key>'} to select a path, e.g. "
+            "{'json_path': ['primary_name', 'surname_list', 0, 'surname']}. "
+            "'as' is optional; if omitted, the response key is a derived "
+            "dotted/bracket string, e.g. 'primary_name.surname_list[0].surname'. "
+            "A path may cross a relationship (Family->Person via 'father'/"
+            "'mother', Person->Event via 'birth'/'death', Event->Place via "
+            "'place'), e.g. {'json_path': ['father', 'surname']} or "
+            "{'json_path': ['birth', 'date']} (the full Date struct -- "
+            "format/calendar/modifier/quality/dateval/text/sortval -- of the "
+            "referenced event, or null if none is recorded). Not usable in "
+            "'order_by'."
+        },
+    )
+    where = wf.List(
+        wf.Nested(QueryWhereConditionArgs),
+        required=False,
+        metadata={"description": "Leaf conditions, implicitly combined with AND."},
+    )
+    where_expr = wf.Str(
+        required=False,
+        allow_none=True,
+        metadata={
+            "description": "Alternative to `where`: an \"almost Python\" expression, "
+            "e.g. \"gender == 1 and primary_name.surname_list[0].surname == 'Smith'\". "
+            "See `query_lang.py`. Mutually exclusive with `where` -- a request "
+            "setting both is rejected."
+        },
+    )
+    order_by = wf.List(
+        wf.Nested(QueryOrderByArgs),
+        required=False,
+        metadata={"description": "Sort order, most significant column first."},
+    )
+    limit = wf.Int(
+        load_default=50,
+        validate=validate.Range(min=1, max=1000),
+        metadata={"description": "Maximum number of rows to return."},
+    )
+    after = wf.Str(
+        required=False,
+        allow_none=True,
+        metadata={
+            "description": "Cursor from a previous response's `next_after`, for "
+            "keyset pagination. Omit for the first page."
+        },
+    )
+    locale = wf.Str(
+        load_default=None,
+        validate=validate.Length(min=1, max=5),
+        metadata={
+            "description": "Language code for locale-aware sorting of text columns "
+            "(e.g. 'de', 'fr'). Affects ORDER BY only, not filtering."
+        },
+    )
+    count = wf.Boolean(
+        load_default=False,
+        metadata={
+            "description": "If true, also compute the total number of rows matching "
+            "`where` (and privacy), independent of `limit`/`after`, and return it "
+            "in the `X-Total-Count` response header (the same convention used "
+            "elsewhere in this API). Costs a second query, so it's opt-in."
+        },
+    )
+
+
+def _parse_column_ref(raw: Any, spec: ObjectTypeSpec) -> ColumnRef:
+    """Parse a `where` condition's `column`: a plain column name, or
+    `{"json_path": [...]}` resolved via `resolve_column_path()` -- which
+    may cross a relationship (`{"json_path": ["birth", "date", "sortval"]}`)
+    or stay a plain `JsonPath` into `json_data`, depending on whether the
+    first segment(s) name a registered relationship on `spec`. A bare
+    string is *not* run through the relationship resolver -- there's
+    nothing to disambiguate for a single segment beyond "is this a real
+    flat column", which `_render_column` already checks at compile time.
+    """
+    if isinstance(raw, str):
+        return raw
+    if isinstance(raw, dict) and "json_path" in raw:
+        segments = raw["json_path"]
+        if not isinstance(segments, list) or not segments:
+            raise QueryError("'json_path' must be a non-empty list")
+        return resolve_column_path(spec, segments)
+    raise QueryError(f"invalid column reference: {raw!r}")
+
+
+def _parse_select_entry(raw: Any, spec: ObjectTypeSpec) -> Tuple[SelectRef, str]:
+    """Parse one `select` entry into `(column_ref, response_key)`.
+
+    A plain string is both the column and its own response key. A
+    `{"json_path": [...], "as": "..."}` object resolves the path the same
+    way `_parse_column_ref` does (relationship-aware), and uses `as` as
+    the response key if given, otherwise a derived dotted/bracket path
+    (`_default_key_for`). `as: "handle"` is rejected unless the entry *is*
+    the real `handle` column -- the response's `handle` key is
+    load-bearing for the `next_after` cursor (see `post()`), so silently
+    shadowing it with unrelated content would corrupt pagination for the
+    caller without any visible error.
+    """
+    if isinstance(raw, str):
+        return raw, raw
+    if isinstance(raw, dict) and "json_path" in raw:
+        column = _parse_column_ref(raw, spec)
+        key = raw.get("as") or _default_key_for(column)
+        if key == "handle":
+            raise QueryError("'handle' is reserved as a response key")
+        return column, key
+    raise QueryError(f"invalid column reference: {raw!r}")
+
+
+def _default_key_for(ref: ColumnRef) -> str:
+    """Derive a default response key for a `select` entry with no explicit
+    `as` alias -- a dotted/bracket string, e.g. `primary_name.surname_list[0]`
+    for a plain `JsonPath`, or `birth.date.sortval` for a `RelatedObject`
+    chain (recursing through `.field` and prefixing each hop's `.name`).
+    """
+    if isinstance(ref, str):
+        return ref
+    if isinstance(ref, RelatedObject):
+        return f"{ref.name}.{_default_key_for(ref.field)}"
+    parts: list = []
+    for segment in ref.segments:
+        if isinstance(segment, int):
+            parts.append(f"[{segment}]")
+        else:
+            parts.append(f".{segment}" if parts else str(segment))
+    return "".join(parts)
+
+
+def _check_no_duplicate_keys(parsed_select: Sequence[Tuple[SelectRef, str]]) -> None:
+    seen: set = set()
+    for _, key in parsed_select:
+        if key in seen:
+            raise QueryError(f"duplicate select key: {key!r}")
+        seen.add(key)
+
+
+def _sort_key(value: Any) -> Tuple[bool, Any]:
+    """Sort key treating `None` (missing/masked) as sorting first in
+    ascending order -- `(False, ...) < (True, ...)` regardless of `value`'s
+    own type, and two `None`s compare equal without ever needing `value`
+    itself to support `<` against `None`. Used only by `_post_proxied`;
+    the SQL path's `ORDER BY` has its own (backend-native) NULL ordering.
+    """
+    return (value is not None, value)
+
+
+def _terminal_is_json_path(ref: ColumnRef) -> bool:
+    """Does `ref` ultimately extract via a `JsonPath` (as opposed to a
+    plain flat column)? Recurses through a `RelatedObject` chain to its
+    leaf `field` -- `father.surname` ends in a plain column (a real SQL
+    column on `person`, no JSON functions involved at all), `birth.date`/
+    `birth.date.sortval` end in a `JsonPath` (`json_extract`/`->` on
+    PostgreSQL, `-> `SQLite`). Used to decide which response values need
+    `_normalize_json_value`'s SQLite-string-vs-PostgreSQL-dict handling --
+    a plain column's value is never JSON-encoded, so applying that
+    normalization there could wrongly reinterpret e.g. a surname that
+    happens to look like a JSON literal (`"123"`).
+    """
+    if isinstance(ref, RelatedObject):
+        return _terminal_is_json_path(ref.field)
+    return isinstance(ref, JsonPath)
+
+
+def _normalize_json_value(value: Any) -> Any:
+    """Normalize a JSON-sourced response value to its parsed form either way.
+
+    SQLite's `json_extract()` returns a JSON *string* for object/array
+    results (scalars come back already correctly typed); PostgreSQL's
+    `jsonb` expressions come back through psycopg2 already parsed
+    (verified live against both). `None` (no such row, or it's private and
+    the caller can't view it) passes through unchanged. Only applied to
+    response values whose `ColumnRef` is `_terminal_is_json_path()` --
+    see there.
+    """
+    if isinstance(value, str):
+        try:
+            return json.loads(value)
+        except ValueError:
+            return value
+    return value
+
+
+def _build_where(conditions: Optional[Sequence[dict]], spec: ObjectTypeSpec):
+    """Build a `query.py` WHERE expression from parsed leaf conditions.
+
+    Each condition carries exactly one of `value` (a literal) or
+    `value_column` (another path, for a field-vs-field comparison, e.g.
+    "families where the mother died before the father") -- validated here
+    since webargs' per-field `required=` can't express "exactly one of
+    these two", the same reason `where`/`where_expr` mutual exclusivity is
+    checked in `_resolve_where_conditions` rather than the schema.
+    """
+    if not conditions:
+        return None
+    exprs: list[Any] = []
+    for condition in conditions:
+        column = _parse_column_ref(condition["column"], spec)
+        op = condition["op"]
+        has_value = "value" in condition
+        has_value_column = "value_column" in condition
+        if has_value == has_value_column:
+            abort_with_message(
+                422, "exactly one of 'value'/'value_column' is required"
+            )
+        if has_value_column:
+            if op in ("in", "like"):
+                abort_with_message(
+                    422, f"'value_column' is not supported for op {op!r}"
+                )
+            value = _parse_column_ref(condition["value_column"], spec)
+        else:
+            value = condition["value"]
+        if op == "in":
+            if not isinstance(value, list) or not value:
+                abort_with_message(422, "'in' operator requires a non-empty list value")
+            exprs.append(In(column, value))
+        else:
+            exprs.append(_OP_TO_EXPR[op](column, value))
+    if len(exprs) == 1:
+        return exprs[0]
+    return And(*exprs)
+
+
+def _resolve_where_conditions(
+    args: dict, spec: ObjectTypeSpec
+) -> Optional[Sequence[dict]]:
+    """Get the leaf-condition list to feed `_build_where`, from `where` or `where_expr`.
+
+    Mutually exclusive: a request setting both is rejected rather than
+    defining merge semantics nobody asked for. `where_expr` is parsed
+    directly against `spec` (`parse_expr_for_spec`, not the namespace-string
+    `parse_expr`) -- the endpoint already knows its own type from `self.spec`,
+    so asking the client to also name it via a namespace string would be
+    redundant.
+    """
+    if args.get("where") and args.get("where_expr"):
+        abort_with_message(422, "'where' and 'where_expr' are mutually exclusive")
+    if args.get("where_expr"):
+        try:
+            return parse_expr_for_spec(spec, args["where_expr"])
+        except QueryLangError as error:
+            abort_with_message(422, str(error))
+    return args.get("where")
+
+
+def _resolve_after(
+    basedb: Any,
+    spec: ObjectTypeSpec,
+    order_by: Sequence[OrderBy],
+    after_handle: str,
+    treeid: Optional[int] = None,
+):
+    """Resolve a client-supplied `after=<handle>` cursor into a value tuple.
+
+    The sort-column values for the cursor row aren't known to the client, so
+    the handle it supplies has to be looked up first. Columns were already
+    validated by the caller, so this is safe to interpolate. Only ever
+    called from `_post_sql`, which only ever runs against an unproxied
+    database -- no privacy predicate needed here (see `query.py`'s module
+    docstring).
+
+    `treeid`, when given, restricts the lookup to the caller's own tree (see
+    `_resolve_treeid`) -- without it, a handle from any other tree on a
+    shared multi-tree backend would resolve just as well, leaking that row's
+    column values (and confirming the handle's existence) across tenants
+    even though the main paginated query stays properly scoped.
+    """
+    columns = after_columns(order_by)
+    sql = f"SELECT {', '.join(columns)} FROM {spec.table} WHERE handle = ?"
+    params: list = [after_handle]
+    if treeid is not None:
+        sql += " AND treeid = ?"
+        params.append(treeid)
+    basedb.dbapi.execute(sql, params)
+    row = basedb.dbapi.fetchone()
+    if row is None:
+        abort_with_message(422, "Invalid 'after' cursor")
+    return tuple(row)
+
+
+def _resolve_collation(basedb: Any, locale: Any) -> Optional[str]:
+    """Ensure the requested locale's collation exists, returning its name.
+
+    Mirrors gramps core's own `DBAPI._collation()` (used internally for
+    `get_person_handles(sort_handles=True, locale=...)`): call the backend
+    connection's `check_collation()`, which creates the collation if needed
+    and (on SQLite) returns the sanitized name it was registered under.
+    `SharedPostgreSQL`'s `check_collation()` doesn't return a name, so fall
+    back to the locale's raw collation name in that case -- Postgres, unlike
+    SQLite, needs no sanitization for `CREATE COLLATION`.
+
+    Returns `None` (no `COLLATE` clause; default ordering) if the backend's
+    connection object has no `check_collation` at all.
+    """
+    if not hasattr(basedb.dbapi, "check_collation"):
+        return None
+    return basedb.dbapi.check_collation(locale) or locale.get_collation()
+
+
+_DIALECT_BY_NAME: dict[str, Dialect] = {
+    "sqlite": Dialect.SQLITE,
+    "postgres": Dialect.POSTGRESQL,
+    "postgresql": Dialect.POSTGRESQL,
+}
+
+
+def _resolve_dialect(basedb: Any) -> Dialect:
+    """Backend SQL dialect for rendering a `JsonPath` (see `query.py`).
+
+    Core `DBAPI`/`SQLite` and the `SharedPostgreSQL` addon don't advertise a
+    `.dialect` attribute yet (proposed but unmerged core-side,
+    gramps-project/gramps#2178); the single-user `PostgreSQL` addon already
+    does (`dialect = "postgresql"`), so that case is read straight off
+    `basedb` when present. Otherwise: `SQLite` (core-provided) is detected
+    directly -- it's what every test fixture and single-tree/dev deployment
+    actually runs, so guessing PostgreSQL for it would emit
+    `jsonb_extract_path(...)` against a real SQLite connection and fail
+    outright, not just sort wrong. Anything else (`SharedPostgreSQL`) falls
+    back to PostgreSQL, since that's the only other backend this project
+    targets today.
+    """
+    name: Optional[str] = getattr(basedb, "dialect", None)
+    if name:
+        dialect = _DIALECT_BY_NAME.get(name)
+        if dialect is not None:
+            return dialect
+    if isinstance(basedb, SQLite):
+        return Dialect.SQLITE
+    return Dialect.POSTGRESQL
+
+
+def _resolve_treeid(basedb: Any) -> Optional[int]:
+    """Current tree's integer ID, for shared multi-tree backends only.
+
+    `SharedPostgreSQL` stores every tree's rows together in the same
+    physical tables, discriminated by a `treeid` column that's part of
+    every object table's primary key. Nothing applies that filter
+    automatically at the connection/execute level -- every one of
+    `SharedDBAPI`'s own query methods (`get_person_handles`, etc.) adds
+    `WHERE treeid = ?` by hand. Any raw SQL issued directly against
+    `.dbapi`, as this compiler and `util.py`'s `_iter_handles()` both do,
+    MUST add it too, or it silently returns rows from every tree sharing
+    the instance -- not just the caller's own.
+
+    Returns `None` for single-tree-per-database backends (`SQLite`, the
+    single-user `PostgreSQL` addon), which have no `treeid` column at all
+    -- `compile_query`/`compile_count_query`/`_resolve_after` all treat
+    `None` as "omit the clause", not "unscoped is fine by default".
+    """
+    return getattr(basedb.dbapi, "treeid", None)
+
+
+class ObjectQueryResource(ProtectedResource):
+    """Paged/filtered/sorted query over one object type.
+
+    Unproxied: fast, pushed down to SQL, bypassing Gramps object
+    deserialization entirely -- rows are read directly from the database's
+    flat secondary columns (see `spec.columns`), never materialized as
+    Gramps objects. See `_post_sql`.
+
+    Proxied: slower, routed through Gramps' own `Filter`/`Rule` machinery
+    instead, so every object is deserialized and sanitized by the proxy the
+    normal way. See `_post_proxied`.
+
+    Subclasses set `spec` to one of `query.py`'s per-type `ObjectTypeSpec`
+    instances; everything else is shared.
+    """
+
+    spec: ObjectTypeSpec
+
+    @api_blueprint.response(200, ObjectQueryResponseSchema())
+    @api_blueprint.arguments(QueryBodyArgs, location="json")
+    def post(self, args: dict) -> Any:
+        """Run a structured query."""
+        db = get_db_handle(readonly=True)
+        if isinstance(db, ProxyDbBase):
+            # Privacy (and any future proxy-applied rule) comes from `db`
+            # itself here, not from a second, SQL-side reimplementation of
+            # it -- see `proxied_query.py`'s module docstring. Not fast,
+            # but correct for whatever proxy this is, current or future,
+            # with nothing in this module needing to know its rules.
+            return self._post_proxied(db, args)
+        return self._post_sql(db, args)
+
+    def _post_sql(self, basedb: Any, args: dict) -> Any:
+        """Fast, SQL-pushed-down query -- only ever called with an unproxied
+        `basedb`, so there is no privacy predicate to apply here at all.
+        """
+        if not hasattr(basedb, "dbapi"):
+            abort_with_message(
+                501, "Structured query is not supported on this database backend"
+            )
+        treeid = _resolve_treeid(basedb)
+
+        order_by = [
+            OrderBy(item["column"], item.get("direction", "asc"))
+            for item in args.get("order_by") or []
+        ]
+        try:
+            check_columns((ob.column for ob in order_by), self.spec)
+        except QueryError as error:
+            abort_with_message(422, str(error))
+
+        after = None
+        if args.get("after"):
+            after = _resolve_after(basedb, self.spec, order_by, args["after"], treeid)
+
+        # `default=False`, deliberately: falling back to the system locale
+        # here would apply COLLATE to every request, silently changing sort
+        # order for callers who never asked for locale-aware sorting.
+        # Locale-aware sorting is opt-in via an explicit `locale` param.
+        locale = get_locale_for_language(args.get("locale"), default=False)
+        collation = _resolve_collation(basedb, locale) if locale is not None else None
+
+        dialect = _resolve_dialect(basedb)
+        try:
+            parsed_select = (
+                [_parse_select_entry(item, self.spec) for item in args["select"]]
+                if args.get("select")
+                else [(col, col) for col in sorted(self.spec.columns)]
+            )
+            _check_no_duplicate_keys(parsed_select)
+            fetch_refs = [ref for ref, _ in parsed_select]
+            fetch_keys = [key for _, key in parsed_select]
+            if not any(ref == "handle" for ref in fetch_refs):
+                fetch_refs = fetch_refs + ["handle"]
+                fetch_keys = fetch_keys + ["handle"]
+            requested_keys = {key for _, key in parsed_select}
+
+            query = Query(
+                select=fetch_refs,
+                where=_build_where(_resolve_where_conditions(args, self.spec), self.spec),
+                order_by=order_by,
+                limit=args["limit"],
+                after=after,
+            )
+            sql, params = compile_query(
+                self.spec,
+                query,
+                collation=collation,
+                dialect=dialect,
+                treeid=treeid,
+            )
+            count_sql, count_params = (
+                compile_count_query(self.spec, query, dialect=dialect, treeid=treeid)
+                if args["count"]
+                else (None, None)
+            )
+        except QueryError as error:
+            abort_with_message(422, str(error))
+
+        basedb.dbapi.execute(sql, params)
+        rows = basedb.dbapi.fetchall()
+
+        headers = {}
+        if count_sql is not None:
+            basedb.dbapi.execute(count_sql, count_params)
+            headers["X-Total-Count"] = str(basedb.dbapi.fetchone()[0])
+
+        handle_index = fetch_refs.index("handle")
+        json_path_terminal_keys = {
+            key for ref, key in zip(fetch_refs, fetch_keys) if _terminal_is_json_path(ref)
+        }
+        items = [
+            {
+                key: (
+                    _normalize_json_value(val) if key in json_path_terminal_keys else val
+                )
+                for key, val in zip(fetch_keys, row)
+                if key in requested_keys
+            }
+            for row in rows
+        ]
+        next_after = rows[-1][handle_index] if len(rows) == args["limit"] else None
+
+        return {"items": items, "next_after": next_after}, 200, headers
+
+    def _post_proxied(self, db: Any, args: dict) -> Any:
+        """Same request/response contract as `_post_sql`, but for a proxied
+        `db` -- runs through Gramps' own `Filter`/`Rule` machinery
+        (`proxied_query.run_query`) instead of SQL. Every candidate is
+        deserialized and tested in Python (no SQL push-down, no keyset
+        narrowing before that happens), so this is intentionally not fast --
+        see `proxied_query.py`'s module docstring.
+
+        `order_by` is only ever a flat top-level column (`OrderBy.column`
+        never carries a `JsonPath`/`RelatedObject` -- see `query.py`), so
+        sorting real objects here needs only `evaluator.get_flat_column`,
+        never the full `resolve_column_ref` recursion `select` needs.
+        Locale-aware `COLLATE` sorting (the SQL path's `locale` param) has
+        no equivalent here yet -- this path always sorts in plain Python
+        `<` order, regardless of `locale`.
+        """
+        order_by = [
+            OrderBy(item["column"], item.get("direction", "asc"))
+            for item in args.get("order_by") or []
+        ]
+        try:
+            check_columns((ob.column for ob in order_by), self.spec)
+            where = _build_where(_resolve_where_conditions(args, self.spec), self.spec)
+            parsed_select = (
+                [_parse_select_entry(item, self.spec) for item in args["select"]]
+                if args.get("select")
+                else [(col, col) for col in sorted(self.spec.columns)]
+            )
+            _check_no_duplicate_keys(parsed_select)
+        except QueryError as error:
+            abort_with_message(422, str(error))
+
+        fetch_refs = [ref for ref, _ in parsed_select]
+        fetch_keys = [key for _, key in parsed_select]
+        if not any(ref == "handle" for ref in fetch_refs):
+            fetch_refs = fetch_refs + ["handle"]
+            fetch_keys = fetch_keys + ["handle"]
+        requested_keys = {key for _, key in parsed_select}
+
+        matches = run_query(db, self.spec, where)
+
+        sort_columns = after_columns(order_by)  # tie-broken with 'handle'
+        directions = {ob.column: ob.direction for ob in order_by}
+        for column in reversed(sort_columns):
+            matches.sort(
+                key=lambda obj, c=column: _sort_key(get_flat_column(obj, c, self.spec)),
+                reverse=directions.get(column, "asc") == "desc",
+            )
+
+        total_count = len(matches)
+
+        start = 0
+        if args.get("after"):
+            getter = getattr(db, GETTER_BY_TABLE[self.spec.table])
+            after_obj = getter(args["after"])
+            if after_obj is None:
+                abort_with_message(422, "Invalid 'after' cursor")
+            for index, obj in enumerate(matches):
+                if obj.handle == after_obj.handle:
+                    start = index + 1
+                    break
+            else:
+                # The cursor handle exists (through `db`) but isn't a member
+                # of this exact `matches` set -- e.g. `where` narrowed since
+                # the cursor was issued. Same "invalid" outcome as a handle
+                # that doesn't resolve at all; a stale cursor isn't a
+                # resumable position either way.
+                abort_with_message(422, "Invalid 'after' cursor")
+
+        limit = args["limit"]
+        page = matches[start : start + limit]
+        next_after = page[-1].handle if len(page) == limit else None
+
+        headers = {}
+        if args["count"]:
+            headers["X-Total-Count"] = str(total_count)
+
+        items = [
+            {
+                key: resolve_column_ref(db, obj, ref, self.spec)
+                for ref, key in zip(fetch_refs, fetch_keys)
+                if key in requested_keys
+            }
+            for obj in page
+        ]
+
+        return {"items": items, "next_after": next_after}, 200, headers
+
+
+class PersonQueryResource(ObjectQueryResource):
+    """Fast, paged/filtered/sorted Person query. See `ObjectQueryResource`."""
+
+    spec = PERSON
+
+
+class FamilyQueryResource(ObjectQueryResource):
+    """Fast, paged/filtered/sorted Family query. See `ObjectQueryResource`."""
+
+    spec = FAMILY
+
+
+class EventQueryResource(ObjectQueryResource):
+    """Fast, paged/filtered/sorted Event query. See `ObjectQueryResource`."""
+
+    spec = EVENT
+
+
+class PlaceQueryResource(ObjectQueryResource):
+    """Fast, paged/filtered/sorted Place query. See `ObjectQueryResource`."""
+
+    spec = PLACE
+
+
+class RepositoryQueryResource(ObjectQueryResource):
+    """Fast, paged/filtered/sorted Repository query. See `ObjectQueryResource`."""
+
+    spec = REPOSITORY
+
+
+class SourceQueryResource(ObjectQueryResource):
+    """Fast, paged/filtered/sorted Source query. See `ObjectQueryResource`."""
+
+    spec = SOURCE
+
+
+class CitationQueryResource(ObjectQueryResource):
+    """Fast, paged/filtered/sorted Citation query. See `ObjectQueryResource`."""
+
+    spec = CITATION
+
+
+class MediaQueryResource(ObjectQueryResource):
+    """Fast, paged/filtered/sorted Media query. See `ObjectQueryResource`."""
+
+    spec = MEDIA
+
+
+class NoteQueryResource(ObjectQueryResource):
+    """Fast, paged/filtered/sorted Note query. See `ObjectQueryResource`."""
+
+    spec = NOTE
+
+
+class TagQueryResource(ObjectQueryResource):
+    """Fast, paged/filtered/sorted Tag query. See `ObjectQueryResource`."""
+
+    spec = TAG

--- a/gramps_webapi/api/resources/object_query.py
+++ b/gramps_webapi/api/resources/object_query.py
@@ -35,7 +35,7 @@ the same pattern `GrampsObjectResourceHelper` subclasses already use with
 """
 
 import json
-from typing import Any, Callable, Optional, Sequence, Tuple
+from typing import Any, Optional, Sequence, Tuple
 
 from gramps.gen.proxy.proxybase import ProxyDbBase
 from gramps.plugins.db.dbapi.sqlite import SQLite
@@ -59,18 +59,9 @@ from gramps_object_query_language.query import (
     REPOSITORY,
     SOURCE,
     TAG,
-    And,
     ColumnRef,
     Dialect,
-    Eq,
-    Gt,
-    Gte,
-    In,
     JsonPath,
-    Like,
-    Lt,
-    Lte,
-    Ne,
     ObjectTypeSpec,
     OrderBy,
     Query,
@@ -81,24 +72,19 @@ from gramps_object_query_language.query import (
     check_columns,
     compile_count_query,
     compile_query,
-    resolve_column_path,
 )
-from gramps_object_query_language.query_lang import QueryLangError, parse_expr_for_spec
+from gramps_object_query_language.query_lang import (
+    VALID_LEAF_OPS,
+    QueryLangError,
+    json_column_to_ref,
+    parse_expr_for_spec,
+    where_list_to_ast,
+)
 
 from ..blueprint import api_blueprint
 from ..util import abort_with_message, get_db_handle, get_locale_for_language
 from . import ProtectedResource
 from .schemas import ObjectQueryResponseSchema
-
-_OP_TO_EXPR = {
-    "eq": Eq,
-    "ne": Ne,
-    "lt": Lt,
-    "lte": Lte,
-    "gt": Gt,
-    "gte": Gte,
-    "like": Like,
-}
 
 
 class QueryWhereConditionArgs(Schema):
@@ -117,9 +103,10 @@ class QueryWhereConditionArgs(Schema):
     )
     op = wf.Str(
         required=True,
-        validate=validate.OneOf(list(_OP_TO_EXPR) + ["in"]),
+        validate=validate.OneOf(list(VALID_LEAF_OPS)),
         metadata={
-            "description": "Comparison operator: eq, ne, lt, lte, gt, gte, like, or in."
+            "description": "Comparison operator: eq, ne, lt, lte, gt, gte, like, "
+            "contains, or in."
         },
     )
     value = wf.Raw(
@@ -228,22 +215,45 @@ class QueryBodyArgs(Schema):
 
 
 def _parse_column_ref(raw: Any, spec: ObjectTypeSpec) -> ColumnRef:
-    """Parse a `where` condition's `column`: a plain column name, or
-    `{"json_path": [...]}` resolved via `resolve_column_path()` -- which
-    may cross a relationship (`{"json_path": ["birth", "date", "sortval"]}`)
-    or stay a plain `JsonPath` into `json_data`, depending on whether the
-    first segment(s) name a registered relationship on `spec`. A bare
-    string is *not* run through the relationship resolver -- there's
-    nothing to disambiguate for a single segment beyond "is this a real
-    flat column", which `_render_column` already checks at compile time.
+    """Parse a `select`/`where`/`order_by` column reference: a plain column
+    name, `{"json_path": [...]}` (may cross a relationship, e.g.
+    `{"json_path": ["birth", "date", "sortval"]}`, or stay a plain `JsonPath`
+    into `json_data`), or `{"count_of": {"relationship": ..., "where": [...]}}`
+    (a `Collection`'s cardinality, optionally narrowed -- `count(events) > 2`'s
+    column side).
+
+    Delegates the actual resolution to
+    `gramps_object_query_language.query_lang`'s `json_column_to_ref` -- the
+    same function `where_expr`'s column references go through -- rather than
+    a second, hand-maintained copy (see `_build_where`'s equivalent note for
+    why: that's exactly how `count_of` ended up supported for filtering via
+    `where_expr` but not for a `select`/plain `where` column reference, before
+    this function was rewritten to delegate too). Only the validation below
+    stays local: `json_column_to_ref`/`resolve_column_path` trust their input
+    (always well-formed when it comes from `parse_expr_for_spec`), but this
+    function's caller is raw, untrusted client JSON -- `select`/`order_by`
+    entries in particular have no schema shape at all (`wf.Raw()` all the
+    way down), so a `json_path`/`count_of` payload could arrive as anything.
     """
     if isinstance(raw, str):
-        return raw
+        return json_column_to_ref(raw, spec)
     if isinstance(raw, dict) and "json_path" in raw:
         segments = raw["json_path"]
         if not isinstance(segments, list) or not segments:
             raise QueryError("'json_path' must be a non-empty list")
-        return resolve_column_path(spec, segments)
+        return json_column_to_ref(raw, spec)
+    if isinstance(raw, dict) and "count_of" in raw:
+        payload = raw["count_of"]
+        if not isinstance(payload, dict) or "relationship" not in payload:
+            raise QueryError("'count_of' requires a 'relationship' field")
+        where = payload.get("where")
+        if where is not None:
+            if not isinstance(where, list):
+                raise QueryError("'count_of.where' must be a list of conditions")
+            for condition in where:
+                if isinstance(condition, dict) and "column" in condition:
+                    _validate_leaf_condition(condition)
+        return json_column_to_ref(raw, spec)
     raise QueryError(f"invalid column reference: {raw!r}")
 
 
@@ -259,12 +269,27 @@ def _parse_select_entry(raw: Any, spec: ObjectTypeSpec) -> Tuple[SelectRef, str]
     load-bearing for the `next_after` cursor (see `post()`), so silently
     shadowing it with unrelated content would corrupt pagination for the
     caller without any visible error.
+
+    `{"count_of": {"relationship": ..., "where": [...]}, "as": "..."}`
+    selects a `Collection`'s cardinality directly as a result column (e.g.
+    "how many events does each person have"), not just as a `where_expr`
+    filter target -- `as` is required for it, since unlike a `json_path`
+    there's no natural dotted-name default to derive (`_default_key_for`
+    has nothing to walk).
     """
     if isinstance(raw, str):
         return raw, raw
     if isinstance(raw, dict) and "json_path" in raw:
         column = _parse_column_ref(raw, spec)
         key = raw.get("as") or _default_key_for(column)
+        if key == "handle":
+            raise QueryError("'handle' is reserved as a response key")
+        return column, key
+    if isinstance(raw, dict) and "count_of" in raw:
+        column = _parse_column_ref(raw, spec)
+        key = raw.get("as")
+        if not key:
+            raise QueryError("'count_of' select entries require an explicit 'as'")
         if key == "handle":
             raise QueryError("'handle' is reserved as a response key")
         return column, key
@@ -308,22 +333,6 @@ def _sort_key(value: Any) -> Tuple[bool, Any]:
     return (value is not None, value)
 
 
-def _sort_key_for_column(
-    column: str, spec: ObjectTypeSpec
-) -> Callable[[Any], Tuple[bool, Any]]:
-    """A `list.sort(key=...)` callable for `column`, bound via closure rather
-    than a lambda's default-argument trick -- mypy can't infer the type of a
-    `lambda obj, c=column: ...` used as a sort key (`Cannot infer type of
-    lambda`), since the extra defaulted parameter breaks its unification
-    with `list.sort`'s expected single-argument callable.
-    """
-
-    def key(obj: Any) -> Tuple[bool, Any]:
-        return _sort_key(get_flat_column(obj, column, spec))
-
-    return key
-
-
 def _terminal_is_json_path(ref: ColumnRef) -> bool:
     """Does `ref` ultimately extract via a `JsonPath` (as opposed to a
     plain flat column)? Recurses through a `RelatedObject` chain to its
@@ -360,45 +369,58 @@ def _normalize_json_value(value: Any) -> Any:
     return value
 
 
-def _build_where(conditions: Optional[Sequence[dict]], spec: ObjectTypeSpec):
-    """Build a `query.py` WHERE expression from parsed leaf conditions.
+def _validate_leaf_condition(condition: dict) -> None:
+    """Cross-field checks `QueryWhereConditionArgs`'s schema can't express on
+    its own -- "exactly one of value/value_column", `value_column` not
+    supported for `in`/`like`, `in` needing a non-empty list -- the same
+    reasoning `where`/`where_expr` mutual exclusivity is checked here rather
+    than in the schema.
 
-    Each condition carries exactly one of `value` (a literal) or
-    `value_column` (another path, for a field-vs-field comparison, e.g.
-    "families where the mother died before the father") -- validated here
-    since webargs' per-field `required=` can't express "exactly one of
-    these two", the same reason `where`/`where_expr` mutual exclusivity is
-    checked in `_resolve_where_conditions` rather than the schema.
+    Only ever applied to a raw, client-submitted `where` JSON leaf (see
+    `_build_where`'s guard) -- a `where_expr`-sourced condition is always
+    well-formed already, by construction of `parse_expr_for_spec`'s own
+    translation, so re-checking it here would be redundant; it's also not
+    always a leaf at all (`or`/`not`/`and`/`exists` nodes have none of
+    `column`/`value`/`value_column`), which this function assumes.
+    """
+    has_value = "value" in condition
+    has_value_column = "value_column" in condition
+    if has_value == has_value_column:
+        abort_with_message(
+            422, "exactly one of 'value'/'value_column' is required"
+        )
+    op = condition["op"]
+    if has_value_column and op in ("in", "like"):
+        abort_with_message(422, f"'value_column' is not supported for op {op!r}")
+    if op == "in":
+        value = condition.get("value")
+        if not isinstance(value, list) or not value:
+            abort_with_message(422, "'in' operator requires a non-empty list value")
+
+
+def _build_where(conditions: Optional[Sequence[dict]], spec: ObjectTypeSpec):
+    """Build a `query.py` WHERE expression from top-level conditions,
+    implicitly AND-combined (see `QueryBodyArgs.where`'s docstring).
+
+    The actual JSON -> `query.py` AST translation -- leaves, and
+    `where_expr`'s `and`/`or`/`not`/`exists`/`count(...)` nesting, and
+    same-table field-vs-field `FlatColumnRef` wrapping -- is
+    `where_list_to_ast`'s job (gramps_object_query_language.query_lang),
+    not reimplemented here; see that function's docstring for why. Only the
+    leaf-shape validation stays local, since it's specific to the raw,
+    untrusted `where` JSON body (see `_validate_leaf_condition`) -- skipped
+    for anything that isn't a leaf (`or`/`not`/`and`/`exists`, `where_expr`
+    -only shapes the `where` schema can never produce in the first place).
     """
     if not conditions:
         return None
-    exprs: list[Any] = []
     for condition in conditions:
-        column = _parse_column_ref(condition["column"], spec)
-        op = condition["op"]
-        has_value = "value" in condition
-        has_value_column = "value_column" in condition
-        if has_value == has_value_column:
-            abort_with_message(
-                422, "exactly one of 'value'/'value_column' is required"
-            )
-        if has_value_column:
-            if op in ("in", "like"):
-                abort_with_message(
-                    422, f"'value_column' is not supported for op {op!r}"
-                )
-            value = _parse_column_ref(condition["value_column"], spec)
-        else:
-            value = condition["value"]
-        if op == "in":
-            if not isinstance(value, list) or not value:
-                abort_with_message(422, "'in' operator requires a non-empty list value")
-            exprs.append(In(column, value))
-        else:
-            exprs.append(_OP_TO_EXPR[op](column, value))
-    if len(exprs) == 1:
-        return exprs[0]
-    return And(*exprs)
+        if "column" in condition:
+            _validate_leaf_condition(condition)
+    try:
+        return where_list_to_ast(conditions, spec)
+    except QueryError as error:
+        abort_with_message(422, str(error))
 
 
 def _resolve_where_conditions(
@@ -498,13 +520,32 @@ def _resolve_dialect(basedb: Any) -> Dialect:
     outright, not just sort wrong. Anything else (`SharedPostgreSQL`) falls
     back to PostgreSQL, since that's the only other backend this project
     targets today.
+
+    The `SQLite` check is by class *name*, not `isinstance`, deliberately:
+    Gramps' plugin loader imports database backend plugins (including core
+    ones) as freestanding modules under a bare name (`sqlite`, not
+    `gramps.plugins.db.dbapi.sqlite`) rather than via a normal package
+    import, so a real request's `basedb` is a *different* class object than
+    this file's own `from gramps.plugins.db.dbapi.sqlite import SQLite` --
+    same name, same behavior, different identity. `isinstance(basedb,
+    SQLite)` silently returns `False` for it every time, which was live
+    (not just theoretically) confirmed to fall through to the
+    `Dialect.POSTGRESQL` default for an actual SQLite deployment -- any
+    dialect-sensitive SQL (`JsonPath`, `Exists`, `CollectionCount`) then
+    renders `::jsonb`/`jsonb_extract_path(...)`/`jsonb_array_elements(...)`
+    against a real SQLite connection and fails outright. A plain flat-column
+    comparison (`Eq`/`Like`/...) never hits this branch at all, which is why
+    the bug went unnoticed until an `exists(...)`/`count(...)` query
+    actually exercised it. `isinstance` is kept first since it's the
+    correct, more specific check when it *does* match (e.g. a `SQLite()`
+    constructed directly in-process, as this file's own tests do).
     """
     name: Optional[str] = getattr(basedb, "dialect", None)
     if name:
         dialect = _DIALECT_BY_NAME.get(name)
         if dialect is not None:
             return dialect
-    if isinstance(basedb, SQLite):
+    if isinstance(basedb, SQLite) or type(basedb).__name__ == "SQLite":
         return Dialect.SQLITE
     return Dialect.POSTGRESQL
 
@@ -700,7 +741,7 @@ class ObjectQueryResource(ProtectedResource):
         directions = {ob.column: ob.direction for ob in order_by}
         for column in reversed(sort_columns):
             matches.sort(
-                key=_sort_key_for_column(column, self.spec),
+                key=lambda obj, c=column: _sort_key(get_flat_column(obj, c, self.spec)),
                 reverse=directions.get(column, "asc") == "desc",
             )
 

--- a/gramps_webapi/api/resources/object_query.py
+++ b/gramps_webapi/api/resources/object_query.py
@@ -35,7 +35,7 @@ the same pattern `GrampsObjectResourceHelper` subclasses already use with
 """
 
 import json
-from typing import Any, Callable, Optional, Sequence, Tuple
+from typing import Any, Callable, Optional, Sequence, Tuple, Union, cast
 
 from gramps.gen.proxy.proxybase import ProxyDbBase
 from gramps.plugins.db.dbapi.sqlite import SQLite
@@ -281,7 +281,14 @@ def _parse_select_entry(raw: Any, spec: ObjectTypeSpec) -> Tuple[SelectRef, str]
         return raw, raw
     if isinstance(raw, dict) and "json_path" in raw:
         column = _parse_column_ref(raw, spec)
-        key = raw.get("as") or _default_key_for(column)
+        # A "json_path" payload only ever resolves to one of these three --
+        # see `_default_key_for`'s docstring -- never a CollectionCount/
+        # FlatColumnRef, which `_parse_column_ref`'s return type (the full
+        # ColumnRef union, shared with the "count_of" branch below) doesn't
+        # capture on its own.
+        key = raw.get("as") or _default_key_for(
+            cast(Union[str, JsonPath, RelatedObject], column)
+        )
         if key == "handle":
             raise QueryError("'handle' is reserved as a response key")
         return column, key

--- a/gramps_webapi/api/resources/object_query.py
+++ b/gramps_webapi/api/resources/object_query.py
@@ -801,14 +801,24 @@ class ObjectQueryResource(ProtectedResource):
 
         headers = {}
         if args["count"]:
-            # `limit`/`after` narrow `rows` to one page; the total needs
-            # every `where`-match independent of both -- same "costs a
-            # second query, opt-in" tradeoff `_post_sql` already makes for
-            # its own `count_sql`. Unlike `count_sql`, which is a single
-            # index-backed `COUNT(*)`, this re-runs the full per-object
-            # deserialize-and-privacy-sanitize pass a second time with no
-            # `limit` at all -- the more expensive of the two by far.
-            headers["X-Total-Count"] = str(len(run_query(db, self.spec, where)))
+            if after is None and not has_more:
+                # The first page already *is* every match -- no `after` to
+                # have skipped earlier rows, and no `has_more` to mean later
+                # ones exist beyond what was fetched. Reuse it instead of
+                # re-deserializing the whole table a second time just to
+                # count what's already sitting in `rows`.
+                total = len(rows)
+            else:
+                # `limit`/`after` narrow `rows` to one page; the total needs
+                # every `where`-match independent of both -- same "costs a
+                # second query, opt-in" tradeoff `_post_sql` already makes
+                # for its own `count_sql`. Unlike `count_sql`, which is a
+                # single index-backed `COUNT(*)`, this re-runs the full
+                # per-object deserialize-and-privacy-sanitize pass a second
+                # time with no `limit` at all -- the more expensive of the
+                # two by far.
+                total = len(run_query(db, self.spec, where))
+            headers["X-Total-Count"] = str(total)
 
         handle_index = fetch_refs.index("handle")
         items = [

--- a/gramps_webapi/api/resources/object_query.py
+++ b/gramps_webapi/api/resources/object_query.py
@@ -77,6 +77,8 @@ from gramps_object_query_language.query_lang import (
     where_list_to_ast,
 )
 
+from ...auth.const import PERM_VIEW_PRIVATE
+from ..auth import require_permissions
 from ..blueprint import api_blueprint
 from ..util import abort_with_message, get_db_handle, get_locale_for_language
 from . import ProtectedResource
@@ -627,8 +629,15 @@ class ObjectQueryResource(ProtectedResource):
 
     def _post_sql(self, basedb: Any, args: dict) -> Any:
         """Fast, SQL-pushed-down query -- only ever called with an unproxied
-        `basedb`, so there is no privacy predicate to apply here at all.
+        `basedb`, so there is no privacy predicate to apply in the query
+        itself. That's only safe because an unproxied `db` is supposed to
+        imply the caller has `PERM_VIEW_PRIVATE` -- an invariant enforced
+        two modules away, in `get_db_handle()`. Asserting it again here,
+        redundantly, keeps that coupling local: if it's ever violated, this
+        raises 403 instead of silently emitting private records with no
+        privacy predicate at all.
         """
+        require_permissions([PERM_VIEW_PRIVATE])
         if not hasattr(basedb, "dbapi"):
             abort_with_message(
                 501, "Structured query is not supported on this database backend"
@@ -670,11 +679,15 @@ class ObjectQueryResource(ProtectedResource):
                 fetch_keys = fetch_keys + ["handle"]
             requested_keys = {key for _, key in parsed_select}
 
+            # Fetch one extra row beyond `limit` so a result set that's an
+            # exact multiple of `limit` doesn't need a wasted follow-up
+            # request just to learn there's no next page; the extra row is
+            # trimmed back off below and never reaches the response.
             query = Query(
                 select=fetch_refs,
                 where=_build_where(_resolve_where_conditions(args, self.spec), self.spec),
                 order_by=order_by,
-                limit=args["limit"],
+                limit=args["limit"] + 1,
                 after=after,
             )
             sql, params = compile_query(
@@ -694,6 +707,8 @@ class ObjectQueryResource(ProtectedResource):
 
         basedb.dbapi.execute(sql, params)
         rows = basedb.dbapi.fetchall()
+        has_more = len(rows) > args["limit"]
+        rows = rows[: args["limit"]]
 
         headers = {}
         if count_sql is not None:
@@ -714,7 +729,7 @@ class ObjectQueryResource(ProtectedResource):
             }
             for row in rows
         ]
-        next_after = rows[-1][handle_index] if len(rows) == args["limit"] else None
+        next_after = rows[-1][handle_index] if has_more else None
 
         return {"items": items, "next_after": next_after}, 200, headers
 
@@ -731,8 +746,17 @@ class ObjectQueryResource(ProtectedResource):
         matching `run_query`'s own scope cap. Locale-aware `COLLATE`
         sorting (the SQL path's `locale` param) has no equivalent here --
         `run_query` always sorts in plain, NULL-safe Python `<` order
-        (matching SQLite's own default), regardless of `locale`.
+        (matching SQLite's own default). Rather than silently returning a
+        different sort order than the same request would get on the SQL
+        path, an explicit `locale` is rejected outright below.
         """
+        if args.get("locale"):
+            abort_with_message(
+                422,
+                "locale-aware sorting is not supported for a caller without "
+                "PERM_VIEW_PRIVATE (no COLLATE equivalent on the proxied "
+                "query path)",
+            )
         order_by = [
             OrderBy(item["column"], item.get("direction", "asc"))
             for item in args.get("order_by") or []
@@ -760,22 +784,30 @@ class ObjectQueryResource(ProtectedResource):
         if args.get("after"):
             after = _resolve_after_proxied(db, self.spec, order_by, args["after"])
 
+        # See the matching comment in `_post_sql`: over-fetch by one row so
+        # an exact-multiple-of-`limit` result set doesn't need a wasted
+        # follow-up request to learn there's no next page.
         rows = run_query(
             db,
             self.spec,
             where,
             order_by=order_by,
-            limit=args["limit"],
+            limit=args["limit"] + 1,
             after=after,
             select=fetch_refs,
         )
+        has_more = len(rows) > args["limit"]
+        rows = rows[: args["limit"]]
 
         headers = {}
         if args["count"]:
             # `limit`/`after` narrow `rows` to one page; the total needs
             # every `where`-match independent of both -- same "costs a
             # second query, opt-in" tradeoff `_post_sql` already makes for
-            # its own `count_sql`, not a new cost this path introduces.
+            # its own `count_sql`. Unlike `count_sql`, which is a single
+            # index-backed `COUNT(*)`, this re-runs the full per-object
+            # deserialize-and-privacy-sanitize pass a second time with no
+            # `limit` at all -- the more expensive of the two by far.
             headers["X-Total-Count"] = str(len(run_query(db, self.spec, where)))
 
         handle_index = fetch_refs.index("handle")
@@ -783,7 +815,7 @@ class ObjectQueryResource(ProtectedResource):
             {key: val for key, val in zip(fetch_keys, row) if key in requested_keys}
             for row in rows
         ]
-        next_after = rows[-1][handle_index] if len(rows) == args["limit"] else None
+        next_after = rows[-1][handle_index] if has_more else None
 
         return {"items": items, "next_after": next_after}, 200, headers
 

--- a/gramps_webapi/api/resources/object_query.py
+++ b/gramps_webapi/api/resources/object_query.py
@@ -104,7 +104,7 @@ class QueryWhereConditionArgs(Schema):
         validate=validate.OneOf(list(VALID_LEAF_OPS)),
         metadata={
             "description": "Comparison operator: eq, ne, lt, lte, gt, gte, like, "
-            "contains, or in."
+            "regex, contains, or in."
         },
     )
     value = wf.Raw(
@@ -122,7 +122,8 @@ class QueryWhereConditionArgs(Schema):
             "mother died before the father -- column: {'json_path': ['mother', "
             "'death', 'date', 'sortval']}, op: 'lt', value_column: {'json_path': "
             "['father', 'death', 'date', 'sortval']}. Same shape as 'column' "
-            "(plain name or {'json_path': [...]}). Not supported for 'in'/'like'."
+            "(plain name or {'json_path': [...]}). Not supported for "
+            "'in'/'like'/'regex'."
         },
     )
 
@@ -374,9 +375,9 @@ def _normalize_json_value(value: Any) -> Any:
 def _validate_leaf_condition(condition: dict) -> None:
     """Cross-field checks `QueryWhereConditionArgs`'s schema can't express on
     its own -- "exactly one of value/value_column", `value_column` not
-    supported for `in`/`like`, `in` needing a non-empty list -- the same
-    reasoning `where`/`where_expr` mutual exclusivity is checked here rather
-    than in the schema.
+    supported for `in`/`like`/`regex`, `in` needing a non-empty list -- the
+    same reasoning `where`/`where_expr` mutual exclusivity is checked here
+    rather than in the schema.
 
     Only ever applied to a raw, client-submitted `where` JSON leaf (see
     `_build_where`'s guard) -- a `where_expr`-sourced condition is always
@@ -392,7 +393,7 @@ def _validate_leaf_condition(condition: dict) -> None:
             422, "exactly one of 'value'/'value_column' is required"
         )
     op = condition["op"]
-    if has_value_column and op in ("in", "like"):
+    if has_value_column and op in ("in", "like", "regex"):
         abort_with_message(422, f"'value_column' is not supported for op {op!r}")
     if op == "in":
         value = condition.get("value")

--- a/gramps_webapi/api/resources/object_query.py
+++ b/gramps_webapi/api/resources/object_query.py
@@ -318,7 +318,8 @@ def _default_key_for(ref: "str | JsonPath | RelatedObject") -> str:
     if isinstance(ref, str):
         return ref
     if isinstance(ref, RelatedObject):
-        return f"{ref.name}.{_default_key_for(ref.field)}"
+        field = cast(Union[str, JsonPath, RelatedObject], ref.field)
+        return f"{ref.name}.{_default_key_for(field)}"
     parts: list = []
     for segment in ref.segments:
         if isinstance(segment, int):

--- a/gramps_webapi/api/resources/object_query.py
+++ b/gramps_webapi/api/resources/object_query.py
@@ -35,7 +35,7 @@ the same pattern `GrampsObjectResourceHelper` subclasses already use with
 """
 
 import json
-from typing import Any, Optional, Sequence, Tuple
+from typing import Any, Callable, Optional, Sequence, Tuple
 
 from gramps.gen.proxy.proxybase import ProxyDbBase
 from gramps.plugins.db.dbapi.sqlite import SQLite
@@ -296,11 +296,17 @@ def _parse_select_entry(raw: Any, spec: ObjectTypeSpec) -> Tuple[SelectRef, str]
     raise QueryError(f"invalid column reference: {raw!r}")
 
 
-def _default_key_for(ref: ColumnRef) -> str:
+def _default_key_for(ref: "str | JsonPath | RelatedObject") -> str:
     """Derive a default response key for a `select` entry with no explicit
     `as` alias -- a dotted/bracket string, e.g. `primary_name.surname_list[0]`
     for a plain `JsonPath`, or `birth.date.sortval` for a `RelatedObject`
     chain (recursing through `.field` and prefixing each hop's `.name`).
+
+    Only ever called for a `json_path` select entry (see `_parse_select_entry`)
+    -- `resolve_column_path` (what `json_column_to_ref` delegates a
+    `json_path` payload to) only ever returns one of these three, never a
+    `CollectionCount`/`FlatColumnRef`, so the narrower type here (rather than
+    the full `ColumnRef` union) is accurate, not just convenient.
     """
     if isinstance(ref, str):
         return ref
@@ -331,6 +337,22 @@ def _sort_key(value: Any) -> Tuple[bool, Any]:
     the SQL path's `ORDER BY` has its own (backend-native) NULL ordering.
     """
     return (value is not None, value)
+
+
+def _sort_key_for_column(
+    column: str, spec: ObjectTypeSpec
+) -> Callable[[Any], Tuple[bool, Any]]:
+    """A `list.sort(key=...)` callable for `column`, bound via closure rather
+    than a lambda's default-argument trick -- mypy can't infer the type of a
+    `lambda obj, c=column: ...` used as a sort key ("Cannot infer type of
+    lambda"), since the extra defaulted parameter breaks its unification
+    with `list.sort`'s expected single-argument callable.
+    """
+
+    def key(obj: Any) -> Tuple[bool, Any]:
+        return _sort_key(get_flat_column(obj, column, spec))
+
+    return key
 
 
 def _terminal_is_json_path(ref: ColumnRef) -> bool:
@@ -418,7 +440,7 @@ def _build_where(conditions: Optional[Sequence[dict]], spec: ObjectTypeSpec):
         if "column" in condition:
             _validate_leaf_condition(condition)
     try:
-        return where_list_to_ast(conditions, spec)
+        return where_list_to_ast(list(conditions), spec)
     except QueryError as error:
         abort_with_message(422, str(error))
 
@@ -741,7 +763,7 @@ class ObjectQueryResource(ProtectedResource):
         directions = {ob.column: ob.direction for ob in order_by}
         for column in reversed(sort_columns):
             matches.sort(
-                key=lambda obj, c=column: _sort_key(get_flat_column(obj, c, self.spec)),
+                key=_sort_key_for_column(column, self.spec),
                 reverse=directions.get(column, "asc") == "desc",
             )
 

--- a/gramps_webapi/api/resources/object_query.py
+++ b/gramps_webapi/api/resources/object_query.py
@@ -35,7 +35,7 @@ the same pattern `GrampsObjectResourceHelper` subclasses already use with
 """
 
 import json
-from typing import Any, Optional, Sequence, Tuple
+from typing import Any, Callable, Optional, Sequence, Tuple
 
 from gramps.gen.proxy.proxybase import ProxyDbBase
 from gramps.plugins.db.dbapi.sqlite import SQLite
@@ -306,6 +306,22 @@ def _sort_key(value: Any) -> Tuple[bool, Any]:
     the SQL path's `ORDER BY` has its own (backend-native) NULL ordering.
     """
     return (value is not None, value)
+
+
+def _sort_key_for_column(
+    column: str, spec: ObjectTypeSpec
+) -> Callable[[Any], Tuple[bool, Any]]:
+    """A `list.sort(key=...)` callable for `column`, bound via closure rather
+    than a lambda's default-argument trick -- mypy can't infer the type of a
+    `lambda obj, c=column: ...` used as a sort key (`Cannot infer type of
+    lambda`), since the extra defaulted parameter breaks its unification
+    with `list.sort`'s expected single-argument callable.
+    """
+
+    def key(obj: Any) -> Tuple[bool, Any]:
+        return _sort_key(get_flat_column(obj, column, spec))
+
+    return key
 
 
 def _terminal_is_json_path(ref: ColumnRef) -> bool:

--- a/gramps_webapi/api/resources/object_query.py
+++ b/gramps_webapi/api/resources/object_query.py
@@ -700,7 +700,7 @@ class ObjectQueryResource(ProtectedResource):
         directions = {ob.column: ob.direction for ob in order_by}
         for column in reversed(sort_columns):
             matches.sort(
-                key=lambda obj, c=column: _sort_key(get_flat_column(obj, c, self.spec)),
+                key=_sort_key_for_column(column, self.spec),
                 reverse=directions.get(column, "asc") == "desc",
             )
 

--- a/gramps_webapi/api/resources/object_query.py
+++ b/gramps_webapi/api/resources/object_query.py
@@ -530,6 +530,18 @@ _DIALECT_BY_NAME: dict[str, Dialect] = {
 }
 
 
+# Backends known to have no `treeid`/dialect concept of their own, checked
+# by class *name* rather than `isinstance` -- see `_resolve_dialect`'s
+# docstring for why `isinstance` is unreliable for a plugin-loaded class.
+_SQLITE_CLASS_NAME = "SQLite"
+_SINGLE_TREE_POSTGRES_CLASS_NAME = "PostgreSQL"
+_SHARED_POSTGRES_CLASS_NAME = "SharedPostgreSQL"
+
+
+def _is_sqlite(basedb: Any) -> bool:
+    return isinstance(basedb, SQLite) or type(basedb).__name__ == _SQLITE_CLASS_NAME
+
+
 def _resolve_dialect(basedb: Any) -> Dialect:
     """Backend SQL dialect for rendering a `JsonPath` (see `query.py`).
 
@@ -541,37 +553,54 @@ def _resolve_dialect(basedb: Any) -> Dialect:
     directly -- it's what every test fixture and single-tree/dev deployment
     actually runs, so guessing PostgreSQL for it would emit
     `jsonb_extract_path(...)` against a real SQLite connection and fail
-    outright, not just sort wrong. Anything else (`SharedPostgreSQL`) falls
-    back to PostgreSQL, since that's the only other backend this project
-    targets today.
+    outright, not just sort wrong. `SharedPostgreSQL` is likewise detected
+    directly, by class name, for the versions of that addon which don't set
+    `.dialect` yet.
 
-    The `SQLite` check is by class *name*, not `isinstance`, deliberately:
-    Gramps' plugin loader imports database backend plugins (including core
-    ones) as freestanding modules under a bare name (`sqlite`, not
-    `gramps.plugins.db.dbapi.sqlite`) rather than via a normal package
-    import, so a real request's `basedb` is a *different* class object than
-    this file's own `from gramps.plugins.db.dbapi.sqlite import SQLite` --
-    same name, same behavior, different identity. `isinstance(basedb,
-    SQLite)` silently returns `False` for it every time, which was live
-    (not just theoretically) confirmed to fall through to the
-    `Dialect.POSTGRESQL` default for an actual SQLite deployment -- any
-    dialect-sensitive SQL (`JsonPath`, `Exists`, `CollectionCount`) then
-    renders `::jsonb`/`jsonb_extract_path(...)`/`jsonb_array_elements(...)`
-    against a real SQLite connection and fails outright. A plain flat-column
+    Anything else -- a backend this module has never seen, where a `.dialect`
+    string didn't resolve and the class name matches neither known SQLite nor
+    Postgres backend -- aborts with 501 rather than guessing PostgreSQL. A
+    wrong guess here doesn't just sort oddly: it can render dialect-specific
+    SQL (`::jsonb`, `jsonb_extract_path(...)`) against a connection that
+    can't run it, or -- worse, for `_resolve_treeid`'s equivalent fallback --
+    silently return another tenant's rows. Failing closed means a genuinely
+    new backend needs this module updated before structured query works
+    against it, rather than working by accident until it doesn't.
+
+    The `SQLite`/`SharedPostgreSQL` checks are by class *name*, not
+    `isinstance`, deliberately: Gramps' plugin loader imports database
+    backend plugins (including core ones) as freestanding modules under a
+    bare name (`sqlite`, not `gramps.plugins.db.dbapi.sqlite`) rather than
+    via a normal package import, so a real request's `basedb` is a
+    *different* class object than this file's own `from
+    gramps.plugins.db.dbapi.sqlite import SQLite` -- same name, same
+    behavior, different identity. `isinstance(basedb, SQLite)` silently
+    returns `False` for it every time, which was live (not just
+    theoretically) confirmed to fall through to the `Dialect.POSTGRESQL`
+    default for an actual SQLite deployment -- any dialect-sensitive SQL
+    (`JsonPath`, `Exists`, `CollectionCount`) then renders
+    `::jsonb`/`jsonb_extract_path(...)`/`jsonb_array_elements(...)` against a
+    real SQLite connection and fails outright. A plain flat-column
     comparison (`Eq`/`Like`/...) never hits this branch at all, which is why
     the bug went unnoticed until an `exists(...)`/`count(...)` query
-    actually exercised it. `isinstance` is kept first since it's the
-    correct, more specific check when it *does* match (e.g. a `SQLite()`
-    constructed directly in-process, as this file's own tests do).
+    actually exercised it. `isinstance` is kept first for `SQLite` since
+    it's the correct, more specific check when it *does* match (e.g. a
+    `SQLite()` constructed directly in-process, as this file's own tests do).
     """
     name: Optional[str] = getattr(basedb, "dialect", None)
     if name:
         dialect = _DIALECT_BY_NAME.get(name)
         if dialect is not None:
             return dialect
-    if isinstance(basedb, SQLite) or type(basedb).__name__ == "SQLite":
+    if _is_sqlite(basedb):
         return Dialect.SQLITE
-    return Dialect.POSTGRESQL
+    class_name = type(basedb).__name__
+    if class_name in (_SINGLE_TREE_POSTGRES_CLASS_NAME, _SHARED_POSTGRES_CLASS_NAME):
+        return Dialect.POSTGRESQL
+    abort_with_message(
+        501,
+        f"Structured query does not recognize database backend {class_name!r}",
+    )
 
 
 def _resolve_treeid(basedb: Any) -> Optional[int]:
@@ -591,8 +620,27 @@ def _resolve_treeid(basedb: Any) -> Optional[int]:
     single-user `PostgreSQL` addon), which have no `treeid` column at all
     -- `compile_query`/`compile_count_query`/`_resolve_after` all treat
     `None` as "omit the clause", not "unscoped is fine by default".
+
+    Anything else -- a backend whose `.dbapi` has no `treeid` and isn't one
+    of the known single-tree backends above -- aborts with 501 instead of
+    treating the missing attribute as "no scoping needed". `None` here
+    doesn't just mean "detection didn't find a value"; every caller downstream
+    treats it as "this backend has no tenant concept, an unscoped query is
+    fine" -- conflating that with "detection failed" would let an unscoped
+    query against a genuinely shared backend succeed and return other
+    tenants' rows instead of erroring.
     """
-    return getattr(basedb.dbapi, "treeid", None)
+    treeid = getattr(basedb.dbapi, "treeid", None)
+    if treeid is not None:
+        return treeid
+    class_name = type(basedb).__name__
+    if _is_sqlite(basedb) or class_name == _SINGLE_TREE_POSTGRES_CLASS_NAME:
+        return None
+    abort_with_message(
+        501,
+        f"Structured query cannot determine tree scoping for database "
+        f"backend {class_name!r}",
+    )
 
 
 class ObjectQueryResource(ProtectedResource):
@@ -753,9 +801,8 @@ class ObjectQueryResource(ProtectedResource):
         if args.get("locale"):
             abort_with_message(
                 422,
-                "locale-aware sorting is not supported for a caller without "
-                "PERM_VIEW_PRIVATE (no COLLATE equivalent on the proxied "
-                "query path)",
+                "locale-aware sorting is not supported on the proxied query "
+                "path (no COLLATE equivalent there)",
             )
         order_by = [
             OrderBy(item["column"], item.get("direction", "asc"))

--- a/gramps_webapi/api/resources/schemas.py
+++ b/gramps_webapi/api/resources/schemas.py
@@ -1597,6 +1597,35 @@ class FamilyExtendedSchema(_Base):
     )
 
 
+class ObjectQueryResponseSchema(_Base):
+    """Result of a fast, SQL-pushed-down structured object query.
+
+    Shared by every `POST .../query/` endpoint (people, families, events,
+    ...) -- the response shape doesn't depend on object type, only on the
+    caller's requested `select` columns.
+
+    Total row count, when requested (`count: true`), is returned via the
+    `X-Total-Count` response header -- the same convention already used by
+    `objects.py`/`emit.py`/`history.py` -- not a body field, for consistency
+    with the rest of the API.
+    """
+
+    items = fields.List(
+        fields.Dict(),
+        metadata={
+            "description": "Matching rows, each containing exactly the requested "
+            "`select` columns."
+        },
+    )
+    next_after = fields.Str(
+        allow_none=True,
+        metadata={
+            "description": "Cursor to pass as `after` to fetch the next page, "
+            "or null if this was the last page."
+        },
+    )
+
+
 class PersonExtendedSchema(_Base):
     """Extended section of a person response."""
 

--- a/gramps_webapi/api/util.py
+++ b/gramps_webapi/api/util.py
@@ -134,15 +134,6 @@ class ModifiedPrivateProxyDb(PrivateProxyDb):
         """Initialize self."""
         super().__init__(*args, **kwargs)
         self.name_formats = self.db.name_formats
-        # `DBAPI` and `SharedDBAPI` (used by the SharedPostgreSQL addon) are
-        # sibling classes, not parent/child, so this deliberately does NOT
-        # match SharedPostgreSQL -- `_iter_handles()` below issues raw SQL
-        # with no `treeid` filter, and SharedPostgreSQL stores every tree's
-        # rows in the same physical tables, discriminated only by `treeid`.
-        # Widening this to `hasattr(self.basedb, "dbapi")` looks like a
-        # narrower-than-necessary check but is actually load-bearing: it's
-        # what keeps SharedPostgreSQL on the slower, correctly tree-scoped
-        # `self.db.iter_*_handles()` path below instead of the raw one.
         self.is_dbapi = isinstance(self.basedb, DBAPI)
 
     def get_dbname(self):

--- a/gramps_webapi/api/util.py
+++ b/gramps_webapi/api/util.py
@@ -2,6 +2,7 @@
 # Gramps Web API - A RESTful API for the Gramps genealogy program
 #
 # Copyright (C) 2020-2024      David Straub
+# Copyright (C) 2026           Douglas Blank
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as published by
@@ -30,7 +31,7 @@ import socket
 from email.message import EmailMessage
 from email.utils import formatdate, make_msgid
 from http import HTTPStatus
-from typing import Any, BinaryIO, NoReturn, Sequence
+from typing import Any, BinaryIO, NoReturn, Optional, Sequence
 
 import gramps.gen.lib
 from celery import Task
@@ -133,6 +134,15 @@ class ModifiedPrivateProxyDb(PrivateProxyDb):
         """Initialize self."""
         super().__init__(*args, **kwargs)
         self.name_formats = self.db.name_formats
+        # `DBAPI` and `SharedDBAPI` (used by the SharedPostgreSQL addon) are
+        # sibling classes, not parent/child, so this deliberately does NOT
+        # match SharedPostgreSQL -- `_iter_handles()` below issues raw SQL
+        # with no `treeid` filter, and SharedPostgreSQL stores every tree's
+        # rows in the same physical tables, discriminated only by `treeid`.
+        # Widening this to `hasattr(self.basedb, "dbapi")` looks like a
+        # narrower-than-necessary check but is actually load-bearing: it's
+        # what keeps SharedPostgreSQL on the slower, correctly tree-scoped
+        # `self.db.iter_*_handles()` path below instead of the raw one.
         self.is_dbapi = isinstance(self.basedb, DBAPI)
 
     def get_dbname(self):
@@ -547,7 +557,9 @@ def get_db_handle(readonly: bool = True) -> DbReadBase:
     return g.db
 
 
-def get_locale_for_language(language: str, default: bool = False) -> GrampsLocale:
+def get_locale_for_language(
+    language: Optional[str], default: bool = False
+) -> GrampsLocale:
     """Get GrampsLocale set to specified language."""
     if language is not None:
         catalog = GRAMPS_LOCALE.get_language_dict()

--- a/gramps_webapi/api/util.py
+++ b/gramps_webapi/api/util.py
@@ -134,6 +134,15 @@ class ModifiedPrivateProxyDb(PrivateProxyDb):
         """Initialize self."""
         super().__init__(*args, **kwargs)
         self.name_formats = self.db.name_formats
+        # `DBAPI` and `SharedDBAPI` (used by the SharedPostgreSQL addon) are
+        # sibling classes, not parent/child, so this deliberately does NOT
+        # match SharedPostgreSQL -- `_iter_handles()` below issues raw SQL
+        # with no `treeid` filter, and SharedPostgreSQL stores every tree's
+        # rows in the same physical tables, discriminated only by `treeid`.
+        # Widening this to `hasattr(self.basedb, "dbapi")` looks like a
+        # narrower-than-necessary check but is actually load-bearing: it's
+        # what keeps SharedPostgreSQL on the slower, correctly tree-scoped
+        # `self.db.iter_*_handles()` path below instead of the raw one.
         self.is_dbapi = isinstance(self.basedb, DBAPI)
 
     def get_dbname(self):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ dependencies = [
     "celery[redis]",
     "Unidecode",
     "pytesseract",
-    "gramps-object-query-language>=0.3.3",
+    "gramps-object-query-language>=0.3.3,<0.4",
     "gramps-ql>=0.4.0",
     "object-ql>=0.1.3",
     "sifts>=1.1.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ dependencies = [
     "celery[redis]",
     "Unidecode",
     "pytesseract",
-    "gramps-object-query-language>=0.3.3,<0.4",
+    "gramps-object-query-language>=0.3.4,<0.4",
     "gramps-ql>=0.4.0",
     "object-ql>=0.1.3",
     "sifts>=1.1.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ dependencies = [
     "celery[redis]",
     "Unidecode",
     "pytesseract",
+    "gramps-object-query-language>=0.3.1",
     "gramps-ql>=0.4.0",
     "object-ql>=0.1.3",
     "sifts>=1.1.0",
@@ -71,9 +72,4 @@ profile = "black"
 version = {attr = "gramps_webapi.__version__"}
 
 [tool.setuptools.packages.find]
-include = [
-    "gramps_webapi",
-    "gramps_webapi.*",
-    "gramps_object_query_language",
-    "gramps_object_query_language.*",
-]
+include = ["gramps_webapi", "gramps_webapi.*"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,6 @@ dependencies = [
     "celery[redis]",
     "Unidecode",
     "pytesseract",
-    "gramps-object-query-language>=0.1.0",
     "gramps-ql>=0.4.0",
     "object-ql>=0.1.3",
     "sifts>=1.1.0",
@@ -72,4 +71,9 @@ profile = "black"
 version = {attr = "gramps_webapi.__version__"}
 
 [tool.setuptools.packages.find]
-include = ["gramps_webapi", "gramps_webapi.*"]
+include = [
+    "gramps_webapi",
+    "gramps_webapi.*",
+    "gramps_object_query_language",
+    "gramps_object_query_language.*",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ dependencies = [
     "celery[redis]",
     "Unidecode",
     "pytesseract",
-    "gramps-object-query-language>=0.3.1",
+    "gramps-object-query-language>=0.3.3",
     "gramps-ql>=0.4.0",
     "object-ql>=0.1.3",
     "sifts>=1.1.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ dependencies = [
     "celery[redis]",
     "Unidecode",
     "pytesseract",
+    "gramps-object-query-language>=0.1.0",
     "gramps-ql>=0.4.0",
     "object-ql>=0.1.3",
     "sifts>=1.1.0",

--- a/tests/test_endpoints/test_object_query.py
+++ b/tests/test_endpoints/test_object_query.py
@@ -27,6 +27,11 @@ own database table, whitelist, and privacy behavior.
 """
 
 import unittest
+from unittest.mock import patch
+
+from gramps.gen.proxy.proxybase import ProxyDbBase
+
+from gramps_webapi.api.util import get_db_handle
 
 from . import BASE_URL, get_object_count, get_test_client
 from .util import fetch_header
@@ -175,3 +180,156 @@ class TestObjectQueryMedia(unittest.TestCase):
             headers=header,
         )
         self.assertEqual(rv.status_code, 200)
+
+
+class _FakeNonPrivateProxy(ProxyDbBase):
+    """Minimal stand-in for a non-privacy proxy (e.g. `LivingProxyDb`).
+
+    Same technique as `test_people_query.py`'s copy of this class (kept
+    local rather than shared, so each test file stays independently
+    runnable): skips `ProxyDbBase.__init__` and defines no `include_*`/
+    `sanitize_*` overrides, so it filters nothing -- a query through it must
+    return exactly what the same query gets unproxied.
+    """
+
+    def __init__(self, db):
+        self.db = self.basedb = db
+
+
+# (url, a real text-typed select/order_by column for that type) -- every
+# object type this feature supports, including Person and Media (which
+# `TYPES` above omits since they get their own dedicated smoke-test classes).
+EQUIVALENCE_TYPES = [
+    ("/people/query/", "surname"),
+    ("/families/query/", "father_handle"),
+    ("/events/query/", "description"),
+    ("/places/query/", "title"),
+    ("/repositories/query/", "name"),
+    ("/sources/query/", "title"),
+    ("/citations/query/", "page"),
+    ("/notes/query/", "gramps_id"),
+    ("/tags/query/", "name"),
+    ("/media/query/", "desc"),
+]
+
+
+def _combo_plain_select(column):
+    return {"select": ["handle", column]}
+
+
+def _combo_where_filtered_and_sorted(column):
+    # "handle ne <bogus>" is true for every row -- it exists to exercise the
+    # WHERE-clause path itself (compiled SQL vs. evaluator-tested condition),
+    # not to narrow the result set, since which rows are private/excluded is
+    # covered elsewhere (e.g. test_private_people_excluded_without_permission).
+    return {
+        "select": ["handle", column],
+        "where": [{"column": "handle", "op": "ne", "value": "does-not-exist"}],
+        "order_by": [{"column": column, "direction": "asc"}],
+    }
+
+
+def _combo_order_by_handle_desc(column):
+    return {
+        "select": ["handle", column],
+        "order_by": [{"column": "handle", "direction": "desc"}],
+    }
+
+
+QUERY_COMBOS = [
+    _combo_plain_select,
+    _combo_where_filtered_and_sorted,
+    _combo_order_by_handle_desc,
+]
+
+
+class TestObjectQuerySqlProxiedEquivalence(unittest.TestCase):
+    """`_FakeNonPrivateProxy` filters nothing, so a request routed through it
+    (the Python evaluator, `proxied_query.run_query`) must return
+    byte-identical results to the same request unproxied (the SQL compiler,
+    `query.compile_query`) -- isolating "does the evaluator agree with the
+    compiler" from "does privacy filtering work" (covered elsewhere). A
+    small page size forces keyset pagination (`after`) on both paths too.
+
+    Parametrised across every object type and a few representative
+    select/where/order_by/limit/after shapes, so a future
+    gramps-object-query-language release that makes the two implementations
+    diverge on some type or shape doesn't go unnoticed -- previously only
+    one such comparison existed
+    (`test_non_private_proxy_database_routes_through_proxied_path`, Person
+    only, `select: ["handle"]` only).
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        """Test class setup."""
+        cls.client = get_test_client()
+        cls.maxDiff = None
+
+    def _fetch_all(self, url, header, body_without_paging, page_size=1000):
+        body = dict(body_without_paging)
+        body["limit"] = page_size
+        items = []
+        after = None
+        while True:
+            if after is not None:
+                body["after"] = after
+            rv = self.client.post(BASE_URL + url, json=body, headers=header)
+            self.assertEqual(rv.status_code, 200)
+            items.extend(rv.json["items"])
+            after = rv.json["next_after"]
+            if after is None:
+                return items
+
+    def _fetch_all_proxied(self, url, header, body_without_paging, page_size=1000):
+        def fake_get_db_handle(readonly=True):
+            db = get_db_handle(readonly=readonly)
+            base = db.basedb if isinstance(db, ProxyDbBase) else db
+            return _FakeNonPrivateProxy(base)
+
+        with patch(
+            "gramps_webapi.api.resources.object_query.get_db_handle",
+            side_effect=fake_get_db_handle,
+        ):
+            return self._fetch_all(url, header, body_without_paging, page_size)
+
+    def test_sql_and_proxied_paths_agree(self):
+        # page_size=1000 (the endpoint's own max `limit`) keeps this to a
+        # handful of pages per type even for example_gramps's largest tables
+        # (thousands of events/citations) -- a page size small enough to
+        # force many more round trips would make this prohibitively slow
+        # without exercising any code path a single crossed page boundary
+        # doesn't already cover (see the dedicated small-page test below for
+        # that).
+        header = fetch_header(self.client)
+        for url, column in EQUIVALENCE_TYPES:
+            for combo_fn in QUERY_COMBOS:
+                body = combo_fn(column)
+                with self.subTest(url=url, body=body):
+                    sql_items = self._fetch_all(url, header, body)
+                    proxied_items = self._fetch_all_proxied(url, header, body)
+                    self.assertEqual(sql_items, proxied_items)
+
+    def test_sql_and_proxied_paths_agree_across_small_pages(self):
+        # A page size of 1 forces every row boundary to also be a keyset-
+        # pagination boundary (`after`) on both paths -- exercises
+        # `_resolve_after`/`_resolve_after_proxied` agreeing on cursor
+        # resolution, not just the bulk row content a single large page
+        # would cover. Limited to the lowest-count types (repositories: 3,
+        # tags: 2 in example_gramps) so this stays a handful of requests
+        # instead of thousands.
+        header = fetch_header(self.client)
+        small_count_types = [
+            (url, column)
+            for url, column in EQUIVALENCE_TYPES
+            if url in ("/repositories/query/", "/tags/query/")
+        ]
+        for url, column in small_count_types:
+            body = _combo_where_filtered_and_sorted(column)
+            with self.subTest(url=url, body=body):
+                sql_items = self._fetch_all(url, header, body, page_size=1)
+                proxied_items = self._fetch_all_proxied(
+                    url, header, body, page_size=1
+                )
+                self.assertEqual(sql_items, proxied_items)
+                self.assertGreater(len(sql_items), 1)

--- a/tests/test_endpoints/test_object_query.py
+++ b/tests/test_endpoints/test_object_query.py
@@ -1,0 +1,177 @@
+#
+# Gramps Web API - A RESTful API for the Gramps genealogy program
+#
+# Copyright (C) 2026      Douglas Blank
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+#
+
+"""Smoke tests for the non-Person `POST .../query/` endpoints.
+
+`test_people_query.py` covers the Person endpoint (and the query AST) in
+depth. This file exists to prove the generalization to the other nine object
+types actually works end-to-end through real HTTP requests, not just through
+`ObjectTypeSpec`/`compile_query()` unit tests -- each type is wired to its
+own database table, whitelist, and privacy behavior.
+"""
+
+import unittest
+
+from . import BASE_URL, get_object_count, get_test_client
+from .util import fetch_header
+
+# (url, object-count key, a real text-typed select column for that type)
+TYPES = [
+    ("/families/query/", "families", "father_handle"),
+    ("/events/query/", "events", "description"),
+    ("/places/query/", "places", "title"),
+    ("/repositories/query/", "repositories", "name"),
+    ("/sources/query/", "sources", "title"),
+    ("/citations/query/", "citations", "page"),
+    ("/notes/query/", "notes", "gramps_id"),
+    ("/tags/query/", "tags", "name"),
+]
+
+
+class TestObjectQueryOtherTypes(unittest.TestCase):
+    """Basic wiring checks for each non-Person, non-Media query endpoint."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Test class setup."""
+        cls.client = get_test_client()
+        cls.maxDiff = None
+
+    def _fetch_all(self, header, url, body_without_paging, page_size=200):
+        """Page through an endpoint via keyset pagination, collecting all rows."""
+        body = dict(body_without_paging)
+        body["limit"] = page_size
+        items = []
+        after = None
+        while True:
+            if after is not None:
+                body["after"] = after
+            rv = self.client.post(BASE_URL + url, json=body, headers=header)
+            self.assertEqual(rv.status_code, 200)
+            items.extend(rv.json["items"])
+            after = rv.json["next_after"]
+            if after is None:
+                return items
+
+    def test_each_type_returns_full_count_with_correct_columns(self):
+        header = fetch_header(self.client)
+        for url, count_key, column in TYPES:
+            with self.subTest(url=url):
+                items = self._fetch_all(header, url, {"select": ["handle", column]})
+                self.assertEqual(len(items), get_object_count(count_key))
+                for item in items:
+                    self.assertEqual(set(item), {"handle", column})
+
+    def test_each_type_rejects_unknown_column(self):
+        header = fetch_header(self.client)
+        for url, _count_key, _column in TYPES:
+            with self.subTest(url=url):
+                rv = self.client.post(
+                    BASE_URL + url,
+                    json={"select": ["not_a_real_column"]},
+                    headers=header,
+                )
+                self.assertEqual(rv.status_code, 422)
+
+    def test_each_type_requires_token(self):
+        for url, _count_key, _column in TYPES:
+            with self.subTest(url=url):
+                rv = self.client.post(BASE_URL + url, json={})
+                self.assertEqual(rv.status_code, 401)
+
+
+class TestObjectQueryTag(unittest.TestCase):
+    """Tag is the one type with no `private` secondary column."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Test class setup."""
+        cls.client = get_test_client()
+
+    def test_tag_query_works_without_a_private_column(self):
+        header = fetch_header(self.client)
+        rv = self.client.post(
+            BASE_URL + "/tags/query/",
+            json={"select": ["handle", "name"], "limit": 1000},
+            headers=header,
+        )
+        self.assertEqual(rv.status_code, 200)
+        self.assertEqual(len(rv.json["items"]), get_object_count("tags"))
+
+    def test_private_is_not_a_selectable_tag_column(self):
+        header = fetch_header(self.client)
+        rv = self.client.post(
+            BASE_URL + "/tags/query/",
+            json={"select": ["private"]},
+            headers=header,
+        )
+        self.assertEqual(rv.status_code, 422)
+
+
+class TestObjectQueryMedia(unittest.TestCase):
+    """Media has a `desc` column -- a reserved word on PostgreSQL.
+
+    Regression coverage for `query.py`'s `_quote_column()`: selecting,
+    filtering, and sorting by `desc` must not break the generated SQL.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        """Test class setup."""
+        cls.client = get_test_client()
+
+    def test_select_desc_column(self):
+        header = fetch_header(self.client)
+        rv = self.client.post(
+            BASE_URL + "/media/query/",
+            json={"select": ["handle", "desc"], "limit": 1000},
+            headers=header,
+        )
+        self.assertEqual(rv.status_code, 200)
+        self.assertEqual(len(rv.json["items"]), get_object_count("media"))
+        for item in rv.json["items"]:
+            self.assertEqual(set(item), {"handle", "desc"})
+
+    def test_order_by_desc_column(self):
+        header = fetch_header(self.client)
+        rv = self.client.post(
+            BASE_URL + "/media/query/",
+            json={
+                "select": ["desc"],
+                "order_by": [{"column": "desc", "direction": "asc"}],
+                "limit": 1000,
+            },
+            headers=header,
+        )
+        self.assertEqual(rv.status_code, 200)
+        descs = [item["desc"] or "" for item in rv.json["items"]]
+        self.assertEqual(descs, sorted(descs))
+
+    def test_where_desc_column(self):
+        header = fetch_header(self.client)
+        rv = self.client.post(
+            BASE_URL + "/media/query/",
+            json={
+                "select": ["handle"],
+                "where": [{"column": "desc", "op": "ne", "value": ""}],
+                "limit": 1000,
+            },
+            headers=header,
+        )
+        self.assertEqual(rv.status_code, 200)

--- a/tests/test_endpoints/test_people_query.py
+++ b/tests/test_endpoints/test_people_query.py
@@ -287,6 +287,39 @@ class TestPeopleQuery(unittest.TestCase):
         self.assertEqual(len(seen_handles), total)
         self.assertEqual(len(set(seen_handles)), total)  # no duplicates/overlap
 
+    def test_next_after_is_null_when_page_exactly_exhausts_results(self):
+        # Regression test: a naive `len(rows) == limit` check can't tell "the
+        # last page happens to be full" apart from "there's another page
+        # coming", forcing a wasted follow-up request. Asking for exactly
+        # as many rows as match in one page must report no next page.
+        # Filtered to gender == FEMALE since example_gramps has more people
+        # than the endpoint's max `limit` (1000) -- a where filter is needed
+        # to get a matching count small enough to request in a single page.
+        header = fetch_header(self.client)
+        where = [{"column": "gender", "op": "eq", "value": 0}]
+        probe = self.client.post(
+            TEST_URL,
+            json={"select": ["handle"], "where": where, "limit": 1, "count": True},
+            headers=header,
+        )
+        self.assertEqual(probe.status_code, 200)
+        total = int(probe.headers["X-Total-Count"])
+        self.assertLessEqual(total, 1000)  # fits in a single page
+
+        rv = self.client.post(
+            TEST_URL,
+            json={
+                "select": ["handle"],
+                "where": where,
+                "order_by": [{"column": "handle", "direction": "asc"}],
+                "limit": total,
+            },
+            headers=header,
+        )
+        self.assertEqual(rv.status_code, 200)
+        self.assertEqual(len(rv.json["items"]), total)
+        self.assertIsNone(rv.json["next_after"])
+
     def test_invalid_after_cursor_rejected(self):
         header = fetch_header(self.client)
         rv = self.client.post(
@@ -346,6 +379,35 @@ class TestPeopleQuery(unittest.TestCase):
             headers=header,
         )
         self.assertEqual(rv.status_code, 200)
+
+    def test_locale_rejected_on_proxied_path(self):
+        # The proxied path (`run_query`) sorts in plain Python order with no
+        # `COLLATE` equivalent to the SQL path's `locale` param -- silently
+        # ignoring `locale` there would return a different sort order than
+        # the same request gets when unproxied, depending on the caller's
+        # permissions alone. Must be rejected outright instead.
+        header = fetch_header(self.client)
+
+        def fake_get_db_handle(readonly=True):
+            db = get_db_handle(readonly=readonly)
+            base = db.basedb if isinstance(db, ProxyDbBase) else db
+            return _FakeNonPrivateProxy(base)
+
+        with patch(
+            "gramps_webapi.api.resources.object_query.get_db_handle",
+            side_effect=fake_get_db_handle,
+        ):
+            rv = self.client.post(
+                TEST_URL,
+                json={
+                    "select": ["handle"],
+                    "order_by": [{"column": "surname", "direction": "asc"}],
+                    "locale": "de",
+                    "limit": 5,
+                },
+                headers=header,
+            )
+        self.assertEqual(rv.status_code, 422)
 
     def test_private_people_excluded_without_permission(self):
         # ROLE_GUEST lacks PERM_VIEW_PRIVATE; ROLE_OWNER has it. (ROLE_MEMBER

--- a/tests/test_endpoints/test_people_query.py
+++ b/tests/test_endpoints/test_people_query.py
@@ -24,6 +24,7 @@ from unittest.mock import patch
 
 from gramps.gen.proxy.proxybase import ProxyDbBase
 
+from gramps_webapi.api.resources.object_query import run_query as _real_run_query
 from gramps_webapi.api.util import get_db_handle
 from gramps_webapi.auth.const import ROLE_GUEST, ROLE_OWNER
 
@@ -408,6 +409,63 @@ class TestPeopleQuery(unittest.TestCase):
                 headers=header,
             )
         self.assertEqual(rv.status_code, 422)
+
+    def _count_with_call_tracking(self, header, body):
+        """POST to the proxied path, returning (response, run_query call count)."""
+
+        def fake_get_db_handle(readonly=True):
+            db = get_db_handle(readonly=readonly)
+            base = db.basedb if isinstance(db, ProxyDbBase) else db
+            return _FakeNonPrivateProxy(base)
+
+        calls = []
+
+        def counting_run_query(*args, **kwargs):
+            calls.append(kwargs)
+            return _real_run_query(*args, **kwargs)
+
+        with patch(
+            "gramps_webapi.api.resources.object_query.get_db_handle",
+            side_effect=fake_get_db_handle,
+        ), patch(
+            "gramps_webapi.api.resources.object_query.run_query",
+            side_effect=counting_run_query,
+        ):
+            rv = self.client.post(TEST_URL, json=body, headers=header)
+        return rv, len(calls)
+
+    def test_proxied_count_reuses_first_page_when_it_is_the_whole_result(self):
+        # When the (over-fetched) first page already contains every match --
+        # no `after`, and fewer rows came back than the over-fetch asked
+        # for -- the total is just `len(rows)`. No need to re-run
+        # `run_query` a second time, with no `limit` at all, just to
+        # recompute a number the first call already established.
+        header = fetch_header(self.client)
+        rv, call_count = self._count_with_call_tracking(
+            header,
+            {
+                "select": ["handle"],
+                "where": [{"column": "gramps_id", "op": "eq", "value": "I0000"}],
+                "limit": 50,
+                "count": True,
+            },
+        )
+        self.assertEqual(rv.status_code, 200)
+        self.assertEqual(int(rv.headers["X-Total-Count"]), len(rv.json["items"]))
+        self.assertEqual(call_count, 1)  # no second, unlimited count query
+
+    def test_proxied_count_still_needs_second_query_when_paginated(self):
+        # A page that does *not* already contain every match -- because
+        # there are more rows beyond it -- can't infer the total from
+        # `rows` alone, and still needs the second, unlimited `run_query`.
+        header = fetch_header(self.client)
+        rv, call_count = self._count_with_call_tracking(
+            header,
+            {"select": ["handle"], "limit": 2, "count": True},
+        )
+        self.assertEqual(rv.status_code, 200)
+        self.assertEqual(int(rv.headers["X-Total-Count"]), get_object_count("people"))
+        self.assertEqual(call_count, 2)
 
     def test_private_people_excluded_without_permission(self):
         # ROLE_GUEST lacks PERM_VIEW_PRIVATE; ROLE_OWNER has it. (ROLE_MEMBER

--- a/tests/test_endpoints/test_people_query.py
+++ b/tests/test_endpoints/test_people_query.py
@@ -1,0 +1,377 @@
+#
+# Gramps Web API - A RESTful API for the Gramps genealogy program
+#
+# Copyright (C) 2026      Douglas Blank
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+#
+
+"""Tests for the POST /api/people/query/ endpoint using example_gramps."""
+
+import unittest
+from unittest.mock import patch
+
+from gramps.gen.proxy.proxybase import ProxyDbBase
+
+from gramps_webapi.api.util import get_db_handle
+from gramps_webapi.auth.const import ROLE_GUEST, ROLE_OWNER
+
+from . import BASE_URL, get_object_count, get_test_client
+from .util import fetch_header
+
+TEST_URL = BASE_URL + "/people/query/"
+
+
+class _FakeNonPrivateProxy(ProxyDbBase):
+    """Minimal stand-in for a non-privacy proxy (e.g. `LivingProxyDb`).
+
+    Deliberately skips `ProxyDbBase.__init__`'s bookmark/name-format wiring
+    -- it only needs to be recognized as *some* `ProxyDbBase`, to exercise
+    the endpoint's proxied dispatch path. Defines no `include_*`/`sanitize_*`
+    overrides of its own, so `ProxyDbBase`'s own defaults (pass everything
+    through) apply -- this proxy filters nothing, so a query through it
+    should return exactly what an unproxied query would.
+    """
+
+    def __init__(self, db):
+        self.db = self.basedb = db
+
+
+class TestPeopleQuery(unittest.TestCase):
+    """Test cases for the fast, SQL-pushed-down Person query endpoint."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Test class setup."""
+        cls.client = get_test_client()
+        cls.maxDiff = None
+
+    def _fetch_all(self, header, body_without_paging, page_size=200):
+        """Page through the endpoint via keyset pagination, collecting all rows.
+
+        Needed because example_gramps has more people than the endpoint's
+        max `limit` (1000), so a single request can't retrieve everything.
+        """
+        body = dict(body_without_paging)
+        body.setdefault("order_by", [{"column": "handle", "direction": "asc"}])
+        body["limit"] = page_size
+        items = []
+        after = None
+        while True:
+            if after is not None:
+                body["after"] = after
+            rv = self.client.post(TEST_URL, json=body, headers=header)
+            self.assertEqual(rv.status_code, 200)
+            items.extend(rv.json["items"])
+            after = rv.json["next_after"]
+            if after is None:
+                return items
+
+    def test_requires_token(self):
+        rv = self.client.post(TEST_URL, json={})
+        self.assertEqual(rv.status_code, 401)
+
+    def test_non_private_proxy_database_routes_through_proxied_path(self):
+        # get_db_handle() never actually constructs anything other than the
+        # raw db or a PrivateProxyDb today -- but the endpoint must not
+        # *assume* that. Any `ProxyDbBase` (e.g. a future LivingProxyDb)
+        # must be queryable correctly: dispatch goes through Gramps' own
+        # Filter/Rule machinery (proxied_query.run_query) rather than a
+        # second, SQL-side reimplementation of that proxy's rules -- so
+        # results reflect whatever *this* proxy actually filters, not a
+        # hardcoded assumption about which proxy types are "safe" to bypass.
+        header = fetch_header(self.client)
+
+        def fake_get_db_handle(readonly=True):
+            db = get_db_handle(readonly=readonly)
+            base = db.basedb if isinstance(db, ProxyDbBase) else db
+            return _FakeNonPrivateProxy(base)
+
+        with patch(
+            "gramps_webapi.api.resources.object_query.get_db_handle",
+            side_effect=fake_get_db_handle,
+        ):
+            items = self._fetch_all(header, {"select": ["handle"]})
+        # This fake proxy filters nothing, so it must match the unproxied
+        # SQL path's result exactly.
+        self.assertEqual(len(items), get_object_count("people"))
+
+    def test_default_query_returns_all_people(self):
+        header = fetch_header(self.client)
+        items = self._fetch_all(header, {"select": ["handle"]})
+        self.assertEqual(len(items), get_object_count("people"))
+
+    def test_total_count_omitted_by_default(self):
+        # Matches the rest of the API's convention (objects.py/emit.py/
+        # history.py): total count is an X-Total-Count response header, not
+        # a body field -- and it's opt-in here since, unlike those endpoints,
+        # it costs a genuinely separate COUNT(*) query.
+        header = fetch_header(self.client)
+        rv = self.client.post(TEST_URL, json={"limit": 5}, headers=header)
+        self.assertEqual(rv.status_code, 200)
+        self.assertNotIn("X-Total-Count", rv.headers)
+
+    def test_total_count_reflects_all_matching_rows_not_just_this_page(self):
+        header = fetch_header(self.client)
+        rv = self.client.post(
+            TEST_URL, json={"select": ["handle"], "limit": 5, "count": True}, headers=header
+        )
+        self.assertEqual(rv.status_code, 200)
+        self.assertEqual(len(rv.json["items"]), 5)  # capped by limit
+        self.assertEqual(int(rv.headers["X-Total-Count"]), get_object_count("people"))
+
+    def test_total_count_respects_where_filter(self):
+        header = fetch_header(self.client)
+        rv = self.client.post(
+            TEST_URL,
+            json={
+                "select": ["handle"],
+                "where": [{"column": "gender", "op": "eq", "value": 1}],
+                "limit": 5,
+                "count": True,
+            },
+            headers=header,
+        )
+        self.assertEqual(rv.status_code, 200)
+        all_items = self._fetch_all(header, {"select": ["handle"]})
+        total_count = int(rv.headers["X-Total-Count"])
+        self.assertGreater(total_count, 0)
+        self.assertLess(total_count, len(all_items))
+
+    def test_total_count_stable_across_pages(self):
+        header = fetch_header(self.client)
+        body = {
+            "select": ["handle"],
+            "order_by": [{"column": "handle", "direction": "asc"}],
+            "limit": 5,
+            "count": True,
+        }
+        rv1 = self.client.post(TEST_URL, json=body, headers=header)
+        body_page2 = dict(body, after=rv1.json["next_after"])
+        rv2 = self.client.post(TEST_URL, json=body_page2, headers=header)
+        self.assertEqual(rv1.headers["X-Total-Count"], rv2.headers["X-Total-Count"])
+        self.assertEqual(int(rv1.headers["X-Total-Count"]), get_object_count("people"))
+
+    def test_select_restricts_returned_columns(self):
+        header = fetch_header(self.client)
+        rv = self.client.post(
+            TEST_URL,
+            json={"select": ["handle", "surname"], "limit": 5},
+            headers=header,
+        )
+        self.assertEqual(rv.status_code, 200)
+        for item in rv.json["items"]:
+            self.assertEqual(set(item), {"handle", "surname"})
+
+    def test_where_eq_filters_rows(self):
+        header = fetch_header(self.client)
+        all_items = self._fetch_all(header, {"select": ["handle"]})
+        male_items = self._fetch_all(
+            header,
+            {
+                "select": ["handle"],
+                "where": [{"column": "gender", "op": "eq", "value": 1}],
+            },
+        )
+        self.assertGreater(len(male_items), 0)
+        self.assertLess(len(male_items), len(all_items))
+
+    def test_unknown_column_in_where_rejected(self):
+        header = fetch_header(self.client)
+        rv = self.client.post(
+            TEST_URL,
+            json={"where": [{"column": "not_a_column", "op": "eq", "value": 1}]},
+            headers=header,
+        )
+        self.assertEqual(rv.status_code, 422)
+
+    def test_unknown_column_in_select_rejected(self):
+        header = fetch_header(self.client)
+        rv = self.client.post(
+            TEST_URL, json={"select": ["not_a_column"]}, headers=header
+        )
+        self.assertEqual(rv.status_code, 422)
+
+    def test_unknown_column_in_order_by_rejected(self):
+        header = fetch_header(self.client)
+        rv = self.client.post(
+            TEST_URL,
+            json={"order_by": [{"column": "not_a_column"}]},
+            headers=header,
+        )
+        self.assertEqual(rv.status_code, 422)
+
+    def test_in_requires_nonempty_list(self):
+        header = fetch_header(self.client)
+        rv = self.client.post(
+            TEST_URL,
+            json={"where": [{"column": "gender", "op": "in", "value": []}]},
+            headers=header,
+        )
+        self.assertEqual(rv.status_code, 422)
+
+    def test_order_by_surname_is_sorted(self):
+        header = fetch_header(self.client)
+        rv = self.client.post(
+            TEST_URL,
+            json={
+                "select": ["surname"],
+                "order_by": [{"column": "surname", "direction": "asc"}],
+                "limit": 1000,
+            },
+            headers=header,
+        )
+        self.assertEqual(rv.status_code, 200)
+        surnames = [item["surname"] or "" for item in rv.json["items"]]
+        self.assertEqual(surnames, sorted(surnames))
+
+    def test_no_locale_uses_plain_codepoint_order_not_system_locale(self):
+        # Regression test: requests without an explicit `locale` must sort by
+        # plain codepoint order (matching Python's sorted()), not silently
+        # apply the server process's system locale collation. example_gramps
+        # includes "Álvarez", which a locale-aware (e.g. en_US) collation
+        # sorts near "Alvarez" -- with "A" names -- while codepoint order
+        # (and SQLite's default BINARY collation) sorts it after all
+        # plain-ASCII names, since 'Á' > 'z' by codepoint.
+        header = fetch_header(self.client)
+        items = self._fetch_all(
+            header,
+            {
+                "select": ["surname"],
+                "order_by": [{"column": "surname", "direction": "asc"}],
+            },
+        )
+        surnames = [item["surname"] or "" for item in items]
+        self.assertEqual(surnames, sorted(surnames))
+        self.assertIn("Álvarez", surnames)
+        # Under codepoint order, "Á" (U+00C1) sorts after all plain-ASCII
+        # letters -- so "Álvarez" must come after "Andersen", not be
+        # interleaved with the "A" names the way locale-aware collation
+        # (which treats "Á" as close to "A") would place it.
+        self.assertGreater(surnames.index("Álvarez"), surnames.index("Andersen"))
+
+    def test_keyset_pagination_covers_all_rows_without_overlap(self):
+        header = fetch_header(self.client)
+        total = get_object_count("people")
+        page_size = max(1, total // 3)
+
+        seen_handles = []
+        after = None
+        for _ in range(total + 1):  # safety bound against an infinite loop
+            body = {
+                "select": ["handle"],
+                "order_by": [{"column": "surname", "direction": "asc"}],
+                "limit": page_size,
+            }
+            if after is not None:
+                body["after"] = after
+            rv = self.client.post(TEST_URL, json=body, headers=header)
+            self.assertEqual(rv.status_code, 200)
+            handles = [item["handle"] for item in rv.json["items"]]
+            seen_handles.extend(handles)
+            after = rv.json["next_after"]
+            if after is None:
+                break
+
+        self.assertEqual(len(seen_handles), total)
+        self.assertEqual(len(set(seen_handles)), total)  # no duplicates/overlap
+
+    def test_invalid_after_cursor_rejected(self):
+        header = fetch_header(self.client)
+        rv = self.client.post(
+            TEST_URL,
+            json={"after": "does-not-exist"},
+            headers=header,
+        )
+        self.assertEqual(rv.status_code, 422)
+
+    def test_limit_out_of_range_rejected(self):
+        header = fetch_header(self.client)
+        rv = self.client.post(TEST_URL, json={"limit": 0}, headers=header)
+        self.assertEqual(rv.status_code, 422)
+        rv = self.client.post(TEST_URL, json={"limit": 100000}, headers=header)
+        self.assertEqual(rv.status_code, 422)
+
+    def test_locale_sort_returns_sorted_results(self):
+        header = fetch_header(self.client)
+        items = self._fetch_all(
+            header,
+            {
+                "select": ["surname"],
+                "order_by": [{"column": "surname", "direction": "asc"}],
+                "locale": "de",
+            },
+        )
+        # Locale collation can reorder relative to a plain Python sort (e.g.
+        # accented characters), so just confirm the request succeeds and
+        # returns every row -- exact ordering under German collation isn't
+        # asserted here.
+        self.assertEqual(len(items), get_object_count("people"))
+
+    def test_unrecognized_locale_falls_back_to_default(self):
+        header = fetch_header(self.client)
+        rv = self.client.post(
+            TEST_URL,
+            json={
+                "select": ["handle"],
+                "order_by": [{"column": "surname", "direction": "asc"}],
+                "locale": "zz",
+                "limit": 5,
+            },
+            headers=header,
+        )
+        self.assertEqual(rv.status_code, 200)
+
+    def test_locale_sort_does_not_apply_collate_to_non_text_columns(self):
+        header = fetch_header(self.client)
+        rv = self.client.post(
+            TEST_URL,
+            json={
+                "select": ["handle"],
+                "order_by": [{"column": "gender", "direction": "asc"}],
+                "locale": "de",
+                "limit": 5,
+            },
+            headers=header,
+        )
+        self.assertEqual(rv.status_code, 200)
+
+    def test_private_people_excluded_without_permission(self):
+        # ROLE_GUEST lacks PERM_VIEW_PRIVATE; ROLE_OWNER has it. (ROLE_MEMBER
+        # is *not* a valid "lacks PERM_VIEW_PRIVATE" role in this codebase --
+        # PERMISSIONS[ROLE_MEMBER] already grants it, per auth/const.py.)
+        header_owner = fetch_header(self.client, role=ROLE_OWNER)
+        header_guest = fetch_header(self.client, role=ROLE_GUEST)
+
+        # example_gramps ships with no private people, so create one --
+        # otherwise this check would pass vacuously regardless of whether
+        # privacy filtering actually works.
+        handle = "test_query_private_person"
+        rv = self.client.post(
+            BASE_URL + "/people/",
+            json={"_class": "Person", "handle": handle, "private": True},
+            headers=header_owner,
+        )
+        self.assertEqual(rv.status_code, 201)
+        try:
+            owner_items = self._fetch_all(header_owner, {"select": ["handle"]})
+            guest_items = self._fetch_all(header_guest, {"select": ["handle"]})
+            owner_handles = {item["handle"] for item in owner_items}
+            guest_handles = {item["handle"] for item in guest_items}
+
+            self.assertIn(handle, owner_handles)
+            self.assertNotIn(handle, guest_handles)
+            self.assertEqual(len(owner_handles) - len(guest_handles), 1)
+        finally:
+            self.client.delete(BASE_URL + f"/people/{handle}", headers=header_owner)

--- a/tests/test_object_query_parsing.py
+++ b/tests/test_object_query_parsing.py
@@ -1,0 +1,493 @@
+#
+# Gramps Web API - A RESTful API for the Gramps genealogy program
+#
+# Copyright (C) 2026      Douglas Blank
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+#
+
+"""Pure unit tests for `object_query.py`'s request-parsing helpers.
+
+Deliberately independent of the Flask app / test client -- these are plain
+functions with no app-context dependency, and the shared endpoint test app
+fixture (`tests/test_endpoints/__init__.py`) pulls in a sentence-transformers
+model load that's broken in some local dev environments (unrelated to this
+module). Full request/response wiring is still covered by
+`tests/test_endpoints/test_people_query.py` and `test_object_query.py`.
+"""
+
+import pytest
+from gramps.plugins.db.dbapi.sqlite import SQLite
+from werkzeug.exceptions import HTTPException
+
+from gramps_object_query_language.query import (
+    FAMILY,
+    PERSON,
+    Dialect,
+    JsonPath,
+    OrderBy,
+    QueryError,
+    RelatedObject,
+    resolve_column_path,
+)
+from gramps_webapi.api.resources.object_query import (
+    _build_where,
+    _check_no_duplicate_keys,
+    _default_key_for,
+    _normalize_json_value,
+    _parse_column_ref,
+    _parse_select_entry,
+    _resolve_after,
+    _resolve_dialect,
+    _resolve_treeid,
+    _resolve_where_conditions,
+    _terminal_is_json_path,
+)
+
+
+# --- _parse_column_ref -------------------------------------------------------
+
+
+def test_parse_column_ref_plain_string():
+    assert _parse_column_ref("gramps_id", PERSON) == "gramps_id"
+
+
+def test_parse_column_ref_json_path():
+    ref = _parse_column_ref({"json_path": ["primary_name", "first_name"]}, PERSON)
+    assert ref == JsonPath(("primary_name", "first_name"))
+
+
+def test_parse_column_ref_relationship_crossing_path():
+    ref = _parse_column_ref({"json_path": ["birth", "date", "sortval"]}, PERSON)
+    assert ref == resolve_column_path(PERSON, ["birth", "date", "sortval"])
+    assert isinstance(ref, RelatedObject)
+
+
+def test_parse_column_ref_family_father_surname():
+    ref = _parse_column_ref({"json_path": ["father", "surname"]}, FAMILY)
+    assert ref == resolve_column_path(FAMILY, ["father", "surname"])
+
+
+def test_parse_column_ref_rejects_non_str_non_dict():
+    with pytest.raises(QueryError):
+        _parse_column_ref(123, PERSON)
+
+
+def test_parse_column_ref_rejects_dict_without_json_path_key():
+    with pytest.raises(QueryError):
+        _parse_column_ref({"column": "gramps_id"}, PERSON)
+
+
+def test_parse_column_ref_rejects_non_list_json_path():
+    with pytest.raises(QueryError):
+        _parse_column_ref({"json_path": "primary_name.first_name"}, PERSON)
+
+
+def test_parse_column_ref_rejects_empty_json_path():
+    with pytest.raises(QueryError):
+        _parse_column_ref({"json_path": []}, PERSON)
+
+
+def test_parse_column_ref_rejects_bad_segment_type():
+    # Bubbles up from JsonPath.__post_init__ -- bool disguised as int, float,
+    # None, nested list, etc. are all rejected there.
+    with pytest.raises(QueryError):
+        _parse_column_ref({"json_path": ["primary_name", True]}, PERSON)
+    with pytest.raises(QueryError):
+        _parse_column_ref({"json_path": ["primary_name", 1.5]}, PERSON)
+
+
+def test_parse_column_ref_rejects_bare_relationship_name():
+    # "birth" alone isn't a value -- needs a further path (resolve_column_path).
+    with pytest.raises(QueryError):
+        _parse_column_ref({"json_path": ["birth"]}, PERSON)
+
+
+# --- _default_key_for -----------------------------------------------------------
+
+
+def test_default_key_for_plain_string():
+    assert _default_key_for("gramps_id") == "gramps_id"
+
+
+def test_default_key_for_json_path_str_segments():
+    path = JsonPath(("primary_name", "first_name"))
+    assert _default_key_for(path) == "primary_name.first_name"
+
+
+def test_default_key_for_json_path_with_int_segment():
+    path = JsonPath(("primary_name", "surname_list", 0, "surname"))
+    assert _default_key_for(path) == "primary_name.surname_list[0].surname"
+
+
+def test_default_key_for_json_path_leading_int_segment():
+    path = JsonPath((0, "value"))
+    assert _default_key_for(path) == "[0].value"
+
+
+def test_default_key_for_json_path_single_segment():
+    assert _default_key_for(JsonPath(("gender",))) == "gender"
+
+
+def test_default_key_for_related_object():
+    ref = resolve_column_path(PERSON, ["birth", "date", "sortval"])
+    assert _default_key_for(ref) == "birth.date.sortval"
+
+
+def test_default_key_for_two_hop_related_object():
+    ref = resolve_column_path(PERSON, ["birth", "place", "title"])
+    assert _default_key_for(ref) == "birth.place.title"
+
+
+def test_default_key_for_related_object_plain_field():
+    ref = resolve_column_path(FAMILY, ["father", "surname"])
+    assert _default_key_for(ref) == "father.surname"
+
+
+# --- _parse_select_entry -------------------------------------------------------
+
+
+def test_parse_select_entry_plain_string():
+    assert _parse_select_entry("surname", PERSON) == ("surname", "surname")
+
+
+def test_parse_select_entry_json_path_without_alias_uses_derived_key():
+    ref, key = _parse_select_entry(
+        {"json_path": ["primary_name", "surname_list", 0, "surname"]}, PERSON
+    )
+    assert ref == JsonPath(("primary_name", "surname_list", 0, "surname"))
+    assert key == "primary_name.surname_list[0].surname"
+
+
+def test_parse_select_entry_json_path_with_alias():
+    ref, key = _parse_select_entry(
+        {"json_path": ["primary_name", "first_name"], "as": "first"}, PERSON
+    )
+    assert ref == JsonPath(("primary_name", "first_name"))
+    assert key == "first"
+
+
+def test_parse_select_entry_rejects_handle_alias_on_json_path():
+    # The response's "handle" key is load-bearing for next_after -- letting a
+    # client shadow it with unrelated JSON content would corrupt pagination
+    # silently.
+    with pytest.raises(QueryError):
+        _parse_select_entry(
+            {"json_path": ["primary_name", "first_name"], "as": "handle"}, PERSON
+        )
+
+
+def test_parse_select_entry_plain_handle_column_is_fine():
+    assert _parse_select_entry("handle", PERSON) == ("handle", "handle")
+
+
+def test_parse_select_entry_rejects_invalid_shape():
+    with pytest.raises(QueryError):
+        _parse_select_entry(123, PERSON)
+
+
+def test_parse_select_entry_relationship_crossing_default_key():
+    ref, key = _parse_select_entry({"json_path": ["birth", "date"]}, PERSON)
+    assert isinstance(ref, RelatedObject)
+    assert key == "birth.date"
+
+
+def test_parse_select_entry_relationship_crossing_with_alias():
+    ref, key = _parse_select_entry(
+        {"json_path": ["father", "surname"], "as": "father_surname"}, FAMILY
+    )
+    assert key == "father_surname"
+
+
+# --- _check_no_duplicate_keys --------------------------------------------------
+
+
+def test_check_no_duplicate_keys_passes_for_unique_keys():
+    _check_no_duplicate_keys([("a", "a"), ("b", "b")])  # no raise
+
+
+def test_check_no_duplicate_keys_rejects_duplicate():
+    path_a = JsonPath(("x",))
+    path_b = JsonPath(("y",))
+    with pytest.raises(QueryError):
+        _check_no_duplicate_keys([(path_a, "same"), (path_b, "same")])
+
+
+# --- _terminal_is_json_path / _normalize_json_value -----------------------------
+
+
+def test_terminal_is_json_path_plain_string_false():
+    assert _terminal_is_json_path("surname") is False
+
+
+def test_terminal_is_json_path_json_path_true():
+    assert _terminal_is_json_path(JsonPath(("primary_name", "first_name"))) is True
+
+
+def test_terminal_is_json_path_related_object_plain_field_false():
+    # father.surname ends in a real flat column -- no JSON functions
+    # involved at all, so no normalization needed.
+    ref = resolve_column_path(FAMILY, ["father", "surname"])
+    assert _terminal_is_json_path(ref) is False
+
+
+def test_terminal_is_json_path_related_object_json_path_field_true():
+    ref = resolve_column_path(PERSON, ["birth", "date"])
+    assert _terminal_is_json_path(ref) is True
+
+
+def test_terminal_is_json_path_chained_related_object():
+    # birth.place.title: the chain's own leaf ("title") is a plain column,
+    # even though an intermediate hop (birth -> Event) uses a JsonPath
+    # internally for its handle_ref -- only the final `field` matters.
+    ref = resolve_column_path(PERSON, ["birth", "place", "title"])
+    assert _terminal_is_json_path(ref) is False
+
+
+def test_normalize_json_value_parses_json_object_string():
+    assert _normalize_json_value('{"sortval": 2439857}') == {"sortval": 2439857}
+
+
+def test_normalize_json_value_parses_json_number_string():
+    # PostgreSQL's jsonb_extract_path_text always returns TEXT, even for a
+    # scalar number -- confirmed live ('2439857', not a native int).
+    assert _normalize_json_value("2439857") == 2439857
+
+
+def test_normalize_json_value_passes_through_dict():
+    # PostgreSQL's jsonb expressions can also come back through psycopg2
+    # already parsed for some call shapes -- nothing to do in that case.
+    value = {"sortval": 2439857}
+    assert _normalize_json_value(value) is value
+
+
+def test_normalize_json_value_passes_through_none():
+    assert _normalize_json_value(None) is None
+
+
+def test_normalize_json_value_passes_through_non_json_text():
+    # A free-text value that happens not to be valid JSON (e.g. SQLite's
+    # json_extract on a plain string field already de-quotes it) must not
+    # raise -- returned unchanged.
+    assert _normalize_json_value("About 1968") == "About 1968"
+
+
+# --- _resolve_dialect -----------------------------------------------------------
+
+
+class _FakeDbWithDialect:
+    def __init__(self, dialect):
+        self.dialect = dialect
+
+
+class _FakeDbNoDialect:
+    pass
+
+
+def test_resolve_dialect_uses_explicit_attribute_when_present():
+    assert _resolve_dialect(_FakeDbWithDialect("sqlite")) == Dialect.SQLITE
+    assert _resolve_dialect(_FakeDbWithDialect("postgres")) == Dialect.POSTGRESQL
+    assert _resolve_dialect(_FakeDbWithDialect("postgresql")) == Dialect.POSTGRESQL
+
+
+def test_resolve_dialect_detects_real_sqlite_instance_without_dialect_attr():
+    # No released Gramps core sets `.dialect` yet -- this is the fallback
+    # that keeps every SQLite-backed test fixture and single-tree/dev
+    # deployment from silently getting PostgreSQL-only SQL syntax.
+    basedb = SQLite.__new__(SQLite)  # bypass __init__ -- isinstance is enough
+    assert not hasattr(basedb, "dialect")
+    assert _resolve_dialect(basedb) == Dialect.SQLITE
+
+
+def test_resolve_dialect_falls_back_to_postgresql_for_unknown_backend():
+    assert _resolve_dialect(_FakeDbNoDialect()) == Dialect.POSTGRESQL
+
+
+def test_resolve_dialect_ignores_unrecognized_explicit_dialect_name():
+    # An unrecognized `.dialect` string falls through to the isinstance/
+    # default fallback rather than raising -- resolution here never fails,
+    # `compile_query` raises `QueryError` if the dialect actually turns out
+    # to be unsupported when rendering a `JsonPath`.
+    assert _resolve_dialect(_FakeDbWithDialect("mysql")) == Dialect.POSTGRESQL
+
+
+# --- _resolve_treeid ------------------------------------------------------------
+#
+# SharedPostgreSQL stores every tree's rows in the same physical tables --
+# `treeid` is the only thing that scopes a query to the caller's own tree.
+
+
+class _FakeDbapiWithTreeid:
+    treeid = 7
+
+
+class _FakeBasedbWithTreeidDbapi:
+    dbapi = _FakeDbapiWithTreeid()
+
+
+class _FakeDbapiNoTreeid:
+    pass
+
+
+class _FakeBasedbNoTreeidDbapi:
+    dbapi = _FakeDbapiNoTreeid()
+
+
+def test_resolve_treeid_reads_dbapi_treeid_when_present():
+    assert _resolve_treeid(_FakeBasedbWithTreeidDbapi()) == 7
+
+
+def test_resolve_treeid_returns_none_for_single_tree_backend():
+    # SQLite / single-user PostgreSQL have no `.dbapi.treeid` at all --
+    # `None` means "omit the clause", not "unscoped is fine by default".
+    assert _resolve_treeid(_FakeBasedbNoTreeidDbapi()) is None
+
+
+# --- _resolve_after treeid scoping -----------------------------------------------
+
+
+class _FakeAfterDbapi:
+    def __init__(self, row):
+        self._row = row
+        self.calls = []
+
+    def execute(self, sql, params):
+        self.calls.append((sql, params))
+
+    def fetchone(self):
+        return self._row
+
+
+class _FakeAfterBasedb:
+    def __init__(self, row):
+        self.dbapi = _FakeAfterDbapi(row)
+
+
+def test_resolve_after_omits_treeid_clause_by_default():
+    basedb = _FakeAfterBasedb(row=("Smith", "h1"))
+    _resolve_after(basedb, PERSON, [OrderBy("surname", "asc")], "h1", treeid=None)
+    sql, params = basedb.dbapi.calls[0]
+    assert "treeid" not in sql
+    assert params == ["h1"]
+
+
+def test_resolve_after_adds_treeid_clause_when_given():
+    # Without this, a handle from another tree on a shared multi-tree
+    # backend would resolve just as well -- leaking that row's sort-column
+    # values (and confirming its existence) across tenants even though the
+    # main paginated query stays properly scoped.
+    basedb = _FakeAfterBasedb(row=("Smith", "h1"))
+    _resolve_after(basedb, PERSON, [OrderBy("surname", "asc")], "h1", treeid=7)
+    sql, params = basedb.dbapi.calls[0]
+    assert "AND treeid = ?" in sql
+    assert params == ["h1", 7]
+
+
+# --- _resolve_where_conditions (where / where_expr mutual exclusivity) ----------
+
+
+def test_resolve_where_conditions_plain_where_passthrough():
+    conditions = [{"column": "gender", "op": "eq", "value": 1}]
+    assert _resolve_where_conditions({"where": conditions}, PERSON) == conditions
+
+
+def test_resolve_where_conditions_neither_given_returns_none():
+    assert _resolve_where_conditions({}, PERSON) is None
+
+
+def test_resolve_where_conditions_where_expr_parsed_against_spec():
+    result = _resolve_where_conditions({"where_expr": "gender == 1"}, PERSON)
+    assert result == [{"column": "gender", "op": "eq", "value": 1}]
+
+
+def test_resolve_where_conditions_where_expr_json_path():
+    result = _resolve_where_conditions(
+        {"where_expr": "primary_name.surname_list[0].surname == 'Smith'"}, PERSON
+    )
+    assert result == [
+        {
+            "column": {"json_path": ["primary_name", "surname_list", 0, "surname"]},
+            "op": "eq",
+            "value": "Smith",
+        }
+    ]
+
+
+def test_resolve_where_conditions_both_given_rejected():
+    with pytest.raises(HTTPException) as exc_info:
+        _resolve_where_conditions(
+            {"where": [{"column": "gender", "op": "eq", "value": 1}], "where_expr": "gender == 1"},
+            PERSON,
+        )
+    assert exc_info.value.code == 422
+
+
+def test_resolve_where_conditions_invalid_expr_rejected():
+    with pytest.raises(HTTPException) as exc_info:
+        _resolve_where_conditions({"where_expr": "gender == 1 or gender == 2"}, PERSON)
+    assert exc_info.value.code == 422
+
+
+# --- _build_where: value / value_column (field-vs-field comparisons) -----------
+
+
+def test_build_where_field_vs_field():
+    conditions = [
+        {
+            "column": {"json_path": ["mother", "death", "date", "sortval"]},
+            "op": "lt",
+            "value_column": {"json_path": ["father", "death", "date", "sortval"]},
+        }
+    ]
+    where = _build_where(conditions, FAMILY)
+    assert where.column == resolve_column_path(
+        FAMILY, ["mother", "death", "date", "sortval"]
+    )
+    assert where.value == resolve_column_path(
+        FAMILY, ["father", "death", "date", "sortval"]
+    )
+
+
+def test_build_where_both_value_and_value_column_rejected():
+    conditions = [
+        {"column": "gramps_id", "op": "eq", "value": "F1", "value_column": {"json_path": ["father", "surname"]}}
+    ]
+    with pytest.raises(HTTPException) as exc_info:
+        _build_where(conditions, FAMILY)
+    assert exc_info.value.code == 422
+
+
+def test_build_where_neither_value_nor_value_column_rejected():
+    conditions = [{"column": "gramps_id", "op": "eq"}]
+    with pytest.raises(HTTPException) as exc_info:
+        _build_where(conditions, FAMILY)
+    assert exc_info.value.code == 422
+
+
+def test_build_where_value_column_rejected_for_in():
+    conditions = [
+        {"column": "gramps_id", "op": "in", "value_column": {"json_path": ["father", "surname"]}}
+    ]
+    with pytest.raises(HTTPException) as exc_info:
+        _build_where(conditions, FAMILY)
+    assert exc_info.value.code == 422
+
+
+def test_build_where_value_column_rejected_for_like():
+    conditions = [
+        {"column": "gramps_id", "op": "like", "value_column": {"json_path": ["father", "surname"]}}
+    ]
+    with pytest.raises(HTTPException) as exc_info:
+        _build_where(conditions, FAMILY)
+    assert exc_info.value.code == 422

--- a/tests/test_object_query_parsing.py
+++ b/tests/test_object_query_parsing.py
@@ -32,7 +32,9 @@ from gramps.plugins.db.dbapi.sqlite import SQLite
 from werkzeug.exceptions import HTTPException
 
 from gramps_object_query_language.query import (
+    EVENT,
     FAMILY,
+    MEDIA,
     PERSON,
     And,
     CollectionCount,
@@ -45,8 +47,11 @@ from gramps_object_query_language.query import (
     Not,
     Or,
     OrderBy,
+    Query,
     QueryError,
     RelatedObject,
+    compile_count_query,
+    compile_query,
     resolve_column_path,
 )
 from gramps_object_query_language.query_lang import VALID_LEAF_OPS
@@ -378,6 +383,15 @@ class _FakeDbNoDialect:
     pass
 
 
+# Named "PostgreSQL"/"SomeFutureBackend" via `type(...)` rather than a real
+# subclass -- exercises the class-*name* allowlist `_resolve_dialect`/
+# `_resolve_treeid` actually check (see `_resolve_dialect`'s docstring on why
+# `isinstance` can't be trusted for a plugin-loaded backend class), without
+# importing the real addon.
+_FakeSingleUserPostgresBackend = type("PostgreSQL", (), {})
+_FakeUnknownBackend = type("SomeFutureBackend", (), {})
+
+
 def test_resolve_dialect_uses_explicit_attribute_when_present():
     assert _resolve_dialect(_FakeDbWithDialect("sqlite")) == Dialect.SQLITE
     assert _resolve_dialect(_FakeDbWithDialect("postgres")) == Dialect.POSTGRESQL
@@ -393,16 +407,41 @@ def test_resolve_dialect_detects_real_sqlite_instance_without_dialect_attr():
     assert _resolve_dialect(basedb) == Dialect.SQLITE
 
 
-def test_resolve_dialect_falls_back_to_postgresql_for_unknown_backend():
-    assert _resolve_dialect(_FakeDbNoDialect()) == Dialect.POSTGRESQL
+def test_resolve_dialect_detects_shared_postgres_by_class_name():
+    # `SharedPostgreSQL` versions without a `.dialect` attribute yet are
+    # still recognized by class name -- not lumped in with genuinely unknown
+    # backends.
+    basedb = type("SharedPostgreSQL", (), {})()
+    assert not hasattr(basedb, "dialect")
+    assert _resolve_dialect(basedb) == Dialect.POSTGRESQL
 
 
-def test_resolve_dialect_ignores_unrecognized_explicit_dialect_name():
-    # An unrecognized `.dialect` string falls through to the isinstance/
-    # default fallback rather than raising -- resolution here never fails,
-    # `compile_query` raises `QueryError` if the dialect actually turns out
-    # to be unsupported when rendering a `JsonPath`.
-    assert _resolve_dialect(_FakeDbWithDialect("mysql")) == Dialect.POSTGRESQL
+def test_resolve_dialect_aborts_for_unknown_backend():
+    # Guessing PostgreSQL for a backend this module has never seen can
+    # render dialect-specific SQL (`::jsonb`, `jsonb_extract_path(...)`)
+    # against a connection that can't run it -- failing closed (501) is
+    # safer than a silent, possibly-wrong guess.
+    with pytest.raises(HTTPException) as exc_info:
+        _resolve_dialect(_FakeDbNoDialect())
+    assert exc_info.value.code == 501
+
+
+def test_resolve_dialect_falls_through_unrecognized_explicit_dialect_name_to_class_check():
+    # An unrecognized `.dialect` string falls through to the class-name
+    # checks rather than being trusted outright or immediately aborting.
+    fake_shared_postgres_with_bad_dialect = type(
+        "SharedPostgreSQL", (), {"dialect": "mysql"}
+    )
+    assert (
+        _resolve_dialect(fake_shared_postgres_with_bad_dialect())
+        == Dialect.POSTGRESQL
+    )
+
+
+def test_resolve_dialect_aborts_when_explicit_dialect_name_and_class_both_unrecognized():
+    with pytest.raises(HTTPException) as exc_info:
+        _resolve_dialect(_FakeDbWithDialect("mysql"))
+    assert exc_info.value.code == 501
 
 
 # --- _resolve_treeid ------------------------------------------------------------
@@ -423,10 +462,6 @@ class _FakeDbapiNoTreeid:
     pass
 
 
-class _FakeBasedbNoTreeidDbapi:
-    dbapi = _FakeDbapiNoTreeid()
-
-
 def test_resolve_treeid_reads_dbapi_treeid_when_present():
     assert _resolve_treeid(_FakeBasedbWithTreeidDbapi()) == 7
 
@@ -434,7 +469,26 @@ def test_resolve_treeid_reads_dbapi_treeid_when_present():
 def test_resolve_treeid_returns_none_for_single_tree_backend():
     # SQLite / single-user PostgreSQL have no `.dbapi.treeid` at all --
     # `None` means "omit the clause", not "unscoped is fine by default".
-    assert _resolve_treeid(_FakeBasedbNoTreeidDbapi()) is None
+    basedb = _FakeSingleUserPostgresBackend()
+    basedb.dbapi = _FakeDbapiNoTreeid()
+    assert _resolve_treeid(basedb) is None
+
+    sqlite_basedb = SQLite.__new__(SQLite)
+    sqlite_basedb.dbapi = _FakeDbapiNoTreeid()
+    assert _resolve_treeid(sqlite_basedb) is None
+
+
+def test_resolve_treeid_aborts_for_unrecognized_backend():
+    # A backend this module has never seen, with no `.dbapi.treeid` and a
+    # class name matching neither known single-tree backend, must not be
+    # treated as "no scoping needed" -- on a genuinely shared backend that
+    # would let an unscoped query return other tenants' rows instead of
+    # erroring.
+    basedb = _FakeUnknownBackend()
+    basedb.dbapi = _FakeDbapiNoTreeid()
+    with pytest.raises(HTTPException) as exc_info:
+        _resolve_treeid(basedb)
+    assert exc_info.value.code == 501
 
 
 # --- _resolve_after treeid scoping -----------------------------------------------
@@ -706,3 +760,117 @@ def test_where_op_schema_matches_valid_leaf_ops():
     op_field = QueryWhereConditionArgs().fields["op"]
     allowed = {choice for validator in op_field.validators for choice in validator.choices}
     assert allowed == set(VALID_LEAF_OPS)
+
+
+# --- treeid threading through every SQL-emitting path -----------------------
+#
+# `_resolve_treeid` (tested above) is only half the story -- the value it
+# returns has to actually reach every place raw SQL gets built, or a new
+# query shape added later without scoping would silently return rows from
+# every tree sharing a `SharedPostgreSQL` instance, not just the caller's
+# own. `_resolve_after`'s own treeid clause is already covered above
+# (`test_resolve_after_adds_treeid_clause_when_given`); the three below --
+# main query, COUNT query, and a RelatedObject subquery -- are `compile_query`/
+# `compile_count_query`'s own responsibility, called from `_post_sql` with
+# whatever `_resolve_treeid` returned.
+
+
+def test_compile_query_adds_treeid_clause_to_main_query():
+    query = Query(select=["handle"], where=None, order_by=[], limit=10, after=None)
+    sql, params = compile_query(PERSON, query, dialect=Dialect.SQLITE, treeid=7)
+    assert "WHERE treeid = ?" in sql
+    assert 7 in params
+
+
+def test_compile_query_omits_treeid_clause_when_none():
+    query = Query(select=["handle"], where=None, order_by=[], limit=10, after=None)
+    sql, params = compile_query(PERSON, query, dialect=Dialect.SQLITE, treeid=None)
+    assert "treeid" not in sql
+    assert 7 not in params
+
+
+def test_compile_count_query_adds_treeid_clause():
+    query = Query(select=["handle"], where=None, order_by=[], limit=10, after=None)
+    sql, params = compile_count_query(PERSON, query, dialect=Dialect.SQLITE, treeid=7)
+    assert "treeid = ?" in sql
+    assert params == [7]
+
+
+def test_compile_count_query_omits_treeid_clause_when_none():
+    query = Query(select=["handle"], where=None, order_by=[], limit=10, after=None)
+    sql, params = compile_count_query(PERSON, query, dialect=Dialect.SQLITE, treeid=None)
+    assert "treeid" not in sql
+    assert params == []
+
+
+def test_compile_query_related_object_subquery_carries_treeid():
+    # A `select`/`where` column that crosses a relationship (Person->Event
+    # via "birth") compiles to a correlated subquery against the related
+    # table -- that subquery's own `FROM event ...` needs its own
+    # `treeid = ?` scoping, independent of (and in addition to) the outer
+    # `person` table's, since the related row lives in the same
+    # shared-tenant physical table.
+    ref = resolve_column_path(PERSON, ["birth", "date", "sortval"])
+    query = Query(select=[ref, "handle"], where=None, order_by=[], limit=10, after=None)
+    sql, params = compile_query(PERSON, query, dialect=Dialect.SQLITE, treeid=7)
+    # Once for the correlated subquery's own related-table scoping, once for
+    # the outer table.
+    assert sql.count("treeid = ?") == 2
+    assert params.count(7) == 2
+
+
+def test_compile_query_related_object_subquery_omits_treeid_when_none():
+    ref = resolve_column_path(PERSON, ["birth", "date", "sortval"])
+    query = Query(select=[ref, "handle"], where=None, order_by=[], limit=10, after=None)
+    sql, params = compile_query(PERSON, query, dialect=Dialect.SQLITE, treeid=None)
+    assert "treeid" not in sql
+
+
+# --- PostgreSQL physical-name column overrides -------------------------------
+#
+# The `SharedPostgreSQL`/`PostgreSQL` addons physically rename a handful of
+# columns that collide with reserved SQL words (`Media.desc` -> `desc_`,
+# `Event.description` -> `desc_ription`) -- see `query.py`'s
+# `_POSTGRESQL_PHYSICAL_COLUMN_OVERRIDES`. `compile_query` takes an explicit
+# `dialect`, so this is asserted directly against the rendered SQL string,
+# with no Postgres instance required.
+
+
+def test_compile_query_renders_postgresql_physical_name_for_desc_select():
+    query = Query(select=["desc", "handle"], where=None, order_by=[], limit=10, after=None)
+    sql, _ = compile_query(MEDIA, query, dialect=Dialect.POSTGRESQL)
+    assert "desc_," in sql or "desc_ FROM" in sql or "SELECT desc_," in sql
+    assert '"desc"' not in sql
+
+
+def test_compile_query_keeps_plain_desc_column_name_for_sqlite():
+    query = Query(select=["desc", "handle"], where=None, order_by=[], limit=10, after=None)
+    sql, _ = compile_query(MEDIA, query, dialect=Dialect.SQLITE)
+    assert '"desc"' in sql
+    assert "desc_" not in sql
+
+
+def test_compile_query_renders_postgresql_physical_name_for_desc_order_by():
+    query = Query(
+        select=["handle"],
+        where=None,
+        order_by=[OrderBy("desc", "asc")],
+        limit=10,
+        after=None,
+    )
+    sql, _ = compile_query(MEDIA, query, dialect=Dialect.POSTGRESQL)
+    assert "ORDER BY desc_ ASC" in sql
+
+
+def test_compile_query_renders_postgresql_physical_name_for_desc_where():
+    query = Query(select=["handle"], where=Eq("desc", ""), order_by=[], limit=10, after=None)
+    sql, params = compile_query(MEDIA, query, dialect=Dialect.POSTGRESQL)
+    assert "desc_" in sql
+    assert '"desc"' not in sql
+    assert params == ["", 10]
+
+
+def test_compile_query_renders_postgresql_physical_name_for_description():
+    query = Query(select=["handle"], where=Eq("description", ""), order_by=[], limit=10, after=None)
+    sql, _ = compile_query(EVENT, query, dialect=Dialect.POSTGRESQL)
+    assert "desc_ription" in sql

--- a/tests/test_object_query_parsing.py
+++ b/tests/test_object_query_parsing.py
@@ -50,6 +50,7 @@ from gramps_object_query_language.query import (
     Query,
     QueryError,
     RelatedObject,
+    Regex,
     compile_count_query,
     compile_query,
     resolve_column_path,
@@ -637,6 +638,30 @@ def test_build_where_value_column_rejected_for_like():
     with pytest.raises(HTTPException) as exc_info:
         _build_where(conditions, FAMILY)
     assert exc_info.value.code == 422
+
+
+def test_build_where_value_column_rejected_for_regex():
+    # A pattern only known at row-execution time can't be validated as a
+    # compilable regex ahead of time, same reasoning as "in"/"like" above --
+    # this is the guard that keeps a hand-crafted raw `where` JSON leaf from
+    # reaching Regex(column, RelatedObject(...)) with no field-vs-field
+    # support of its own for this op.
+    conditions = [
+        {"column": "gramps_id", "op": "regex", "value_column": {"json_path": ["father", "surname"]}}
+    ]
+    with pytest.raises(HTTPException) as exc_info:
+        _build_where(conditions, FAMILY)
+    assert exc_info.value.code == 422
+
+
+def test_build_where_regex_with_plain_value_accepted():
+    # The value_column guard above is scoped to `value_column` specifically
+    # -- a plain literal pattern (the normal case) must still build fine.
+    conditions = [{"column": "gramps_id", "op": "regex", "value": "^F.*"}]
+    where = _build_where(conditions, FAMILY)
+    assert isinstance(where, Regex)
+    assert where.column == resolve_column_path(FAMILY, ["gramps_id"])
+    assert where.value == "^F.*"
 
 
 # --- _build_where: 'or'/'not' groups (from where_expr's "a or b"/"not a") ------

--- a/tests/test_object_query_parsing.py
+++ b/tests/test_object_query_parsing.py
@@ -34,14 +34,24 @@ from werkzeug.exceptions import HTTPException
 from gramps_object_query_language.query import (
     FAMILY,
     PERSON,
+    And,
+    CollectionCount,
     Dialect,
+    Eq,
+    Exists,
+    FlatColumnRef,
+    Gt,
     JsonPath,
+    Not,
+    Or,
     OrderBy,
     QueryError,
     RelatedObject,
     resolve_column_path,
 )
+from gramps_object_query_language.query_lang import VALID_LEAF_OPS
 from gramps_webapi.api.resources.object_query import (
+    QueryWhereConditionArgs,
     _build_where,
     _check_no_duplicate_keys,
     _default_key_for,
@@ -112,6 +122,58 @@ def test_parse_column_ref_rejects_bare_relationship_name():
     # "birth" alone isn't a value -- needs a further path (resolve_column_path).
     with pytest.raises(QueryError):
         _parse_column_ref({"json_path": ["birth"]}, PERSON)
+
+
+def test_parse_column_ref_count_of():
+    # count(events) > 2's column side -- previously only reachable via
+    # where_expr (which bypasses _parse_column_ref entirely); this is the
+    # regression test for that gap.
+    ref = _parse_column_ref({"count_of": {"relationship": "events"}}, PERSON)
+    assert isinstance(ref, CollectionCount)
+    assert ref.collection.name == "events"
+    assert ref.condition is None
+
+
+def test_parse_column_ref_count_of_with_where():
+    ref = _parse_column_ref(
+        {
+            "count_of": {
+                "relationship": "events",
+                "where": [{"column": {"json_path": ["type", "value"]}, "op": "eq", "value": 12}],
+            }
+        },
+        PERSON,
+    )
+    assert isinstance(ref, CollectionCount)
+    assert isinstance(ref.condition, Eq)
+
+
+def test_parse_column_ref_rejects_count_of_missing_relationship():
+    with pytest.raises(QueryError):
+        _parse_column_ref({"count_of": {}}, PERSON)
+
+
+def test_parse_column_ref_rejects_count_of_non_list_where():
+    with pytest.raises(QueryError):
+        _parse_column_ref(
+            {"count_of": {"relationship": "events", "where": "not-a-list"}}, PERSON
+        )
+
+
+def test_parse_column_ref_rejects_count_of_malformed_nested_leaf():
+    # The same value/value_column XOR check a top-level `where` leaf gets --
+    # count_of's nested `where` is just as untrusted (select/order_by have
+    # no schema shape at all), so it needs the same guard.
+    with pytest.raises(HTTPException):
+        _parse_column_ref(
+            {
+                "count_of": {
+                    "relationship": "events",
+                    "where": [{"column": "gramps_id", "op": "eq"}],
+                }
+            },
+            PERSON,
+        )
 
 
 # --- _default_key_for -----------------------------------------------------------
@@ -195,6 +257,27 @@ def test_parse_select_entry_plain_handle_column_is_fine():
 def test_parse_select_entry_rejects_invalid_shape():
     with pytest.raises(QueryError):
         _parse_select_entry(123, PERSON)
+
+
+def test_parse_select_entry_count_of_with_alias():
+    ref, key = _parse_select_entry(
+        {"count_of": {"relationship": "events"}, "as": "event_count"}, PERSON
+    )
+    assert isinstance(ref, CollectionCount)
+    assert key == "event_count"
+
+
+def test_parse_select_entry_count_of_requires_alias():
+    # Unlike json_path, there's no natural dotted-name default to derive.
+    with pytest.raises(QueryError):
+        _parse_select_entry({"count_of": {"relationship": "events"}}, PERSON)
+
+
+def test_parse_select_entry_count_of_rejects_handle_alias():
+    with pytest.raises(QueryError):
+        _parse_select_entry(
+            {"count_of": {"relationship": "events"}, "as": "handle"}, PERSON
+        )
 
 
 def test_parse_select_entry_relationship_crossing_default_key():
@@ -433,10 +516,19 @@ def test_resolve_where_conditions_both_given_rejected():
     assert exc_info.value.code == 422
 
 
-def test_resolve_where_conditions_invalid_expr_rejected():
-    with pytest.raises(HTTPException) as exc_info:
-        _resolve_where_conditions({"where_expr": "gender == 1 or gender == 2"}, PERSON)
-    assert exc_info.value.code == 422
+def test_resolve_where_conditions_where_expr_or_group():
+    # `or` (and `not`) compile to a nested {"or": [...]}/{"not": ...} node
+    # rather than a QueryLangError -- see _build_where's "or"/"not" tests
+    # below for what happens to this shape next.
+    result = _resolve_where_conditions({"where_expr": "gender == 1 or gender == 2"}, PERSON)
+    assert result == [
+        {
+            "or": [
+                {"column": "gender", "op": "eq", "value": 1},
+                {"column": "gender", "op": "eq", "value": 2},
+            ]
+        }
+    ]
 
 
 # --- _build_where: value / value_column (field-vs-field comparisons) -----------
@@ -491,3 +583,126 @@ def test_build_where_value_column_rejected_for_like():
     with pytest.raises(HTTPException) as exc_info:
         _build_where(conditions, FAMILY)
     assert exc_info.value.code == 422
+
+
+# --- _build_where: 'or'/'not' groups (from where_expr's "a or b"/"not a") ------
+
+
+def test_build_where_or_group():
+    conditions = [
+        {
+            "or": [
+                {"column": "gender", "op": "eq", "value": 1},
+                {"column": "gender", "op": "eq", "value": 2},
+            ]
+        }
+    ]
+    where = _build_where(conditions, PERSON)
+    assert isinstance(where, Or)
+    assert len(where.exprs) == 2
+    assert all(isinstance(e, Eq) and e.column == "gender" for e in where.exprs)
+    assert [e.value for e in where.exprs] == [1, 2]
+
+
+def test_build_where_not_group():
+    conditions = [{"not": {"column": "gender", "op": "eq", "value": 1}}]
+    where = _build_where(conditions, PERSON)
+    assert isinstance(where, Not)
+    assert isinstance(where.expr, Eq)
+    assert where.expr.column == "gender"
+    assert where.expr.value == 1
+
+
+def test_build_where_or_empty_rejected():
+    with pytest.raises(HTTPException) as exc_info:
+        _build_where([{"or": []}], PERSON)
+    assert exc_info.value.code == 422
+
+
+def test_build_where_nested_or_and_leaf():
+    # "gender == 1 and (surname == 'Smith' or surname == 'Jones')" --
+    # top-level list item 0 is a plain leaf, item 1 is an 'or' group; the
+    # two combine via the same implicit-AND _build_where already does for
+    # an all-leaf conditions list.
+    conditions = [
+        {"column": "gender", "op": "eq", "value": 1},
+        {
+            "or": [
+                {"column": "surname", "op": "eq", "value": "Smith"},
+                {"column": "surname", "op": "eq", "value": "Jones"},
+            ]
+        },
+    ]
+    where = _build_where(conditions, PERSON)
+    assert len(where.exprs) == 2
+    assert isinstance(where.exprs[0], Eq)
+    assert isinstance(where.exprs[1], Or)
+
+
+# --- _build_where: end-to-end via where_expr (and/exists/count_of/FlatColumnRef) --
+#
+# These go through the real _resolve_where_conditions -> _build_where pair
+# together, the same as _post_sql, since 'and'/'exists'/'count_of' only ever
+# arise from where_expr (QueryWhereConditionArgs' schema can't produce them
+# for a raw `where` body) -- see where_list_to_ast's docstring for why these
+# are delegated there rather than hand-built here.
+
+
+def _where(expr: str, spec=PERSON):
+    return _build_where(_resolve_where_conditions({"where_expr": expr}, spec), spec)
+
+
+def test_build_where_and_group_nested_under_not():
+    where = _where("not (gender == 1 and gramps_id == 'I1')")
+    assert isinstance(where, Not)
+    assert isinstance(where.expr, And)
+    assert all(isinstance(e, Eq) for e in where.expr.exprs)
+
+
+def test_build_where_exists():
+    where = _where("exists(events, type.value == 12)")
+    assert isinstance(where, Exists)
+    assert where.collection.name == "events"
+    assert where.condition is not None
+
+
+def test_build_where_exists_any_sugar_equivalent():
+    assert repr(_where("exists(events, type.value == 12)")) == repr(
+        _where("any(e.type.value == 12 for e in events)")
+    )
+
+
+def test_build_where_count_of():
+    where = _where("count(events) > 2")
+    assert isinstance(where, Gt)
+    assert isinstance(where.column, CollectionCount)
+    assert where.column.collection.name == "events"
+    assert where.value == 2
+
+
+def test_build_where_value_column_same_table_wrapped_as_flat_column_ref():
+    # Regression test: a same-table plain-string value_column ("given_name
+    # == surname") must resolve to a FlatColumnRef, not a bare str -- a bare
+    # str is indistinguishable from an ordinary literal to Comparison/
+    # Contains, so without this wrapping the query would silently compare
+    # given_name against the *literal text* "surname" instead of the two
+    # columns against each other (see FlatColumnRef's docstring).
+    conditions = [{"column": "given_name", "op": "eq", "value_column": "surname"}]
+    where = _build_where(conditions, PERSON)
+    assert isinstance(where, Eq)
+    assert isinstance(where.value, FlatColumnRef)
+    assert where.value.name == "surname"
+
+
+# --- QueryWhereConditionArgs.op: derived from VALID_LEAF_OPS, not hand-copied --
+
+
+def test_where_op_schema_matches_valid_leaf_ops():
+    # Regression test for the whole point of VALID_LEAF_OPS existing: a new
+    # op added to gramps_object_query_language should become valid for a raw
+    # `where` JSON body automatically, with no gramps-web-api edit needed --
+    # this fails the moment the schema's allowed set and VALID_LEAF_OPS
+    # diverge, whichever direction that happens.
+    op_field = QueryWhereConditionArgs().fields["op"]
+    allowed = {choice for validator in op_field.validators for choice in validator.choices}
+    assert allowed == set(VALID_LEAF_OPS)


### PR DESCRIPTION
## Summary

`GET /api/people/?page=1` and `?page=999` both take ~8 seconds flat on a 100k-person tree, regardless of page, because the existing endpoints fully deserialize every object in the table before filtering, sorting, or paging any of it in Python — cost scales with table size, not with what's actually requested.

Adds `POST /api/<type>/query/` for every primary object type (person, family, event, place, repository, source, citation, media, note, tag): a structured query (`select`/`where`/`order_by`/`limit`/`after`, or a `where_expr` string shorthand) that compiles to a single parameterized SQL statement against the columns Gramps already indexes server-side, with real keyset pagination instead of materialize-then-slice.

## Where the pieces live

The compiler, query AST, and expression-language parser live in a separately maintained package, [`gramps-object-query-language`](https://github.com/dsblank/gramps-object-query-language) ([on PyPI](https://pypi.org/project/gramps-object-query-language/)) — it has no Web API-specific concepts in it at all (no Flask, no permissions, nothing HTTP-shaped), just Gramps-object-to-SQL compilation, so there's no reason for it to live in this codebase. This repo owns the policy layer: which columns are selectable, how an HTTP request maps to the query AST, and — the part that matters most — deciding per request whether a query is even allowed to reach the SQL compiler at all.

`gramps-object-query-language>=0.1.0` is declared as a normal dependency in `pyproject.toml`.

## The privacy dispatch

Every query request is routed one of two ways, decided per request from the resolved database handle:

- **Full access** — compiles straight to SQL via the external compiler, as above.
- **Restricted access** (a user without permission to see private records) — never touches the SQL compiler. The same query is evaluated instead through Gramps' own internal record-filtering machinery, so every value a restricted caller can see has already passed through the real, authoritative privacy rules rather than a second implementation of them living in this endpoint. Slower for that path, but correct by construction, and it holds for any future kind of access restriction this project adds later, without this endpoint needing to know what that restriction even is.

## Benchmark

Measured live against a real 100k-person tree, comparing this PR's `POST /api/people/query/` (`gender == MALE`, 42,884 matches) against the existing `GET /api/people/` (no filter — always a full scan, regardless of page), on both SQLite and a `SharedPostgreSQL` instance, for both a full-access user and a restricted user (no permission to view private records):

| Endpoint | Query | Access level | Backend | Time |
|---|---|---|---|---|
| `GET /api/people/` | *(none — full scan)* | Full access | SQLite | 8.1 s |
| `GET /api/people/` | *(none — full scan)* | Full access | SharedPostgreSQL | 7.0 s |
| `GET /api/people/` | *(none — full scan)* | Restricted | SQLite | 30.6 s |
| `GET /api/people/` | *(none — full scan)* | Restricted | SharedPostgreSQL | 84.3 s |
| `POST /api/people/query/` | `gender == MALE` | Full access | SQLite | **5.4 ms** |
| `POST /api/people/query/` | `gender == MALE` | Full access | SharedPostgreSQL | **14.5 ms** |
| `POST /api/people/query/` | `gender == MALE` | Restricted | SQLite | 29.7 s |
| `POST /api/people/query/` | `gender == MALE` | Restricted | SharedPostgreSQL | 84.1 s |
| `POST /api/people/query/` | *(none — full scan)* | Full access | SQLite | **0.06 ms** |
| `POST /api/people/query/` | *(none — full scan)* | Full access | SharedPostgreSQL | **0.19 ms** |
| `POST /api/people/query/` | *(none — full scan)* | Restricted | SQLite | 32.1 s |
| `POST /api/people/query/` | *(none — full scan)* | Restricted | SharedPostgreSQL | 99.3 s |

Two things to take from this:

- **Full-access users** — the case this PR is primarily for — see a ~1,500x (SQLite) / ~480x (Postgres) speedup on `gender == MALE`, and effectively unmeasurable-vs-8-seconds for the unfiltered case, because the query never deserializes a single object; it's pushed down entirely to SQL.
- **Restricted users** land on roughly the same order of magnitude as the existing `GET` endpoint, not worse — both paths pay the same underlying per-object privacy-sanitization cost (see "The privacy dispatch" above), since neither one takes the SQL shortcut for this case.

**Does `limit` change any of this?** Tested `limit=1` vs `limit=50` vs `limit=1000` on the unfiltered query, both paths: the SQL path stays flat (sub-millisecond throughout, both backends) because `LIMIT` is compiled directly into the SQL statement. The restricted path is *also* flat regardless of `limit` (32–35s SQLite, 95–99s Postgres, no consistent trend with `limit` size) — but for a less happy reason: it evaluates and sanitizes every row in the table before `limit` is ever applied, so asking for 1 row costs the same as asking for 1000.

## Test plan

- [x] `tests/test_object_query_parsing.py` — pure unit tests for the endpoint's request-parsing helpers
- [x] `tests/test_endpoints/test_object_query.py` — per-type endpoint tests
- [x] `tests/test_endpoints/test_people_query.py` — person-endpoint tests, including both the full-access and restricted-access dispatch paths
- [x] All passing locally against `gramps-object-query-language` installed from PyPI

🤖 Generated with [Claude Code](https://claude.com/claude-code)


