### PR TITLE
Negotiate thumbnail format instead of hardcoding AVIF

### DIFF
--- a/gramps_webapi/api/cache.py
+++ b/gramps_webapi/api/cache.py
@@ -13,6 +13,7 @@ from flask_caching import Cache
 from gramps.gen.errors import HandleError
 
 from gramps_webapi.api.auth import has_permissions
+from gramps_webapi.api.image import negotiate_thumbnail_format
 from gramps_webapi.api.util import (
     get_db_handle,
     get_db_manager,
@@ -70,7 +71,12 @@ def make_cache_key_thumbnails(*args, **kwargs):
 
     dbmgr = get_db_manager(tree)
 
-    cache_key = checksum + request.path + arg_hash + dbmgr.dirname + ":avif"
+    # Format is negotiated per-client (see negotiate_thumbnail_format's
+    # docstring -- AVIF decoding isn't universal), so it has to be part of
+    # the cache key too, or the first requester's format would get served
+    # to every later client regardless of what *they* can decode.
+    _fmt, mimetype = negotiate_thumbnail_format()
+    cache_key = checksum + request.path + arg_hash + dbmgr.dirname + ":" + mimetype
 
     return cache_key
 

--- a/gramps_webapi/api/file.py
+++ b/gramps_webapi/api/file.py
@@ -45,6 +45,7 @@ from .image import (
     get_native_max_zoom,
     negotiate_thumbnail_format,
     open_image,
+    send_negotiated_thumbnail,
     transparent_png_tile,
 )
 from .util import abort_with_message
@@ -262,7 +263,7 @@ class LocalFileHandler(FileHandler):
         thumb = LocalFileThumbnailHandler(self.path_abs, self.mime)
         fmt, mimetype = negotiate_thumbnail_format()
         buffer = thumb.get_cropped(x1=x1, y1=y1, x2=x2, y2=y2, square=square, fmt=fmt)
-        return send_file(buffer, mimetype=mimetype)
+        return send_negotiated_thumbnail(buffer, mimetype)
 
     def send_thumbnail(self, size: int, square: bool = False):
         """Send thumbnail of image."""
@@ -274,7 +275,7 @@ class LocalFileHandler(FileHandler):
         thumb = LocalFileThumbnailHandler(self.path_abs, self.mime)
         fmt, mimetype = negotiate_thumbnail_format()
         buffer = thumb.get_thumbnail(size=size, square=square, fmt=fmt)
-        return send_file(buffer, mimetype=mimetype)
+        return send_negotiated_thumbnail(buffer, mimetype)
 
     def send_thumbnail_cropped(
         self, size: int, x1: int, y1: int, x2: int, y2: int, square: bool = False
@@ -290,7 +291,7 @@ class LocalFileHandler(FileHandler):
         buffer = thumb.get_thumbnail_cropped(
             size=size, x1=x1, y1=y1, x2=x2, y2=y2, square=square, fmt=fmt
         )
-        return send_file(buffer, mimetype=mimetype)
+        return send_negotiated_thumbnail(buffer, mimetype)
 
     def send_map_tile(self, z: int, x: int, y: int, max_zoom: int | None = None):
         """Send a map tile for a georeferenced image."""

--- a/gramps_webapi/api/file.py
+++ b/gramps_webapi/api/file.py
@@ -33,7 +33,7 @@ from gramps.gen.lib import Media
 from PIL import Image
 from werkzeug.datastructures import FileStorage
 
-from gramps_webapi.const import MIME_AVIF, MIME_PNG
+from gramps_webapi.const import MIME_PNG
 
 from ..types import FilenameOrPath
 from .cache import get_cached_native_max_zoom, set_cached_native_max_zoom
@@ -43,6 +43,7 @@ from .image import (
     detect_faces,
     get_map_tile,
     get_native_max_zoom,
+    negotiate_thumbnail_format,
     open_image,
     transparent_png_tile,
 )
@@ -259,8 +260,9 @@ class LocalFileHandler(FileHandler):
             abort_with_message(403, "File access not allowed")
         self._abort_if_too_large()
         thumb = LocalFileThumbnailHandler(self.path_abs, self.mime)
-        buffer = thumb.get_cropped(x1=x1, y1=y1, x2=x2, y2=y2, square=square)
-        return send_file(buffer, mimetype=MIME_AVIF)
+        fmt, mimetype = negotiate_thumbnail_format()
+        buffer = thumb.get_cropped(x1=x1, y1=y1, x2=x2, y2=y2, square=square, fmt=fmt)
+        return send_file(buffer, mimetype=mimetype)
 
     def send_thumbnail(self, size: int, square: bool = False):
         """Send thumbnail of image."""
@@ -270,8 +272,9 @@ class LocalFileHandler(FileHandler):
             abort_with_message(403, "File access not allowed")
         self._abort_if_too_large()
         thumb = LocalFileThumbnailHandler(self.path_abs, self.mime)
-        buffer = thumb.get_thumbnail(size=size, square=square)
-        return send_file(buffer, mimetype=MIME_AVIF)
+        fmt, mimetype = negotiate_thumbnail_format()
+        buffer = thumb.get_thumbnail(size=size, square=square, fmt=fmt)
+        return send_file(buffer, mimetype=mimetype)
 
     def send_thumbnail_cropped(
         self, size: int, x1: int, y1: int, x2: int, y2: int, square: bool = False
@@ -283,10 +286,11 @@ class LocalFileHandler(FileHandler):
             abort_with_message(403, "File access not allowed")
         self._abort_if_too_large()
         thumb = LocalFileThumbnailHandler(self.path_abs, self.mime)
+        fmt, mimetype = negotiate_thumbnail_format()
         buffer = thumb.get_thumbnail_cropped(
-            size=size, x1=x1, y1=y1, x2=x2, y2=y2, square=square
+            size=size, x1=x1, y1=y1, x2=x2, y2=y2, square=square, fmt=fmt
         )
-        return send_file(buffer, mimetype=MIME_AVIF)
+        return send_file(buffer, mimetype=mimetype)
 
     def send_map_tile(self, z: int, x: int, y: int, max_zoom: int | None = None):
         """Send a map tile for a georeferenced image."""

--- a/gramps_webapi/api/image.py
+++ b/gramps_webapi/api/image.py
@@ -29,11 +29,12 @@ from importlib.resources import as_file, files
 from pathlib import Path
 from typing import BinaryIO, Callable, Iterator, Union
 
+from flask import request
 from PIL import Image, ImageOps, UnidentifiedImageError
 from PIL.Image import DecompressionBombError
 from PIL.Image import Image as ImageType
 
-from gramps_webapi.const import MIME_PDF
+from gramps_webapi.const import MIME_AVIF, MIME_JPEG, MIME_PDF
 from gramps_webapi.types import FilenameOrPath
 
 from .util import abort_with_message
@@ -127,6 +128,35 @@ def save_image_buffer(image: ImageType, fmt="AVIF") -> BinaryIO:
     image.save(buffer, format=fmt)
     buffer.seek(0)
     return buffer
+
+
+def negotiate_thumbnail_format() -> tuple[str, str]:
+    """Pick a thumbnail encoding the requesting client actually said it can decode.
+
+    AVIF decoding isn't universal -- e.g. Ubuntu's stock WebKitGTK (used for
+    gramps-connect's standalone Linux build's native window) ships with no
+    libavif/dav1d decoder at all, so an AVIF thumbnail 200s over the wire and
+    then silently fails to render, with no error anywhere. JPEG is the one
+    format every client can be assumed to decode, so it's the default;
+    AVIF is only sent to a client whose Accept header explicitly lists it
+    (real browsers with AVIF support do -- Chromium-family engines since
+    ~2020: `image/avif,image/webp,...,image/*,*/*;q=0.8`).
+
+    Deliberately not accept_mimetypes.best_match([MIME_AVIF, MIME_JPEG]):
+    that treats a bare "*/*" (which curl sends by default, and which
+    trails most real Accept headers as a catch-all) as a match for every
+    candidate, so it can't tell "this client explicitly said it decodes
+    AVIF" apart from "this client accepts anything" -- confirmed live, it
+    returned AVIF even for a request with no avif/webp/image/* entry at
+    all, just "*/*;q=0.8". Checking for an exact "image/avif" entry
+    sidesteps that entirely.
+
+    Returns a `(PIL format string, MIME type)` pair.
+    """
+    accepted = {mimetype.lower() for mimetype, _quality in request.accept_mimetypes}
+    if MIME_AVIF in accepted:
+        return "AVIF", MIME_AVIF
+    return "JPEG", MIME_JPEG
 
 
 class ThumbnailHandler:

--- a/gramps_webapi/api/image.py
+++ b/gramps_webapi/api/image.py
@@ -29,7 +29,7 @@ from importlib.resources import as_file, files
 from pathlib import Path
 from typing import BinaryIO, Callable, Iterator, Union
 
-from flask import request
+from flask import Response, request, send_file
 from PIL import Image, ImageOps, UnidentifiedImageError
 from PIL.Image import DecompressionBombError
 from PIL.Image import Image as ImageType
@@ -157,6 +157,20 @@ def negotiate_thumbnail_format() -> tuple[str, str]:
     if MIME_AVIF in accepted:
         return "AVIF", MIME_AVIF
     return "JPEG", MIME_JPEG
+
+
+def send_negotiated_thumbnail(buffer: BinaryIO, mimetype: str) -> Response:
+    """Send a thumbnail buffer whose format was picked by `negotiate_thumbnail_format`.
+
+    Sets `Vary: Accept` since the response body now depends on the request's
+    Accept header -- without it, a shared cache sitting in front of the API
+    (a CDN or reverse-proxy cache, not Gramps Web API's own file cache, which
+    already keys on the negotiated MIME type) could serve one client's
+    negotiated format to a different client requesting the same URL.
+    """
+    response = send_file(buffer, mimetype=mimetype)
+    response.headers["Vary"] = "Accept"
+    return response
 
 
 class ThumbnailHandler:

--- a/gramps_webapi/api/s3.py
+++ b/gramps_webapi/api/s3.py
@@ -27,7 +27,7 @@ from gramps.gen.db.base import DbReadBase
 
 from PIL import Image
 
-from ..const import MIME_AVIF, MIME_PNG
+from ..const import MIME_PNG
 from .cache import get_cached_native_max_zoom, set_cached_native_max_zoom
 from .file import FileHandler, _get_map_bounds
 from .image import (
@@ -35,6 +35,7 @@ from .image import (
     abort_on_image_errors,
     get_map_tile,
     get_native_max_zoom,
+    negotiate_thumbnail_format,
     transparent_png_tile,
 )
 from .util import abort_with_message
@@ -163,16 +164,18 @@ class ObjectStorageFileHandler(FileHandler):
         self._abort_if_too_large()
         fileobj = self._download_fileobj()
         thumb = ThumbnailHandler(fileobj, self.mime)
-        buffer = thumb.get_cropped(x1=x1, y1=y1, x2=x2, y2=y2, square=square)
-        return send_file(buffer, mimetype=MIME_AVIF)
+        fmt, mimetype = negotiate_thumbnail_format()
+        buffer = thumb.get_cropped(x1=x1, y1=y1, x2=x2, y2=y2, square=square, fmt=fmt)
+        return send_file(buffer, mimetype=mimetype)
 
     def send_thumbnail(self, size: int, square: bool = False):
         """Send thumbnail of image."""
         self._abort_if_too_large()
         fileobj = self._download_fileobj()
         thumb = ThumbnailHandler(fileobj, self.mime)
-        buffer = thumb.get_thumbnail(size=size, square=square)
-        return send_file(buffer, mimetype=MIME_AVIF)
+        fmt, mimetype = negotiate_thumbnail_format()
+        buffer = thumb.get_thumbnail(size=size, square=square, fmt=fmt)
+        return send_file(buffer, mimetype=mimetype)
 
     def send_thumbnail_cropped(
         self, size: int, x1: int, y1: int, x2: int, y2: int, square: bool = False
@@ -181,10 +184,11 @@ class ObjectStorageFileHandler(FileHandler):
         self._abort_if_too_large()
         fileobj = self._download_fileobj()
         thumb = ThumbnailHandler(fileobj, self.mime)
+        fmt, mimetype = negotiate_thumbnail_format()
         buffer = thumb.get_thumbnail_cropped(
-            size=size, x1=x1, y1=y1, x2=x2, y2=y2, square=square
+            size=size, x1=x1, y1=y1, x2=x2, y2=y2, square=square, fmt=fmt
         )
-        return send_file(buffer, mimetype=MIME_AVIF)
+        return send_file(buffer, mimetype=mimetype)
 
     def send_map_tile(self, z: int, x: int, y: int, max_zoom: int | None = None):
         """Send a map tile for a georeferenced image."""

--- a/gramps_webapi/api/s3.py
+++ b/gramps_webapi/api/s3.py
@@ -36,6 +36,7 @@ from .image import (
     get_map_tile,
     get_native_max_zoom,
     negotiate_thumbnail_format,
+    send_negotiated_thumbnail,
     transparent_png_tile,
 )
 from .util import abort_with_message
@@ -166,7 +167,7 @@ class ObjectStorageFileHandler(FileHandler):
         thumb = ThumbnailHandler(fileobj, self.mime)
         fmt, mimetype = negotiate_thumbnail_format()
         buffer = thumb.get_cropped(x1=x1, y1=y1, x2=x2, y2=y2, square=square, fmt=fmt)
-        return send_file(buffer, mimetype=mimetype)
+        return send_negotiated_thumbnail(buffer, mimetype)
 
     def send_thumbnail(self, size: int, square: bool = False):
         """Send thumbnail of image."""
@@ -175,7 +176,7 @@ class ObjectStorageFileHandler(FileHandler):
         thumb = ThumbnailHandler(fileobj, self.mime)
         fmt, mimetype = negotiate_thumbnail_format()
         buffer = thumb.get_thumbnail(size=size, square=square, fmt=fmt)
-        return send_file(buffer, mimetype=mimetype)
+        return send_negotiated_thumbnail(buffer, mimetype)
 
     def send_thumbnail_cropped(
         self, size: int, x1: int, y1: int, x2: int, y2: int, square: bool = False
@@ -188,7 +189,7 @@ class ObjectStorageFileHandler(FileHandler):
         buffer = thumb.get_thumbnail_cropped(
             size=size, x1=x1, y1=y1, x2=x2, y2=y2, square=square, fmt=fmt
         )
-        return send_file(buffer, mimetype=mimetype)
+        return send_negotiated_thumbnail(buffer, mimetype)
 
     def send_map_tile(self, z: int, x: int, y: int, max_zoom: int | None = None):
         """Send a map tile for a georeferenced image."""

--- a/tests/test_endpoints/test_file.py
+++ b/tests/test_endpoints/test_file.py
@@ -24,7 +24,7 @@ from io import BytesIO
 
 from PIL import Image
 
-from gramps_webapi.const import MIME_AVIF
+from gramps_webapi.const import MIME_AVIF, MIME_JPEG
 
 from . import BASE_URL, get_test_client
 from .checks import check_requires_token, check_success
@@ -69,12 +69,28 @@ class TestThumbnail(unittest.TestCase):
         check_requires_token(self, TEST_URL + "b39fe1cfc1305ac4a21/thumbnail/20")
 
     def test_get_thumbnail_small(self):
-        """Test reponse for thumbnails."""
+        """Test reponse for thumbnails: JPEG by default (no AVIF in Accept)."""
         media_objects = check_success(self, TEST_URL)
         for obj in media_objects:
             rv = check_success(
                 self, "{}{}/thumbnail/20".format(TEST_URL, obj["handle"]), full=True
             )
+            assert rv.mimetype == MIME_JPEG
+            img = Image.open(BytesIO(rv.data))
+            assert img.format == "JPEG"
+            # long side should be 20 px
+            assert max(img.width, img.height) == 20
+
+    def test_get_thumbnail_small_avif(self):
+        """Test AVIF is served when the client's Accept header asks for it."""
+        media_objects = check_success(self, TEST_URL)
+        for obj in media_objects:
+            header = fetch_header(self.client)
+            header["Accept"] = MIME_AVIF
+            rv = self.client.get(
+                "{}{}/thumbnail/20".format(TEST_URL, obj["handle"]), headers=header
+            )
+            assert rv.status_code == 200
             assert rv.mimetype == MIME_AVIF
             img = Image.open(BytesIO(rv.data))
             assert img.format == "AVIF"
@@ -165,7 +181,7 @@ class TestCropped(unittest.TestCase):
         )
 
     def test_get_cropped(self):
-        """Test reponse for cropped image."""
+        """Test reponse for cropped image: JPEG by default (no AVIF in Accept)."""
         media_objects = check_success(self, TEST_URL)
         for obj in media_objects:
             rv = check_success(
@@ -177,6 +193,28 @@ class TestCropped(unittest.TestCase):
                 "{}{}/cropped/10/80/20/100".format(TEST_URL, obj["handle"]),
                 full=True,
             )
+            assert rv.mimetype == MIME_JPEG
+            img = Image.open(BytesIO(rv.data))
+            assert img.format == "JPEG"
+            # allow 1 px difference due to rounding
+            self.assertAlmostEqual(img.width, 0.1 * full_img.width, delta=1)
+            self.assertAlmostEqual(img.height, 0.2 * full_img.height, delta=1)
+
+    def test_get_cropped_avif(self):
+        """Test AVIF is served when the client's Accept header asks for it."""
+        media_objects = check_success(self, TEST_URL)
+        for obj in media_objects:
+            rv = check_success(
+                self, "{}{}/file".format(TEST_URL, obj["handle"]), full=True
+            )
+            full_img = Image.open(BytesIO(rv.data))
+            header = fetch_header(self.client)
+            header["Accept"] = MIME_AVIF
+            rv = self.client.get(
+                "{}{}/cropped/10/80/20/100".format(TEST_URL, obj["handle"]),
+                headers=header,
+            )
+            assert rv.status_code == 200
             assert rv.mimetype == MIME_AVIF
             img = Image.open(BytesIO(rv.data))
             assert img.format == "AVIF"
@@ -218,7 +256,7 @@ class TestCroppedThumbnail(unittest.TestCase):
         )
 
     def test_get_cropped_thumbnail_small(self):
-        """Test reponse for thumbnails."""
+        """Test reponse for thumbnails: JPEG by default (no AVIF in Accept)."""
         media_objects = check_success(self, TEST_URL)
         for obj in media_objects:
             rv = check_success(
@@ -226,6 +264,23 @@ class TestCroppedThumbnail(unittest.TestCase):
                 "{}{}/cropped/10/10/90/90/thumbnail/20".format(TEST_URL, obj["handle"]),
                 full=True,
             )
+            assert rv.mimetype == MIME_JPEG
+            img = Image.open(BytesIO(rv.data))
+            assert img.format == "JPEG"
+            # long side should be 20 px
+            assert max(img.width, img.height) == 20
+
+    def test_get_cropped_thumbnail_small_avif(self):
+        """Test AVIF is served when the client's Accept header asks for it."""
+        media_objects = check_success(self, TEST_URL)
+        for obj in media_objects:
+            header = fetch_header(self.client)
+            header["Accept"] = MIME_AVIF
+            rv = self.client.get(
+                "{}{}/cropped/10/10/90/90/thumbnail/20".format(TEST_URL, obj["handle"]),
+                headers=header,
+            )
+            assert rv.status_code == 200
             assert rv.mimetype == MIME_AVIF
             img = Image.open(BytesIO(rv.data))
             assert img.format == "AVIF"


### PR DESCRIPTION
## Summary
- `send_thumbnail`/`send_thumbnail_cropped`/`send_cropped` always encoded thumbnails as AVIF with no way for a client to ask for anything else
- AVIF decoding isn't universal: confirmed live against Ubuntu's stock WebKitGTK (2.52.3, no libavif/dav1d linked) that a thumbnail request 200s with valid AVIF bytes and then silently fails to decode in an `<img>` — no console error, no broken-image fallback. Every thumbnail in a client built on that engine (gramps-connect's standalone Linux build's native window) was therefore just blank
- `negotiate_thumbnail_format()` (`api/image.py`) now returns JPEG unless the client's `Accept` header explicitly lists `image/avif` as an exact entry — deliberately not `accept_mimetypes.best_match()`, since that treats a bare `*/*` (curl's default, and the trailing catch-all on most real `Accept` headers) as a match for every candidate and can't distinguish "this client said it decodes AVIF" from "this client accepts anything" (confirmed it returned AVIF even with no avif/webp/image/* entry at all)
- The thumbnail cache key (`api/cache.py`) now includes the negotiated MIME type, since it previously hardcoded `:avif` — otherwise an AVIF-capable and AVIF-incapable client would collide on the same cached response

## Test plan
- [x] Confirmed fixed by loading the real thumbnail URL in a headless WebKitGTK view and checking `img.naturalWidth`: 0 before, 100 after
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)