### PR TITLE
Pass Postgres credentials when creating new trees

### DIFF
--- a/gramps_webapi/api/resources/trees.py
+++ b/gramps_webapi/api/resources/trees.py
@@ -166,6 +166,8 @@ class TreesResource(ProtectedResource):
         WebDbManager(
             dirname=tree_id,
             name=args["name"],
+            username=current_app.config["POSTGRES_USER"],
+            password=current_app.config["POSTGRES_PASSWORD"],
             create_if_missing=True,
             create_backend=backend,
             ignore_lock=current_app.config["IGNORE_DB_LOCK"],


### PR DESCRIPTION
## Summary
- `TreesResource.post()` creates a new tree's database via `WebDbManager` but never passed `username`/`password`, so tree *creation* always relied on passwordless/default Postgres auth — even though every other `WebDbManager` call site (see `api/util.py`) already passes `POSTGRES_USER`/`POSTGRES_PASSWORD` from app config.
- This opens up using Postgres via a non-standard auth path (i.e. a Postgres instance that actually requires a username/password) for multi-tree deployments.
- `POSTGRES_USER`/`POSTGRES_PASSWORD` already have `None` defaults in `config.py`, and `WebDbManager` already treats them as optional, so this is a no-op for existing sqlite/default-Postgres setups.

## Test plan
- [x] Existing test suite (sqlite backend) still passes
- [x] Manually verified: create a tree against a Postgres backend configured with non-default `POSTGRES_USER`/`POSTGRES_PASSWORD`

🤖 Generated with [Claude Code](https://claude.com/claude-code)