### PR TITLE
Add Trustabl Agent Scanner to CI

### DIFF
--- a/.github/workflows/trustabl.yml
+++ b/.github/workflows/trustabl.yml
@@ -1,0 +1,17 @@
+name: Trustabl
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+permissions:
+  contents: read
+  security-events: write
+  pull-requests: write
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: trustabl/trustabl-action@v0


### PR DESCRIPTION
We came across your project and we like how you are building a web API for genealogy data access, which can be really helpful for researchers and family historians. 

1. In gramps_webapi/api/llm/agent.py, the agent does not constrain its output to a validated type: output_type is absent (defaulting to free-form str) or set explicitly to str. This can lead to unexpected behavior and make it harder to process the agent's responses reliably.

2. In tests/test_endpoints/test_chat.py, the agent does not constrain its output to a validated type: output_type is absent (defaulting to free-form str) or set explicitly to str. This can lead to unexpected behavior and make it harder to process the agent's responses reliably.

3. In tests/test_endpoints/test_chat.py, the agent does not constrain its output to a validated type: output_type is absent (defaulting to free-form str) or set explicitly to str. This can lead to unexpected behavior and make it harder to process the agent's responses reliably.

Recommendations are based on our understanding of agent runtime reliability, some findings may be intentional. Please let us know if this was intentional or if our findings are helpful so we can improve the accuracy of the scanner.

Best,
Trustabl.ai
Open-source AI agent reliability scanner (runs locally, GitHub Action)