### PR TITLE
Use pessimistic disconnect handling for user db by default

### DIFF
--- a/gramps_webapi/config.py
+++ b/gramps_webapi/config.py
@@ -41,6 +41,8 @@ class DefaultConfig(object):
     OPENAPI_SWAGGER_UI_URL = "https://cdn.jsdelivr.net/npm/swagger-ui-dist/"
     SEARCH_INDEX_DIR = "indexdir"  # deprecated!
     SEARCH_INDEX_DB_URI = ""
+    # verify pooled connections on checkout, as idle ones can be dropped server-side
+    SQLALCHEMY_ENGINE_OPTIONS = {"pool_pre_ping": True}
     EMAIL_HOST = "localhost"
     EMAIL_PORT = "465"
     EMAIL_HOST_USER = ""


### PR DESCRIPTION
Claude:

## Problem

Connections to the user database are pooled and can be closed server-side while idle (DB restart, idle timeout, connection pooler, load balancer). SQLAlchemy then hands out a dead connection and the request fails with `OperationalError: server closed the connection unexpectedly`.

This app is especially exposed: permissions come from JWT claims, so only a minority of requests touch the user DB. Connections therefore sit idle in each worker's pool for hours between uses.

## Fix

Set `pool_pre_ping` in `DefaultConfig`:

```python
SQLALCHEMY_ENGINE_OPTIONS = {"pool_pre_ping": True}
```

SQLAlchemy validates each connection on checkout and transparently replaces dead ones, so requests never see the error.

## Notes

- Safe on every backend, including in-memory SQLite (`StaticPool`) used in tests — verified the option reaches the engine.
- `pool_recycle` is deliberately **not** set: it would recreate `StaticPool` connections and wipe in-memory SQLite databases.
- Cost is one `SELECT 1` per checkout — a local no-op for SQLite, sub-millisecond for a networked DB, and only on requests that touch the user DB.
- Overridable per deployment via `GRAMPSWEB_SQLALCHEMY_ENGINE_OPTIONS` (JSON), e.g. to add `pool_size` or `pool_recycle`.
