### PR TITLE
Make heavy optional dependencies import lazily

### DIFF
--- a/gramps_webapi/api/check.py
+++ b/gramps_webapi/api/check.py
@@ -28,7 +28,6 @@ from typing import Callable, Optional
 
 from gramps.gen.db import DbTxn, DbWriteBase
 from gramps.gen.dbstate import DbState
-from gramps.plugins.tool.check import CheckIntegrity
 
 # db.<attr> caches of custom type values (e.g. db.event_names); only ever
 # grow as records commit, so they need rebuilding from live data here.
@@ -144,6 +143,8 @@ def rebuild_custom_type_caches(db_handle: DbWriteBase) -> list[tuple[str, str]]:
 
 
 def check_database(db_handle: DbWriteBase, progress_cb: Optional[Callable] = None):
+    from gramps.plugins.tool.check import CheckIntegrity
+
     i = 0
 
     def progress(i):

--- a/gramps_webapi/api/file.py
+++ b/gramps_webapi/api/file.py
@@ -146,7 +146,10 @@ class FileHandler:
         """Return regions containing faces."""
         if not self.mime.startswith("image"):
             return {}
-        import pytesseract
+        try:
+            import pytesseract
+        except ImportError:
+            abort_with_message(501, "pytesseract is not installed")
 
         try:
             pytesseract.get_tesseract_version()

--- a/gramps_webapi/api/file.py
+++ b/gramps_webapi/api/file.py
@@ -26,7 +26,6 @@ from io import BytesIO
 from pathlib import Path
 from typing import Any, BinaryIO, Optional, Tuple, Union
 
-import pytesseract
 from flask import jsonify, make_response, send_file, send_from_directory, current_app
 from gramps.gen.db.base import DbReadBase
 from gramps.gen.errors import HandleError
@@ -147,6 +146,8 @@ class FileHandler:
         """Return regions containing faces."""
         if not self.mime.startswith("image"):
             return {}
+        import pytesseract
+
         try:
             pytesseract.get_tesseract_version()
         except pytesseract.TesseractNotFoundError:

--- a/gramps_webapi/api/image.py
+++ b/gramps_webapi/api/image.py
@@ -28,8 +28,6 @@ from importlib.resources import as_file, files
 from pathlib import Path
 from typing import BinaryIO, Callable
 
-import ffmpeg
-from pdf2image import convert_from_path
 from PIL import Image, ImageOps
 from PIL.Image import Image as ImageType
 
@@ -160,6 +158,8 @@ class ThumbnailHandler:
 
     def _get_image_pdf(self) -> ImageType:
         """Get a Pillow Image instance of the PDF's first page."""
+        from pdf2image import convert_from_path
+
         ims = self._apply_to_path(
             convert_from_path,
             first_page=1,
@@ -188,6 +188,8 @@ class ThumbnailHandler:
 
     def _get_image_video(self) -> ImageType:
         """Get a Pillow Image instance of the video's first frame."""
+        import ffmpeg
+
         out, _ = self._apply_to_path(
             lambda path: (
                 ffmpeg.input(path, ss=0)

--- a/gramps_webapi/api/image.py
+++ b/gramps_webapi/api/image.py
@@ -158,7 +158,10 @@ class ThumbnailHandler:
 
     def _get_image_pdf(self) -> ImageType:
         """Get a Pillow Image instance of the PDF's first page."""
-        from pdf2image import convert_from_path
+        try:
+            from pdf2image import convert_from_path
+        except ImportError:
+            abort_with_message(501, "pdf2image is not installed")
 
         ims = self._apply_to_path(
             convert_from_path,
@@ -188,7 +191,10 @@ class ThumbnailHandler:
 
     def _get_image_video(self) -> ImageType:
         """Get a Pillow Image instance of the video's first frame."""
-        import ffmpeg
+        try:
+            import ffmpeg
+        except ImportError:
+            abort_with_message(501, "ffmpeg-python is not installed")
 
         out, _ = self._apply_to_path(
             lambda path: (

--- a/gramps_webapi/api/media.py
+++ b/gramps_webapi/api/media.py
@@ -19,10 +19,12 @@
 
 """Generic media handler."""
 
+from __future__ import annotations
+
 import os
 import zipfile
 from pathlib import Path
-from typing import BinaryIO, Callable, List, Optional, Set
+from typing import TYPE_CHECKING, BinaryIO, Callable, List, Optional, Set
 
 from flask import current_app
 from flask_jwt_extended import get_jwt_identity
@@ -34,7 +36,6 @@ from ..auth import get_tree_usage, set_tree_usage
 from ..types import FilenameOrPath
 from ..util import get_extension
 from .file import FileHandler, LocalFileHandler, upload_file_local
-from .s3 import ObjectStorageFileHandler, get_object_keys_size, upload_file_s3
 from .util import (
     abort_with_message,
     close_db,
@@ -43,6 +44,9 @@ from .util import (
     get_tree_from_jwt,
     get_tree_from_jwt_or_fail,
 )
+
+if TYPE_CHECKING:
+    from .s3 import ObjectStorageFileHandler
 
 PREFIX_S3 = "s3://"
 
@@ -224,6 +228,8 @@ class MediaHandlerS3(MediaHandlerBase):
 
     def get_remote_keys(self) -> Set[str]:
         """Return the set of all object keys that are known to exist on remote."""
+        from .s3 import get_object_keys_size
+
         keys = get_object_keys_size(
             self.bucket_name, prefix=self.prefix, endpoint_url=self.endpoint_url
         )
@@ -233,6 +239,8 @@ class MediaHandlerS3(MediaHandlerBase):
         self, handle, db_handle: DbReadBase
     ) -> ObjectStorageFileHandler:
         """Get an S3 file handler."""
+        from .s3 import ObjectStorageFileHandler
+
         return ObjectStorageFileHandler(
             handle,
             bucket_name=self.bucket_name,
@@ -249,6 +257,8 @@ class MediaHandlerS3(MediaHandlerBase):
         path: Optional[FilenameOrPath] = None,
     ) -> None:
         """Upload a file from a stream."""
+        from .s3 import upload_file_s3
+
         upload_file_s3(
             self.bucket_name,
             stream,
@@ -269,6 +279,8 @@ class MediaHandlerS3(MediaHandlerBase):
 
     def get_media_size(self, db_handle: Optional[DbReadBase] = None) -> int:
         """Return the total disk space used by all existing media objects."""
+        from .s3 import get_object_keys_size
+
         if not db_handle:
             db_handle = get_db_handle()
         keys = set(obj.checksum for obj in db_handle.iter_media())

--- a/gramps_webapi/api/resources/exporters.py
+++ b/gramps_webapi/api/resources/exporters.py
@@ -30,6 +30,7 @@ import re
 import time
 from typing import Dict
 
+import gramps.gen.mime  # noqa: F401  (registers .gramps/.gpkg/.ged in mimetypes)
 from flask import Response, abort, current_app, jsonify, send_file
 from flask_jwt_extended import get_jwt_identity
 from marshmallow import Schema

--- a/gramps_webapi/api/resources/metadata.py
+++ b/gramps_webapi/api/resources/metadata.py
@@ -55,7 +55,9 @@ def _get_ocr_info() -> tuple[bool, list[str]]:
     """Detect OCR availability once and cache the result."""
     try:
         import pytesseract
-
+    except ImportError:
+        return False, []
+    try:
         pytesseract.get_tesseract_version()
         return True, [lang for lang in pytesseract.get_languages() if lang != "osd"]
     except pytesseract.TesseractNotFoundError:

--- a/gramps_webapi/api/resources/metadata.py
+++ b/gramps_webapi/api/resources/metadata.py
@@ -25,7 +25,6 @@ from importlib import metadata
 
 import gramps_ql as gql
 import object_ql as oql
-import pytesseract
 import sifts
 from flask import Response, current_app
 from gramps.gen.const import ENV, GRAMPS_LOCALE
@@ -55,6 +54,8 @@ from .schemas import MetadataSchema, ResearcherSchema
 def _get_ocr_info() -> tuple[bool, list[str]]:
     """Detect OCR availability once and cache the result."""
     try:
+        import pytesseract
+
         pytesseract.get_tesseract_version()
         return True, [lang for lang in pytesseract.get_languages() if lang != "osd"]
     except pytesseract.TesseractNotFoundError:

--- a/gramps_webapi/api/s3.py
+++ b/gramps_webapi/api/s3.py
@@ -22,9 +22,6 @@
 from io import BytesIO
 from typing import BinaryIO, Dict, Optional
 
-import boto3
-from botocore.config import Config
-from botocore.exceptions import ClientError
 from flask import current_app, redirect, send_file
 from gramps.gen.db.base import DbReadBase
 
@@ -39,6 +36,9 @@ from .util import abort_with_message
 
 def get_client(endpoint_url: Optional[str] = None):
     """Return an S3 client configured for GCS compatibility."""
+    import boto3
+    from botocore.config import Config
+
     config = Config(
         s3={"addressing_style": "path"},
         signature_version="s3v4",
@@ -78,6 +78,8 @@ class ObjectStorageFileHandler(FileHandler):
         self, expires_in: float, download: bool = False, filename: str = ""
     ):
         """Get a presigned URL to a file object."""
+        from botocore.exceptions import ClientError
+
         params = {
             "Bucket": self.bucket_name,
             "Key": self.object_name,
@@ -98,6 +100,8 @@ class ObjectStorageFileHandler(FileHandler):
 
     def _download_fileobj(self) -> BinaryIO:
         """Download a binary file object."""
+        from botocore.exceptions import ClientError
+
         try:
             response = self.client.get_object(
                 Bucket=self.bucket_name, Key=self.object_name
@@ -118,6 +122,8 @@ class ObjectStorageFileHandler(FileHandler):
 
     def file_exists(self) -> bool:
         """Check if the file exists."""
+        from botocore.exceptions import ClientError
+
         try:
             self.client.head_object(Bucket=self.bucket_name, Key=self.object_name)
             return True
@@ -126,6 +132,8 @@ class ObjectStorageFileHandler(FileHandler):
 
     def get_file_size(self) -> int:
         """Return the file size in bytes."""
+        from botocore.exceptions import ClientError
+
         try:
             response = self.client.head_object(
                 Bucket=self.bucket_name, Key=self.object_name


### PR DESCRIPTION
## Summary
- `boto3`, `ffmpeg-python`, `pdf2image`, `pytesseract`, and `PYGObject` were all imported unconditionally at module load time, even though each backs one narrowly-scoped feature: S3 media storage, video/PDF thumbnails, OCR, and the check-and-repair-database tool, respectively.
- This made it impossible to import `gramps_webapi` without all five packages installed, even for consumers (e.g. an embedded/desktop build) that never touch those features.
- Moved each import into the specific function/method that actually uses it. In `media.py`, added `from __future__ import annotations` + a `TYPE_CHECKING` guard so the `ObjectStorageFileHandler` return-type annotation doesn't force-import `s3.py` (and therefore `boto3`) at module load.
- No behavior change for existing installs — `pyproject.toml` is untouched, and every code path still imports the same package the moment the corresponding feature actually runs (S3 configured, a video/PDF thumbnail is requested, OCR is invoked, or the repair-database endpoint is called).

## Test plan
- [x] `python -c "from gramps_webapi.app import create_app"` succeeds with `boto3`, `botocore`, `ffmpeg`, `pdf2image`, `pytesseract`, and `gi` all blocked via a monkey-patched `__import__`, confirming none are required for basic app startup.
- [x] Confirmed `celery` is still (as before) required for startup, since it's unrelated to this change.
- [x] `pytest tests/test_check.py tests/test_image.py tests/test_endpoints/test_file.py tests/test_endpoints/test_ocr.py tests/test_endpoints/test_media.py` — same pass/fail counts before and after this change (29 pre-existing failures unrelated to this PR, reproduced identically on `master`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)