### PR TITLE
Add exact before_id/after_id cursor for transaction history

### DIFF
--- a/gramps_webapi/api/resources/history.py
+++ b/gramps_webapi/api/resources/history.py
@@ -100,6 +100,20 @@ class TransactionsHistoryQueryArgs(Schema):
             "description": "Unix timestamp; if provided, return only transactions committed after this time."
         },
     )
+    before_id = fields.Integer(
+        load_default=None,
+        validate=validate.Range(min=0),
+        metadata={
+            "description": "Transaction ID; if provided, return only transactions with an id strictly less than this value. Unlike the timestamp-based `before`/`after` cursor, this is exact and has no floating-point precision loss."
+        },
+    )
+    after_id = fields.Integer(
+        load_default=None,
+        validate=validate.Range(min=0),
+        metadata={
+            "description": "Transaction ID; if provided, return only transactions with an id strictly greater than this value. Unlike the timestamp-based `before`/`after` cursor, this is exact and has no floating-point precision loss. 0 means 'from the beginning'."
+        },
+    )
 
 
 class TransactionsHistoryResource(ProtectedResource):
@@ -122,6 +136,8 @@ class TransactionsHistoryResource(ProtectedResource):
             ascending=ascending,
             before=args["before"],
             after=args["after"],
+            before_id=args["before_id"],
+            after_id=args["after_id"],
         )
 
         # replace user IDs by user name

--- a/gramps_webapi/undodb.py
+++ b/gramps_webapi/undodb.py
@@ -539,6 +539,8 @@ class DbUndoSQLWeb(DbUndoSQL):
         ascending: bool = True,
         before: int | None = None,
         after: int | None = None,
+        before_id: int | None = None,
+        after_id: int | None = None,
     ) -> tuple[list[dict[str, Any]], int]:
         """Get transactions as a JSONifiable list."""
         with self.session_scope() as session:
@@ -551,6 +553,10 @@ class DbUndoSQLWeb(DbUndoSQL):
                 query = query.filter(Transaction.timestamp < before * 1e9)
             if after:
                 query = query.filter(Transaction.timestamp > after * 1e9)
+            if before_id is not None:
+                query = query.filter(Transaction.id < before_id)
+            if after_id is not None:
+                query = query.filter(Transaction.id > after_id)
             count = query.count()
             if ascending:
                 query = query.order_by(Transaction.id)

--- a/gramps_webapi/undodb.py
+++ b/gramps_webapi/undodb.py
@@ -537,8 +537,8 @@ class DbUndoSQLWeb(DbUndoSQL):
         old_data: bool = True,
         new_data: bool = True,
         ascending: bool = True,
-        before: int | None = None,
-        after: int | None = None,
+        before: float | None = None,
+        after: float | None = None,
         before_id: int | None = None,
         after_id: int | None = None,
     ) -> tuple[list[dict[str, Any]], int]:

--- a/tests/test_endpoints/test_history.py
+++ b/tests/test_endpoints/test_history.py
@@ -26,6 +26,7 @@ from unittest.mock import patch
 
 from gramps.cli.clidbman import CLIDbManager
 from gramps.gen.dbstate import DbState
+from sqlalchemy import create_engine, text
 
 from gramps_webapi.app import create_app
 from gramps_webapi.auth import add_user, user_db
@@ -51,6 +52,7 @@ class TestTransactionHistoryResource(unittest.TestCase):
         self.name = "Test Web API History"
         self.dbman = CLIDbManager(DbState())
         dirpath, _ = self.dbman.create_new_db_cli(self.name, dbid="sqlite")
+        self.dirpath = dirpath
         tree = os.path.basename(dirpath)
         with patch.dict("os.environ", {ENV_CONFIG_FILE: TEST_EMPTY_GRAMPS_AUTH_CONFIG}):
             self.app = create_app(config_from_env=False, config={"TREE": self.name})
@@ -252,6 +254,106 @@ class TestTransactionHistoryResource(unittest.TestCase):
         )
         assert rv.status_code == 200
         assert len(rv.json) == 1
+
+    def test_after_id_before_id(self):
+        headers = get_headers(self.client, "editor", "123")
+        rv = self.client.post("/api/people/", json={}, headers=headers)
+        assert rv.status_code == 201
+        rv = self.client.post("/api/people/", json={}, headers=headers)
+        assert rv.status_code == 201
+        rv = self.client.post("/api/people/", json={}, headers=headers)
+        assert rv.status_code == 201
+        rv = self.client.get("/api/transactions/history/", headers=headers)
+        assert rv.status_code == 200
+        transactions = rv.json
+        assert [t["id"] for t in transactions] == [1, 2, 3]
+
+        # after_id excludes exactly the given id and everything before it
+        rv = self.client.get("/api/transactions/history/?after_id=1", headers=headers)
+        assert rv.status_code == 200
+        assert [t["id"] for t in rv.json] == [2, 3]
+
+        # after_id=0 is the "everything" sentinel, not a falsy no-op
+        rv = self.client.get("/api/transactions/history/?after_id=0", headers=headers)
+        assert rv.status_code == 200
+        assert [t["id"] for t in rv.json] == [1, 2, 3]
+
+        # before_id excludes exactly the given id and everything after it
+        rv = self.client.get("/api/transactions/history/?before_id=3", headers=headers)
+        assert rv.status_code == 200
+        assert [t["id"] for t in rv.json] == [1, 2]
+
+        # before_id/after_id AND-compose with each other
+        rv = self.client.get(
+            "/api/transactions/history/?after_id=1&before_id=3", headers=headers
+        )
+        assert rv.status_code == 200
+        assert [t["id"] for t in rv.json] == [2]
+
+        # before_id/after_id AND-compose with the legacy timestamp before/after
+        after_ts = transactions[0]["timestamp"]
+        rv = self.client.get(
+            f"/api/transactions/history/?after={after_ts}&after_id=0",
+            headers=headers,
+        )
+        assert rv.status_code == 200
+        assert [t["id"] for t in rv.json] == [2, 3]
+
+        # an over-constrained combination yields fewer rows, never wrong ones
+        rv = self.client.get(
+            f"/api/transactions/history/?after={after_ts}&before_id=2",
+            headers=headers,
+        )
+        assert rv.status_code == 200
+        assert rv.json == []
+
+    def test_after_precision_bug_vs_after_id(self):
+        """Legacy timestamp cursor can redeliver a transaction forever; id cursor cannot.
+
+        T1 is a hand-picked nanosecond epoch where the float round-trip
+        through the served `timestamp` field (`self.timestamp / 1e9`) loses
+        precision: T1 / 1e9 == 1700000000.0 exactly, but
+        1700000000.0 * 1e9 == 1_700_000_000_000_000_000, which is *less
+        than* T1. So filtering with `after=<served timestamp>` reconstructs
+        a threshold below the transaction's actual stored timestamp, the
+        `>` comparison still matches it, and it gets redelivered on every
+        subsequent poll. This is a known, deliberately-preserved legacy
+        bug (existing consumers rely on the current `after`/`before`
+        timestamp contract, so it is not changed) -- the assertion below
+        documents it and must not be "fixed" by deleting it.
+        """
+        headers = get_headers(self.client, "editor", "123")
+        rv = self.client.post("/api/people/", json={}, headers=headers)
+        assert rv.status_code == 201
+
+        T1 = 1_700_000_000_000_000_001
+        assert T1 / 1e9 == 1700000000.0
+        assert 1700000000.0 * 1e9 < T1
+
+        undo_db_path = os.path.join(self.dirpath, "undo.db")
+        engine = create_engine(f"sqlite:///{undo_db_path}")
+        with engine.begin() as conn:
+            conn.execute(
+                text("UPDATE transactions SET timestamp = :ts WHERE id = 1"),
+                {"ts": T1},
+            )
+
+        rv = self.client.get("/api/transactions/history/", headers=headers)
+        assert rv.status_code == 200
+        served_timestamp = rv.json[0]["timestamp"]
+        assert served_timestamp == 1700000000.0
+
+        # legacy timestamp cursor: redelivers transaction 1 forever (known bug)
+        rv = self.client.get(
+            f"/api/transactions/history/?after={served_timestamp}", headers=headers
+        )
+        assert rv.status_code == 200
+        assert [t["id"] for t in rv.json] == [1]
+
+        # id cursor: exact, no precision loss, no redelivery
+        rv = self.client.get("/api/transactions/history/?after_id=1", headers=headers)
+        assert rv.status_code == 200
+        assert rv.json == []
 
     def test_guest(self):
         headers = get_headers(self.client, "user", "123")


### PR DESCRIPTION
## Problem

`Transaction.timestamp` is stored as an integer nanosecond epoch, but
`GET /api/transactions/history/` serializes it as `timestamp / 1e9` (float
seconds), and the `before`/`after` query filters reconstruct the threshold
via `timestamp < before * 1e9` / `timestamp > after * 1e9`.

That round trip through a float is not exact. For roughly half of
realistic nanosecond timestamps, `T / 1e9 * 1e9 < T`, so a client that
takes the served `timestamp` and re-sends it as the next `after` gets a
threshold that's *below* the original transaction's stored value — the
`>` comparison still matches, and the transaction is returned again. Any
consumer that polls this endpoint using its own last-seen `timestamp` as
the next cursor can end up redelivering the same transaction on every
subsequent poll.

## Fix

Add `before_id` / `after_id` as new, optional query parameters that
filter on `Transaction.id` instead — a plain autoincrement integer PK,
already returned in every response and already used for ordering, so
there's no floating-point precision loss to reason about.

- `after_id`: return transactions with `id` strictly greater than this
  value. `0` is a valid, meaningful value ("everything from the
  beginning"), not treated as unset.
- `before_id`: return transactions with `id` strictly less than this
  value.
- Both AND-compose with each other and with the existing `before`/`after`
  timestamp filters (sequential `.filter()`, same as `before`/`after`
  already do with each other) — an over-constrained combination just
  yields fewer rows, never wrong ones.

This is purely additive: the existing `before`/`after` timestamp
parameters and their behavior (precision-loss bug included) are
untouched, so nothing currently relying on that contract needs to
change. No schema/DB migration needed — `UndoTransactionSchema` already
serializes `id`.

## Changes

- `gramps_webapi/undodb.py` — `DbUndoSQLWeb.get_transactions()` gains
  `before_id`/`after_id` params.
- `gramps_webapi/api/resources/history.py` — `TransactionsHistoryQueryArgs`
  gains the two new fields, passed through to `get_transactions()`.
- `tests/test_endpoints/test_history.py` —
  - `test_after_id_before_id`: exact exclusion, AND-composition with each
    other and with the legacy `before`/`after`, and `after_id=0` as the
    "everything" sentinel.
  - `test_after_precision_bug_vs_after_id`: deterministic repro (a
    hand-picked timestamp known to trigger the float round-trip bug)
    showing the legacy `after` cursor still redelivers a transaction,
    while `after_id` does not. This documents the legacy behavior as
    intentionally preserved, not a regression.

## Test plan

- [x] `pytest tests/test_endpoints/test_history.py -v` — 21 passed
- [x] `pytest tests/test_undodb.py -v` — 8 passed (regression check on the
      raw-SQL test pattern reused above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)