### PR TITLE
Give generic object CRUD endpoints unique OpenAPI operationIds

### DIFF
--- a/gramps_webapi/api/__init__.py
+++ b/gramps_webapi/api/__init__.py
@@ -32,7 +32,7 @@ from .cache import thumbnail_cache_decorator, tile_cache_decorator
 from .media import get_media_handler
 from .resources.access_tokens import UserAccessTokenResource
 from .resources.anniversaries import AnniversariesIcsResource
-from .resources.base import Resource
+from .resources.base import Resource, object_request_body
 from .resources.bookmarks import (
     BookmarkEditResource,
     BookmarkResource,
@@ -170,9 +170,34 @@ from .util import abort_with_message, get_db_handle, get_tree_from_jwt, parser, 
 
 
 def register_endpt(
-    resource: Type[Resource], url: str, name: str, tags: Optional[List[str]] = None
+    resource: Type[Resource],
+    url: str,
+    name: str,
+    tags: Optional[List[str]] = None,
+    request_body: Optional[dict] = None,
 ):
-    """Register an endpoint."""
+    """Register an endpoint.
+
+    `name` is already unique per call site, so `{verb}_{name}` gives every
+    HTTP method of every resource its own OpenAPI operationId from one
+    place, instead of relying on each resource class to derive one for
+    itself. Without a distinct operationId, tools that generate clients (or
+    MCP servers) from openapi.json cannot tell operations apart.
+
+    `request_body` documents the JSON payload of a POST/PUT endpoint (e.g.
+    via `object_request_body()`); omit it for endpoints that take no body
+    or a non-JSON one (such as Media's raw file upload).
+    """
+    for verb in ("get", "post", "put", "delete", "patch"):
+        method = getattr(resource, verb, None)
+        if method is None:
+            continue
+        doc_kwargs: dict = {"operationId": f"{verb}_{name}"}
+        if request_body is not None and verb in ("post", "put"):
+            doc_kwargs["requestBody"] = request_body
+        # setattr rather than plain assignment: mypy rejects assigning to a
+        # method.
+        setattr(resource, verb, api_blueprint.doc(**doc_kwargs)(method))
     # Register all HTTP methods explicitly so Werkzeug always finds the route
     # and returns 405 (not 404) for methods the view doesn't implement.
     # flask-smorest still only documents methods actually defined on the class.
@@ -256,7 +281,13 @@ register_endpt(
     "person-timeline",
     tags=["Timeline"],
 )
-register_endpt(PersonResource, "/people/<string:handle>", "person", tags=["People"])
+register_endpt(
+    PersonResource,
+    "/people/<string:handle>",
+    "person",
+    tags=["People"],
+    request_body=object_request_body("Person"),
+)
 register_endpt(
     PersonDnaMatchesResource,
     "/people/<string:handle>/dna/matches",
@@ -266,7 +297,13 @@ register_endpt(
 register_endpt(
     PersonYDnaResource, "/people/<string:handle>/ydna", "person-ydna", tags=["DNA"]
 )
-register_endpt(PeopleResource, "/people/", "people", tags=["People"])
+register_endpt(
+    PeopleResource,
+    "/people/",
+    "people",
+    tags=["People"],
+    request_body=object_request_body("Person"),
+)
 register_endpt(PersonQueryResource, "/people/query/", "people-query", tags=["People"])
 register_endpt(
     MergePersonResource,
@@ -281,8 +318,20 @@ register_endpt(
     "family-timeline",
     tags=["Timeline"],
 )
-register_endpt(FamilyResource, "/families/<string:handle>", "family", tags=["Families"])
-register_endpt(FamiliesResource, "/families/", "families", tags=["Families"])
+register_endpt(
+    FamilyResource,
+    "/families/<string:handle>",
+    "family",
+    tags=["Families"],
+    request_body=object_request_body("Family"),
+)
+register_endpt(
+    FamiliesResource,
+    "/families/",
+    "families",
+    tags=["Families"],
+    request_body=object_request_body("Family"),
+)
 register_endpt(
     FamilyQueryResource, "/families/query/", "families-query", tags=["Families"]
 )
@@ -299,8 +348,20 @@ register_endpt(
     "event-span",
     tags=["Events"],
 )
-register_endpt(EventResource, "/events/<string:handle>", "event", tags=["Events"])
-register_endpt(EventsResource, "/events/", "events", tags=["Events"])
+register_endpt(
+    EventResource,
+    "/events/<string:handle>",
+    "event",
+    tags=["Events"],
+    request_body=object_request_body("Event"),
+)
+register_endpt(
+    EventsResource,
+    "/events/",
+    "events",
+    tags=["Events"],
+    request_body=object_request_body("Event"),
+)
 register_endpt(EventQueryResource, "/events/query/", "events-query", tags=["Events"])
 register_endpt(
     MergeEventResource,
@@ -319,8 +380,20 @@ register_endpt(
     tags=["Timeline"],
 )
 # Places
-register_endpt(PlaceResource, "/places/<string:handle>", "place", tags=["Places"])
-register_endpt(PlacesResource, "/places/", "places", tags=["Places"])
+register_endpt(
+    PlaceResource,
+    "/places/<string:handle>",
+    "place",
+    tags=["Places"],
+    request_body=object_request_body("Place"),
+)
+register_endpt(
+    PlacesResource,
+    "/places/",
+    "places",
+    tags=["Places"],
+    request_body=object_request_body("Place"),
+)
 register_endpt(PlaceQueryResource, "/places/query/", "places-query", tags=["Places"])
 register_endpt(
     MergePlaceResource,
@@ -330,9 +403,19 @@ register_endpt(
 )
 # Citations
 register_endpt(
-    CitationResource, "/citations/<string:handle>", "citation", tags=["Citations"]
+    CitationResource,
+    "/citations/<string:handle>",
+    "citation",
+    tags=["Citations"],
+    request_body=object_request_body("Citation"),
 )
-register_endpt(CitationsResource, "/citations/", "citations", tags=["Citations"])
+register_endpt(
+    CitationsResource,
+    "/citations/",
+    "citations",
+    tags=["Citations"],
+    request_body=object_request_body("Citation"),
+)
 register_endpt(
     CitationQueryResource, "/citations/query/", "citations-query", tags=["Citations"]
 )
@@ -343,8 +426,20 @@ register_endpt(
     tags=["Citations"],
 )
 # Sources
-register_endpt(SourceResource, "/sources/<string:handle>", "source", tags=["Sources"])
-register_endpt(SourcesResource, "/sources/", "sources", tags=["Sources"])
+register_endpt(
+    SourceResource,
+    "/sources/<string:handle>",
+    "source",
+    tags=["Sources"],
+    request_body=object_request_body("Source"),
+)
+register_endpt(
+    SourcesResource,
+    "/sources/",
+    "sources",
+    tags=["Sources"],
+    request_body=object_request_body("Source"),
+)
 register_endpt(
     SourceQueryResource, "/sources/query/", "sources-query", tags=["Sources"]
 )
@@ -360,9 +455,14 @@ register_endpt(
     "/repositories/<string:handle>",
     "repository",
     tags=["Repositories"],
+    request_body=object_request_body("Repository"),
 )
 register_endpt(
-    RepositoriesResource, "/repositories/", "repositories", tags=["Repositories"]
+    RepositoriesResource,
+    "/repositories/",
+    "repositories",
+    tags=["Repositories"],
+    request_body=object_request_body("Repository"),
 )
 register_endpt(
     RepositoryQueryResource,
@@ -378,8 +478,14 @@ register_endpt(
 )
 # Media
 register_endpt(
-    MediaObjectResource, "/media/<string:handle>", "media_object", tags=["Media"]
+    MediaObjectResource,
+    "/media/<string:handle>",
+    "media_object",
+    tags=["Media"],
+    request_body=object_request_body("Media"),
 )
+# MediaObjectsResource's POST takes a raw file upload (multipart), not JSON,
+# so it gets no request_body doc here.
 register_endpt(MediaObjectsResource, "/media/", "media_objects", tags=["Media"])
 register_endpt(MediaQueryResource, "/media/query/", "media-query", tags=["Media"])
 register_endpt(
@@ -389,8 +495,20 @@ register_endpt(
     tags=["Media"],
 )
 # Notes
-register_endpt(NoteResource, "/notes/<string:handle>", "note", tags=["Notes"])
-register_endpt(NotesResource, "/notes/", "notes", tags=["Notes"])
+register_endpt(
+    NoteResource,
+    "/notes/<string:handle>",
+    "note",
+    tags=["Notes"],
+    request_body=object_request_body("Note"),
+)
+register_endpt(
+    NotesResource,
+    "/notes/",
+    "notes",
+    tags=["Notes"],
+    request_body=object_request_body("Note"),
+)
 register_endpt(NoteQueryResource, "/notes/query/", "notes-query", tags=["Notes"])
 register_endpt(
     MergeNoteResource,
@@ -399,8 +517,20 @@ register_endpt(
     tags=["Notes"],
 )
 # Tags
-register_endpt(TagResource, "/tags/<string:handle>", "tag", tags=["Tags"])
-register_endpt(TagsResource, "/tags/", "tags", tags=["Tags"])
+register_endpt(
+    TagResource,
+    "/tags/<string:handle>",
+    "tag",
+    tags=["Tags"],
+    request_body=object_request_body("Tag"),
+)
+register_endpt(
+    TagsResource,
+    "/tags/",
+    "tags",
+    tags=["Tags"],
+    request_body=object_request_body("Tag"),
+)
 register_endpt(TagQueryResource, "/tags/query/", "tags-query", tags=["Tags"])
 # Trees
 register_endpt(TreeResource, "/trees/<string:tree_id>", "tree", tags=["Trees"])
@@ -705,6 +835,7 @@ register_endpt(
 # Shared query params: jwt (auth via URL), checksum (frontend service worker
 # cache busting by URL versioning; ignored by the backend).
 @api_blueprint.route("/media/<string:handle>/tile/<int:z>/<int:x>/<int:y>")
+@api_blueprint.doc(operationId="get_media_tile")
 @jwt_required
 @use_args(
     {
@@ -734,6 +865,7 @@ def get_media_map_tile(args, handle: str, z: int, x: int, y: int):
 
 
 @api_blueprint.route("/media/<string:handle>/thumbnail/<int:size>")
+@api_blueprint.doc(operationId="get_media_thumbnail")
 @jwt_required
 @use_args(
     {
@@ -757,6 +889,7 @@ def get_thumbnail(args, handle, size):
 @api_blueprint.route(
     "/media/<string:handle>/cropped/<int:x1>/<int:y1>/<int:x2>/<int:y2>"
 )
+@api_blueprint.doc(operationId="get_media_cropped")
 @jwt_required
 @use_args(
     {
@@ -780,6 +913,7 @@ def get_cropped(args, handle: str, x1: int, y1: int, x2: int, y2: int):
 @api_blueprint.route(
     "/media/<string:handle>/cropped/<int:x1>/<int:y1>/<int:x2>/<int:y2>/thumbnail/<int:size>"
 )
+@api_blueprint.doc(operationId="get_media_cropped_thumbnail")
 @jwt_required
 @use_args(
     {

--- a/gramps_webapi/api/__init__.py
+++ b/gramps_webapi/api/__init__.py
@@ -188,11 +188,12 @@ def register_endpt(
     via `object_request_body()`); omit it for endpoints that take no body
     or a non-JSON one (such as Media's raw file upload).
     """
+    operation_name = name.replace("-", "_")
     for verb in ("get", "post", "put", "delete", "patch"):
         method = getattr(resource, verb, None)
         if method is None:
             continue
-        doc_kwargs: dict = {"operationId": f"{verb}_{name}"}
+        doc_kwargs: dict = {"operationId": f"{verb}_{operation_name}"}
         if request_body is not None and verb in ("post", "put"):
             doc_kwargs["requestBody"] = request_body
         # setattr rather than plain assignment: mypy rejects assigning to a

--- a/gramps_webapi/api/resources/base.py
+++ b/gramps_webapi/api/resources/base.py
@@ -19,7 +19,7 @@
 
 """Base for Gramps object API resources."""
 
-from typing import Any, TypeVar
+from typing import TypeVar
 
 import gramps_ql as gql
 import object_ql as oql
@@ -289,12 +289,7 @@ class GrampsObjectQueryArgs(Schema):
     )
 
 
-def _indefinite_article(word: str) -> str:
-    """Return "a" or "an" depending on the word's leading sound."""
-    return "an" if word[:1].lower() in "aeiou" else "a"
-
-
-def _object_request_body(gramps_class_name: str) -> dict:
+def object_request_body(gramps_class_name: str) -> dict:
     """Build the requestBody doc for a Gramps object mutation endpoint.
 
     The payload is the object itself, so it is documented by referencing
@@ -321,47 +316,6 @@ def _object_request_body(gramps_class_name: str) -> dict:
 
 class GrampsObjectResource(GrampsObjectResourceHelper, Resource):
     """Resource for a single object."""
-
-    def __init_subclass__(cls, **kwargs) -> None:
-        """Give each object type (Person, Family, ...) its own operationId.
-
-        get/put/delete are defined once here and inherited unchanged by
-        every object type, so every generated OpenAPI operation would
-        otherwise share the same auto-derived operationId/summary (e.g.
-        "Get the object."). That breaks tools that key off operationId,
-        such as OpenAPI-to-MCP generators.
-        """
-        super().__init_subclass__(**kwargs)
-        gramps_class_name = getattr(cls, "gramps_class_name", None)
-        if not gramps_class_name:
-            return
-        name = gramps_class_name.lower()
-        article = _indefinite_article(name)
-        # setattr rather than plain assignment: mypy rejects assigning to a
-        # method, and these are inherited methods being re-decorated.
-        setattr(
-            cls,
-            "get",
-            api_blueprint.doc(
-                operationId=f"get_{name}", summary=f"Get {article} {name}"
-            )(cls.get),
-        )
-        setattr(
-            cls,
-            "put",
-            api_blueprint.doc(
-                operationId=f"update_{name}",
-                summary=f"Update an existing {name}",
-                requestBody=_object_request_body(gramps_class_name),
-            )(cls.put),
-        )
-        setattr(
-            cls,
-            "delete",
-            api_blueprint.doc(
-                operationId=f"delete_{name}", summary=f"Delete {article} {name}"
-            )(cls.delete),
-        )
 
     @api_blueprint.response(200, Schema())
     @api_blueprint.arguments(GrampsObjectQueryArgs, location="query")
@@ -632,33 +586,6 @@ class GrampsObjectsQueryArgs(Schema):
 
 class GrampsObjectsResource(GrampsObjectResourceHelper, Resource):
     """Resource for multiple objects."""
-
-    def __init_subclass__(cls, **kwargs) -> None:
-        """See `GrampsObjectResource.__init_subclass__`."""
-        super().__init_subclass__(**kwargs)
-        gramps_class_name = getattr(cls, "gramps_class_name", None)
-        if not gramps_class_name:
-            return
-        plural = GRAMPS_OBJECT_PLURAL[gramps_class_name]
-        singular = gramps_class_name.lower()
-        # setattr rather than plain assignment: mypy rejects assigning to a
-        # method, and these are inherited methods being re-decorated.
-        setattr(
-            cls,
-            "get",
-            api_blueprint.doc(
-                operationId=f"list_{plural}", summary=f"List {plural}"
-            )(cls.get),
-        )
-        post_doc: dict[str, Any] = {
-            "operationId": f"create_{singular}",
-            "summary": f"Create {_indefinite_article(singular)} new {singular}",
-        }
-        if gramps_class_name != "Media":
-            # Media's POST takes a raw file upload (multipart), not a JSON
-            # object, so it keeps its own request body documentation.
-            post_doc["requestBody"] = _object_request_body(gramps_class_name)
-        setattr(cls, "post", api_blueprint.doc(**post_doc)(cls.post))
 
     @api_blueprint.response(200, Schema(many=True))
     @api_blueprint.arguments(GrampsObjectsQueryArgs, location="query")

--- a/gramps_webapi/api/resources/base.py
+++ b/gramps_webapi/api/resources/base.py
@@ -294,22 +294,29 @@ def _indefinite_article(word: str) -> str:
     return "an" if word[:1].lower() in "aeiou" else "a"
 
 
-GRAMPS_OBJECT_REQUEST_BODY = {
-    "required": True,
-    "content": {
-        "application/json": {
-            "schema": {
-                "type": "object",
-                "additionalProperties": True,
-                "description": (
-                    "A Gramps object dict for this resource's object type. "
-                    "The `_class` field is optional; if present it must "
-                    "match the resource's object type."
-                ),
+def _object_request_body(gramps_class_name: str) -> dict:
+    """Build the requestBody doc for a Gramps object mutation endpoint.
+
+    The payload is the object itself, so it is documented by referencing
+    the object's already-registered component schema rather than an
+    opaque `type: object`. The schema is shared with the response, so it
+    also lists the read-only fields (`backlinks`, `extended`, `profile`)
+    that the server adds on output and ignores on input.
+    """
+    return {
+        "required": True,
+        "content": {
+            "application/json": {
+                "schema": {
+                    "$ref": f"#/components/schemas/{gramps_class_name}",
+                }
             }
-        }
-    },
-}
+        },
+        "description": (
+            f"The {gramps_class_name} object to store. The `_class` field is "
+            f"optional; if present it must be `{gramps_class_name}`."
+        ),
+    }
 
 
 class GrampsObjectResource(GrampsObjectResourceHelper, Resource):
@@ -336,7 +343,7 @@ class GrampsObjectResource(GrampsObjectResourceHelper, Resource):
         cls.put = api_blueprint.doc(
             operationId=f"update_{name}",
             summary=f"Update an existing {name}",
-            requestBody=GRAMPS_OBJECT_REQUEST_BODY,
+            requestBody=_object_request_body(gramps_class_name),
         )(cls.put)
         cls.delete = api_blueprint.doc(
             operationId=f"delete_{name}", summary=f"Delete {article} {name}"
@@ -626,7 +633,7 @@ class GrampsObjectsResource(GrampsObjectResourceHelper, Resource):
         if gramps_class_name != "Media":
             # Media's POST takes a raw file upload (multipart), not a JSON
             # object, so it keeps its own request body documentation.
-            post_doc["requestBody"] = GRAMPS_OBJECT_REQUEST_BODY
+            post_doc["requestBody"] = _object_request_body(gramps_class_name)
         cls.post = api_blueprint.doc(**post_doc)(cls.post)
 
     @api_blueprint.response(200, Schema(many=True))

--- a/gramps_webapi/api/resources/base.py
+++ b/gramps_webapi/api/resources/base.py
@@ -289,6 +289,11 @@ class GrampsObjectQueryArgs(Schema):
     )
 
 
+def _indefinite_article(word: str) -> str:
+    """Return "a" or "an" depending on the word's leading sound."""
+    return "an" if word[:1].lower() in "aeiou" else "a"
+
+
 GRAMPS_OBJECT_REQUEST_BODY = {
     "required": True,
     "content": {
@@ -324,8 +329,9 @@ class GrampsObjectResource(GrampsObjectResourceHelper, Resource):
         if not gramps_class_name:
             return
         name = gramps_class_name.lower()
+        article = _indefinite_article(name)
         cls.get = api_blueprint.doc(
-            operationId=f"get_{name}", summary=f"Get a {name}"
+            operationId=f"get_{name}", summary=f"Get {article} {name}"
         )(cls.get)
         cls.put = api_blueprint.doc(
             operationId=f"update_{name}",
@@ -333,7 +339,7 @@ class GrampsObjectResource(GrampsObjectResourceHelper, Resource):
             requestBody=GRAMPS_OBJECT_REQUEST_BODY,
         )(cls.put)
         cls.delete = api_blueprint.doc(
-            operationId=f"delete_{name}", summary=f"Delete a {name}"
+            operationId=f"delete_{name}", summary=f"Delete {article} {name}"
         )(cls.delete)
 
     @api_blueprint.response(200, Schema())
@@ -615,7 +621,7 @@ class GrampsObjectsResource(GrampsObjectResourceHelper, Resource):
         )(cls.get)
         post_doc = {
             "operationId": f"create_{singular}",
-            "summary": f"Create a new {singular}",
+            "summary": f"Create {_indefinite_article(singular)} new {singular}",
         }
         if gramps_class_name != "Media":
             # Media's POST takes a raw file upload (multipart), not a JSON

--- a/gramps_webapi/api/resources/base.py
+++ b/gramps_webapi/api/resources/base.py
@@ -289,8 +289,52 @@ class GrampsObjectQueryArgs(Schema):
     )
 
 
+GRAMPS_OBJECT_REQUEST_BODY = {
+    "required": True,
+    "content": {
+        "application/json": {
+            "schema": {
+                "type": "object",
+                "additionalProperties": True,
+                "description": (
+                    "A Gramps object dict for this resource's object type. "
+                    "The `_class` field is optional; if present it must "
+                    "match the resource's object type."
+                ),
+            }
+        }
+    },
+}
+
+
 class GrampsObjectResource(GrampsObjectResourceHelper, Resource):
     """Resource for a single object."""
+
+    def __init_subclass__(cls, **kwargs) -> None:
+        """Give each object type (Person, Family, ...) its own operationId.
+
+        get/put/delete are defined once here and inherited unchanged by
+        every object type, so every generated OpenAPI operation would
+        otherwise share the same auto-derived operationId/summary (e.g.
+        "Get the object."). That breaks tools that key off operationId,
+        such as OpenAPI-to-MCP generators.
+        """
+        super().__init_subclass__(**kwargs)
+        gramps_class_name = getattr(cls, "gramps_class_name", None)
+        if not gramps_class_name:
+            return
+        name = gramps_class_name.lower()
+        cls.get = api_blueprint.doc(
+            operationId=f"get_{name}", summary=f"Get a {name}"
+        )(cls.get)
+        cls.put = api_blueprint.doc(
+            operationId=f"update_{name}",
+            summary=f"Update an existing {name}",
+            requestBody=GRAMPS_OBJECT_REQUEST_BODY,
+        )(cls.put)
+        cls.delete = api_blueprint.doc(
+            operationId=f"delete_{name}", summary=f"Delete a {name}"
+        )(cls.delete)
 
     @api_blueprint.response(200, Schema())
     @api_blueprint.arguments(GrampsObjectQueryArgs, location="query")
@@ -557,6 +601,27 @@ class GrampsObjectsQueryArgs(Schema):
 
 class GrampsObjectsResource(GrampsObjectResourceHelper, Resource):
     """Resource for multiple objects."""
+
+    def __init_subclass__(cls, **kwargs) -> None:
+        """See `GrampsObjectResource.__init_subclass__`."""
+        super().__init_subclass__(**kwargs)
+        gramps_class_name = getattr(cls, "gramps_class_name", None)
+        if not gramps_class_name:
+            return
+        plural = GRAMPS_OBJECT_PLURAL[gramps_class_name]
+        singular = gramps_class_name.lower()
+        cls.get = api_blueprint.doc(
+            operationId=f"list_{plural}", summary=f"List {plural}"
+        )(cls.get)
+        post_doc = {
+            "operationId": f"create_{singular}",
+            "summary": f"Create a new {singular}",
+        }
+        if gramps_class_name != "Media":
+            # Media's POST takes a raw file upload (multipart), not a JSON
+            # object, so it keeps its own request body documentation.
+            post_doc["requestBody"] = GRAMPS_OBJECT_REQUEST_BODY
+        cls.post = api_blueprint.doc(**post_doc)(cls.post)
 
     @api_blueprint.response(200, Schema(many=True))
     @api_blueprint.arguments(GrampsObjectsQueryArgs, location="query")

--- a/gramps_webapi/api/resources/base.py
+++ b/gramps_webapi/api/resources/base.py
@@ -504,7 +504,11 @@ class GrampsObjectsQueryArgs(Schema):
     gql = fields.Str(
         validate=validate.Length(min=1),
         metadata={
-            "description": "A Gramps QL query string used to filter the objects (e.g. 'media_list.length >= 10')."
+            "description": (
+                "A Gramps QL (GQL) query string used to filter the objects "
+                "(e.g. 'media_list.length >= 10'). Full syntax reference: "
+                "https://github.com/DavidMStraub/gramps-ql/blob/main/README.md"
+            )
         },
     )
     oql = fields.Str(

--- a/gramps_webapi/api/resources/base.py
+++ b/gramps_webapi/api/resources/base.py
@@ -19,7 +19,7 @@
 
 """Base for Gramps object API resources."""
 
-from typing import TypeVar
+from typing import Any, TypeVar
 
 import gramps_ql as gql
 import object_ql as oql
@@ -337,17 +337,31 @@ class GrampsObjectResource(GrampsObjectResourceHelper, Resource):
             return
         name = gramps_class_name.lower()
         article = _indefinite_article(name)
-        cls.get = api_blueprint.doc(
-            operationId=f"get_{name}", summary=f"Get {article} {name}"
-        )(cls.get)
-        cls.put = api_blueprint.doc(
-            operationId=f"update_{name}",
-            summary=f"Update an existing {name}",
-            requestBody=_object_request_body(gramps_class_name),
-        )(cls.put)
-        cls.delete = api_blueprint.doc(
-            operationId=f"delete_{name}", summary=f"Delete {article} {name}"
-        )(cls.delete)
+        # setattr rather than plain assignment: mypy rejects assigning to a
+        # method, and these are inherited methods being re-decorated.
+        setattr(
+            cls,
+            "get",
+            api_blueprint.doc(
+                operationId=f"get_{name}", summary=f"Get {article} {name}"
+            )(cls.get),
+        )
+        setattr(
+            cls,
+            "put",
+            api_blueprint.doc(
+                operationId=f"update_{name}",
+                summary=f"Update an existing {name}",
+                requestBody=_object_request_body(gramps_class_name),
+            )(cls.put),
+        )
+        setattr(
+            cls,
+            "delete",
+            api_blueprint.doc(
+                operationId=f"delete_{name}", summary=f"Delete {article} {name}"
+            )(cls.delete),
+        )
 
     @api_blueprint.response(200, Schema())
     @api_blueprint.arguments(GrampsObjectQueryArgs, location="query")
@@ -623,10 +637,16 @@ class GrampsObjectsResource(GrampsObjectResourceHelper, Resource):
             return
         plural = GRAMPS_OBJECT_PLURAL[gramps_class_name]
         singular = gramps_class_name.lower()
-        cls.get = api_blueprint.doc(
-            operationId=f"list_{plural}", summary=f"List {plural}"
-        )(cls.get)
-        post_doc = {
+        # setattr rather than plain assignment: mypy rejects assigning to a
+        # method, and these are inherited methods being re-decorated.
+        setattr(
+            cls,
+            "get",
+            api_blueprint.doc(
+                operationId=f"list_{plural}", summary=f"List {plural}"
+            )(cls.get),
+        )
+        post_doc: dict[str, Any] = {
             "operationId": f"create_{singular}",
             "summary": f"Create {_indefinite_article(singular)} new {singular}",
         }
@@ -634,7 +654,7 @@ class GrampsObjectsResource(GrampsObjectResourceHelper, Resource):
             # Media's POST takes a raw file upload (multipart), not a JSON
             # object, so it keeps its own request body documentation.
             post_doc["requestBody"] = _object_request_body(gramps_class_name)
-        cls.post = api_blueprint.doc(**post_doc)(cls.post)
+        setattr(cls, "post", api_blueprint.doc(**post_doc)(cls.post))
 
     @api_blueprint.response(200, Schema(many=True))
     @api_blueprint.arguments(GrampsObjectsQueryArgs, location="query")

--- a/gramps_webapi/api/resources/merge.py
+++ b/gramps_webapi/api/resources/merge.py
@@ -181,31 +181,6 @@ class _SimpleMergeResource(GrampsJSONEncoder, ProtectedResource):
     gramps_class_name: str
     _merge_query_class: Type
 
-    def __init_subclass__(cls, **kwargs) -> None:
-        """Give each object type (Event, Place, ...) its own operationId.
-
-        post is defined once here and inherited unchanged by every merge
-        resource, so every generated OpenAPI operation would otherwise
-        share the same auto-derived operationId/summary ("Merge two
-        objects..."). That breaks tools that key off operationId, such as
-        OpenAPI-to-MCP generators.
-        """
-        super().__init_subclass__(**kwargs)
-        gramps_class_name = getattr(cls, "gramps_class_name", None)
-        if not gramps_class_name:
-            return
-        name = gramps_class_name.lower()
-        # setattr rather than plain assignment: mypy rejects assigning to a
-        # method, and this is an inherited method being re-decorated.
-        setattr(
-            cls,
-            "post",
-            api_blueprint.doc(
-                operationId=f"merge_{name}",
-                summary=f"Merge two {name} objects; phoenix survives, titanic is deleted",
-            )(cls.post),
-        )
-
     @api_blueprint.response(200, Schema())
     def post(self, phoenix_handle: str, titanic_handle: str) -> ResponseReturnValue:
         """Merge two objects. Phoenix survives; titanic is deleted."""

--- a/gramps_webapi/api/resources/merge.py
+++ b/gramps_webapi/api/resources/merge.py
@@ -181,6 +181,31 @@ class _SimpleMergeResource(GrampsJSONEncoder, ProtectedResource):
     gramps_class_name: str
     _merge_query_class: Type
 
+    def __init_subclass__(cls, **kwargs) -> None:
+        """Give each object type (Event, Place, ...) its own operationId.
+
+        post is defined once here and inherited unchanged by every merge
+        resource, so every generated OpenAPI operation would otherwise
+        share the same auto-derived operationId/summary ("Merge two
+        objects..."). That breaks tools that key off operationId, such as
+        OpenAPI-to-MCP generators.
+        """
+        super().__init_subclass__(**kwargs)
+        gramps_class_name = getattr(cls, "gramps_class_name", None)
+        if not gramps_class_name:
+            return
+        name = gramps_class_name.lower()
+        # setattr rather than plain assignment: mypy rejects assigning to a
+        # method, and this is an inherited method being re-decorated.
+        setattr(
+            cls,
+            "post",
+            api_blueprint.doc(
+                operationId=f"merge_{name}",
+                summary=f"Merge two {name} objects; phoenix survives, titanic is deleted",
+            )(cls.post),
+        )
+
     @api_blueprint.response(200, Schema())
     def post(self, phoenix_handle: str, titanic_handle: str) -> ResponseReturnValue:
         """Merge two objects. Phoenix survives; titanic is deleted."""

--- a/gramps_webapi/api/resources/schemas.py
+++ b/gramps_webapi/api/resources/schemas.py
@@ -744,6 +744,7 @@ class NoteSchema(_Base):
     backlinks = fields.Nested(
         BacklinksSchema,
         metadata={"description": "Objects referring to this note, grouped by type."},
+        dump_only=True,
     )
     change = fields.Float(
         metadata={"description": "Unix timestamp of the last modification."},
@@ -752,6 +753,7 @@ class NoteSchema(_Base):
         metadata={
             "description": "Optional extended section with full referenced records."
         },
+        dump_only=True,
     )
     format = fields.Int(
         metadata={"description": "Format identifier (0=plain text, 1=pre-formatted)."},
@@ -792,6 +794,7 @@ class MediaSchema(_Base):
         metadata={
             "description": "Objects referring to this media item, grouped by type."
         },
+        dump_only=True,
     )
     change = fields.Float(
         metadata={"description": "Unix timestamp of the last modification."},
@@ -814,6 +817,7 @@ class MediaSchema(_Base):
         metadata={
             "description": "Optional extended section with full referenced records."
         },
+        dump_only=True,
     )
     gramps_id = fields.Str(
         metadata={"description": "Alternate user-managed identifier."},
@@ -837,6 +841,7 @@ class MediaSchema(_Base):
     profile = fields.Nested(
         MediaProfileSchema,
         metadata={"description": "Optional summary of media information."},
+        dump_only=True,
     )
     tag_list = fields.List(
         fields.Str(),
@@ -860,6 +865,7 @@ class RepositorySchema(_Base):
         metadata={
             "description": "Objects referring to this repository, grouped by type."
         },
+        dump_only=True,
     )
     change = fields.Float(
         metadata={"description": "Unix timestamp of the last modification."},
@@ -868,6 +874,7 @@ class RepositorySchema(_Base):
         metadata={
             "description": "Optional extended section with full referenced records."
         },
+        dump_only=True,
     )
     gramps_id = fields.Str(
         metadata={"description": "Alternate user-managed identifier."},
@@ -918,6 +925,7 @@ class SourceSchema(_Base):
     backlinks = fields.Nested(
         BacklinksSchema,
         metadata={"description": "Objects referring to this source, grouped by type."},
+        dump_only=True,
     )
     change = fields.Float(
         metadata={"description": "Unix timestamp of the last modification."},
@@ -926,6 +934,7 @@ class SourceSchema(_Base):
         metadata={
             "description": "Optional extended section with full referenced records."
         },
+        dump_only=True,
     )
     gramps_id = fields.Str(
         metadata={"description": "Alternate user-managed identifier."},
@@ -945,6 +954,7 @@ class SourceSchema(_Base):
     profile = fields.Nested(
         SourceProfileSchema,
         metadata={"description": "Optional summary of source information."},
+        dump_only=True,
     )
     pubinfo = fields.Str(
         metadata={"description": "Publication information."},
@@ -978,6 +988,7 @@ class CitationSchema(_Base):
         metadata={
             "description": "Objects referring to this citation, grouped by type."
         },
+        dump_only=True,
     )
     change = fields.Float(
         metadata={"description": "Unix timestamp of the last modification."},
@@ -993,6 +1004,7 @@ class CitationSchema(_Base):
         metadata={
             "description": "Optional extended section with full referenced records."
         },
+        dump_only=True,
     )
     gramps_id = fields.Str(
         metadata={"description": "Alternate user-managed identifier."},
@@ -1015,6 +1027,7 @@ class CitationSchema(_Base):
     profile = fields.Nested(
         CitationProfileSchema,
         metadata={"description": "Optional summary of citation information."},
+        dump_only=True,
     )
     source_handle = fields.Str(
         metadata={"description": "Handle of the source being cited."},
@@ -1043,6 +1056,7 @@ class PlaceSchema(_Base):
     backlinks = fields.Nested(
         BacklinksSchema,
         metadata={"description": "Objects referring to this place, grouped by type."},
+        dump_only=True,
     )
     change = fields.Float(
         metadata={"description": "Unix timestamp of the last modification."},
@@ -1058,6 +1072,7 @@ class PlaceSchema(_Base):
         metadata={
             "description": "Optional extended section with full referenced records."
         },
+        dump_only=True,
     )
     gramps_id = fields.Str(
         metadata={"description": "Alternate user-managed identifier."},
@@ -1094,6 +1109,7 @@ class PlaceSchema(_Base):
     profile = fields.Nested(
         PlaceProfileSchema,
         metadata={"description": "Optional summary of place information."},
+        dump_only=True,
     )
     tag_list = fields.List(
         fields.Str(),
@@ -1122,6 +1138,7 @@ class EventSchema(_Base):
     backlinks = fields.Nested(
         BacklinksSchema,
         metadata={"description": "Objects referring to this event, grouped by type."},
+        dump_only=True,
     )
     change = fields.Float(
         metadata={"description": "Unix timestamp of the last modification."},
@@ -1141,6 +1158,7 @@ class EventSchema(_Base):
         metadata={
             "description": "Optional extended section with full referenced records."
         },
+        dump_only=True,
     )
     gramps_id = fields.Str(
         metadata={"description": "Alternate user-managed identifier."},
@@ -1163,6 +1181,7 @@ class EventSchema(_Base):
     profile = fields.Nested(
         EventProfileSchema,
         metadata={"description": "Optional summary of event information."},
+        dump_only=True,
     )
     tag_list = fields.List(
         fields.Str(),
@@ -1187,6 +1206,7 @@ class FamilySchema(_Base):
     backlinks = fields.Nested(
         BacklinksSchema,
         metadata={"description": "Objects referring to this family, grouped by type."},
+        dump_only=True,
     )
     change = fields.Float(
         metadata={"description": "Unix timestamp of the last modification."},
@@ -1207,6 +1227,7 @@ class FamilySchema(_Base):
         metadata={
             "description": "Optional extended section with full referenced records."
         },
+        dump_only=True,
     )
     father_handle = fields.Str(
         metadata={"description": "Handle of the father."},
@@ -1236,6 +1257,7 @@ class FamilySchema(_Base):
     profile = fields.Nested(
         FamilyProfileSchema,
         metadata={"description": "Optional summary of family information."},
+        dump_only=True,
     )
     tag_list = fields.List(
         fields.Str(),
@@ -1270,6 +1292,7 @@ class PersonSchema(_Base):
     backlinks = fields.Nested(
         BacklinksSchema,
         metadata={"description": "Objects referring to this person, grouped by type."},
+        dump_only=True,
     )
     birth_ref_index = fields.Int(
         metadata={
@@ -1296,6 +1319,7 @@ class PersonSchema(_Base):
         metadata={
             "description": "Optional extended section with full referenced records."
         },
+        dump_only=True,
     )
     family_list = fields.List(
         fields.Str(),
@@ -1340,6 +1364,7 @@ class PersonSchema(_Base):
     profile = fields.Nested(
         PersonProfileSchema,
         metadata={"description": "Optional summary of key biographical information."},
+        dump_only=True,
     )
     tag_list = fields.List(
         fields.Str(),

--- a/gramps_webapi/app.py
+++ b/gramps_webapi/app.py
@@ -42,6 +42,7 @@ from .api.resources.schemas import (
     FamilySchema,
     MediaSchema,
     NoteSchema,
+    PersonSchema,
     PlaceSchema,
     RepositorySchema,
     SourceSchema,
@@ -307,12 +308,16 @@ def create_app(config: Optional[Dict[str, Any]] = None, config_from_env: bool = 
         ("Family", FamilySchema),
         ("Media", MediaSchema),
         ("Note", NoteSchema),
+        ("Person", PersonSchema),
         ("Place", PlaceSchema),
         ("Repository", RepositorySchema),
         ("Source", SourceSchema),
         ("Tag", TagSchema),
     ]:
-        api.spec.components.schema(_schema_name, schema=_schema_cls())
+        # Some of these (e.g. Person, via LivingDates) are already registered
+        # transitively as nested schemas while registering the blueprint.
+        if _schema_name not in api.spec.components.schemas:
+            api.spec.components.schema(_schema_name, schema=_schema_cls())
 
     limiter.init_app(app)
 

--- a/gramps_webapi/app.py
+++ b/gramps_webapi/app.py
@@ -36,6 +36,8 @@ from gramps.gen.errors import HandleError
 from PIL import Image
 
 from .api import api_blueprint
+from .api.cache import persistent_cache, request_cache, thumbnail_cache
+from .api.ratelimiter import limiter
 from .api.resources.schemas import (
     CitationSchema,
     EventSchema,
@@ -48,8 +50,6 @@ from .api.resources.schemas import (
     SourceSchema,
     TagSchema,
 )
-from .api.cache import persistent_cache, request_cache, thumbnail_cache
-from .api.ratelimiter import limiter
 from .api.search.embeddings import create_remote_embedding_function, load_model
 from .api.tasks import run_task, send_telemetry_task
 from .api.telemetry import get_server_uuid, should_send_telemetry

--- a/gramps_webapi/app.py
+++ b/gramps_webapi/app.py
@@ -36,6 +36,18 @@ from gramps.gen.errors import HandleError
 from PIL import Image
 
 from .api import api_blueprint
+from .api.resources.schemas import (
+    CitationSchema,
+    EventSchema,
+    FamilySchema,
+    MediaSchema,
+    NoteSchema,
+    PersonSchema,
+    PlaceSchema,
+    RepositorySchema,
+    SourceSchema,
+    TagSchema,
+)
 from .api.cache import persistent_cache, request_cache, thumbnail_cache
 from .api.ratelimiter import limiter
 from .api.search.embeddings import create_remote_embedding_function, load_model
@@ -286,6 +298,26 @@ def create_app(config: Optional[Dict[str, Any]] = None, config_from_env: bool = 
         },
     )
     api.register_blueprint(api_blueprint)
+
+    # Explicitly register core Gramps object schemas so they appear in the
+    # generated OpenAPI spec even though the base-class GET methods use the
+    # generic Schema() response decorator. Verified against the real app:
+    # only Person ends up in components.schemas without this (pulled in
+    # transitively via LivingDates); the other 9 need it registered here.
+    for _schema_name, _schema_cls in [
+        ("Citation", CitationSchema),
+        ("Event", EventSchema),
+        ("Family", FamilySchema),
+        ("Media", MediaSchema),
+        ("Note", NoteSchema),
+        ("Person", PersonSchema),
+        ("Place", PlaceSchema),
+        ("Repository", RepositorySchema),
+        ("Source", SourceSchema),
+        ("Tag", TagSchema),
+    ]:
+        if _schema_name not in api.spec.components.schemas:
+            api.spec.components.schema(_schema_name, schema=_schema_cls())
 
     limiter.init_app(app)
 

--- a/gramps_webapi/app.py
+++ b/gramps_webapi/app.py
@@ -36,18 +36,6 @@ from gramps.gen.errors import HandleError
 from PIL import Image
 
 from .api import api_blueprint
-from .api.resources.schemas import (
-    CitationSchema,
-    EventSchema,
-    FamilySchema,
-    MediaSchema,
-    NoteSchema,
-    PersonSchema,
-    PlaceSchema,
-    RepositorySchema,
-    SourceSchema,
-    TagSchema,
-)
 from .api.cache import persistent_cache, request_cache, thumbnail_cache
 from .api.ratelimiter import limiter
 from .api.search.embeddings import create_remote_embedding_function, load_model
@@ -298,26 +286,6 @@ def create_app(config: Optional[Dict[str, Any]] = None, config_from_env: bool = 
         },
     )
     api.register_blueprint(api_blueprint)
-
-    # Explicitly register core Gramps object schemas so they appear in the
-    # generated OpenAPI spec even though the base-class GET methods use the
-    # generic Schema() response decorator.
-    for _schema_name, _schema_cls in [
-        ("Citation", CitationSchema),
-        ("Event", EventSchema),
-        ("Family", FamilySchema),
-        ("Media", MediaSchema),
-        ("Note", NoteSchema),
-        ("Person", PersonSchema),
-        ("Place", PlaceSchema),
-        ("Repository", RepositorySchema),
-        ("Source", SourceSchema),
-        ("Tag", TagSchema),
-    ]:
-        # Some of these (e.g. Person, via LivingDates) are already registered
-        # transitively as nested schemas while registering the blueprint.
-        if _schema_name not in api.spec.components.schemas:
-            api.spec.components.schema(_schema_name, schema=_schema_cls())
 
     limiter.init_app(app)
 

--- a/tests/test_openapi_operation_ids.py
+++ b/tests/test_openapi_operation_ids.py
@@ -91,9 +91,8 @@ class TestOpenapiOperationIds(unittest.TestCase):
         for gramps_class_name, plural in GRAMPS_OBJECT_PLURAL.items():
             with self.subTest(gramps_class_name=gramps_class_name):
                 post_op = self._operation(f"/api/{plural}/", "post")
-                if gramps_class_name == "Media":
+                if gramps_class_name != "Media":
                     # Media upload takes a raw file, not a JSON object.
-                    continue
-                self.assertIn("requestBody", post_op)
+                    self.assertIn("requestBody", post_op)
                 put_op = self._operation(f"/api/{plural}/{{handle}}", "put")
                 self.assertIn("requestBody", put_op)

--- a/tests/test_openapi_operation_ids.py
+++ b/tests/test_openapi_operation_ids.py
@@ -1,0 +1,99 @@
+#
+# Gramps Web API - A RESTful API for the Gramps genealogy program
+#
+# Copyright (C) 2026      Jerome Viveret
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+#
+
+"""Test that the generic object CRUD endpoints have distinct OpenAPI operationIds.
+
+The generic get/post/put/delete methods for Person, Family, Event, ... are
+defined once in `GrampsObjectResource`/`GrampsObjectsResource` and inherited
+unchanged by every object type. Without per-type operationIds, tools that
+generate clients (or MCP servers) from the OpenAPI spec cannot tell the
+generated operations apart.
+"""
+
+import unittest
+
+from gramps_webapi.app import create_app
+from gramps_webapi.const import GRAMPS_OBJECT_PLURAL
+
+
+class TestOpenapiOperationIds(unittest.TestCase):
+    """Test operationId/requestBody documentation for the object CRUD endpoints."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Set up a minimal app and fetch the live OpenAPI spec."""
+        app = create_app(
+            {"TREE": "test", "SECRET_KEY": "test", "USER_DB_URI": "sqlite://"},
+            config_from_env=False,
+        )
+        with app.test_client() as client:
+            response = client.get("/api/openapi.json")
+            assert (
+                response.status_code == 200
+            ), f"Failed to fetch OpenAPI spec: {response.status_code}"
+            cls.spec = response.get_json()
+            assert cls.spec is not None, "OpenAPI spec returned non-JSON response"
+
+    def _operation(self, path, method):
+        methods = self.spec["paths"][path]
+        return methods[method]
+
+    def test_operation_ids_are_unique_per_object_type(self):
+        """Every object type's CRUD operations get a distinct operationId."""
+        operation_ids = []
+        for gramps_class_name, plural in GRAMPS_OBJECT_PLURAL.items():
+            operation_ids.append(
+                self._operation(f"/api/{plural}/", "get").get("operationId")
+            )
+            operation_ids.append(
+                self._operation(f"/api/{plural}/", "post").get("operationId")
+            )
+            operation_ids.append(
+                self._operation(f"/api/{plural}/{{handle}}", "get").get(
+                    "operationId"
+                )
+            )
+            operation_ids.append(
+                self._operation(f"/api/{plural}/{{handle}}", "put").get(
+                    "operationId"
+                )
+            )
+            operation_ids.append(
+                self._operation(f"/api/{plural}/{{handle}}", "delete").get(
+                    "operationId"
+                )
+            )
+        self.assertTrue(all(operation_ids), "Every CRUD operation needs an operationId")
+        self.assertEqual(
+            len(operation_ids),
+            len(set(operation_ids)),
+            "operationIds must be unique across object types",
+        )
+
+    def test_mutation_endpoints_document_a_request_body(self):
+        """POST/PUT on object endpoints advertise the expected JSON payload."""
+        for gramps_class_name, plural in GRAMPS_OBJECT_PLURAL.items():
+            with self.subTest(gramps_class_name=gramps_class_name):
+                post_op = self._operation(f"/api/{plural}/", "post")
+                if gramps_class_name == "Media":
+                    # Media upload takes a raw file, not a JSON object.
+                    continue
+                self.assertIn("requestBody", post_op)
+                put_op = self._operation(f"/api/{plural}/{{handle}}", "put")
+                self.assertIn("requestBody", put_op)

--- a/tests/test_openapi_operation_ids.py
+++ b/tests/test_openapi_operation_ids.py
@@ -17,23 +17,38 @@
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 #
 
-"""Test that the generic object CRUD endpoints have distinct OpenAPI operationIds.
+"""Test that `register_endpt()` gives every OpenAPI operation a distinct id.
 
-The generic get/post/put/delete methods for Person, Family, Event, ... are
-defined once in `GrampsObjectResource`/`GrampsObjectsResource` and inherited
-unchanged by every object type. Without per-type operationIds, tools that
-generate clients (or MCP servers) from the OpenAPI spec cannot tell the
-generated operations apart.
+`register_endpt()` derives an operationId of `{verb}_{name}` from the
+endpoint `name` every call site already passes, instead of each resource
+having to derive one for itself. Without a distinct operationId, tools that
+generate clients (or MCP servers) from the OpenAPI spec cannot tell
+operations apart.
 """
 
 import unittest
 
 from gramps_webapi.app import create_app
-from gramps_webapi.const import GRAMPS_OBJECT_PLURAL
+
+# gramps_class_name -> (url path segment, singular route name, plural route name)
+# The route names mirror the `name` argument passed to register_endpt() in
+# gramps_webapi/api/__init__.py for that type's endpoints.
+OBJECT_ROUTES = {
+    "Person": ("people", "person", "people"),
+    "Family": ("families", "family", "families"),
+    "Event": ("events", "event", "events"),
+    "Place": ("places", "place", "places"),
+    "Citation": ("citations", "citation", "citations"),
+    "Source": ("sources", "source", "sources"),
+    "Repository": ("repositories", "repository", "repositories"),
+    "Media": ("media", "media_object", "media_objects"),
+    "Note": ("notes", "note", "notes"),
+    "Tag": ("tags", "tag", "tags"),
+}
 
 
 class TestOpenapiOperationIds(unittest.TestCase):
-    """Test operationId/requestBody documentation for the object CRUD endpoints."""
+    """Test operationId/requestBody documentation across the OpenAPI spec."""
 
     @classmethod
     def setUpClass(cls):
@@ -44,55 +59,84 @@ class TestOpenapiOperationIds(unittest.TestCase):
         )
         with app.test_client() as client:
             response = client.get("/api/openapi.json")
-            assert (
-                response.status_code == 200
-            ), f"Failed to fetch OpenAPI spec: {response.status_code}"
+            if response.status_code != 200:
+                raise AssertionError(
+                    f"Failed to fetch OpenAPI spec: {response.status_code}"
+                )
             cls.spec = response.get_json()
-            assert cls.spec is not None, "OpenAPI spec returned non-JSON response"
+            if cls.spec is None:
+                raise AssertionError("OpenAPI spec returned non-JSON response")
 
     def _operation(self, path, method):
         methods = self.spec["paths"][path]
         return methods[method]
 
-    def test_operation_ids_are_unique_per_object_type(self):
-        """Every object type's CRUD operations get a distinct operationId."""
-        operation_ids = []
-        for gramps_class_name, plural in GRAMPS_OBJECT_PLURAL.items():
-            operation_ids.append(
-                self._operation(f"/api/{plural}/", "get").get("operationId")
-            )
-            operation_ids.append(
-                self._operation(f"/api/{plural}/", "post").get("operationId")
-            )
-            operation_ids.append(
-                self._operation(f"/api/{plural}/{{handle}}", "get").get(
-                    "operationId"
-                )
-            )
-            operation_ids.append(
-                self._operation(f"/api/{plural}/{{handle}}", "put").get(
-                    "operationId"
-                )
-            )
-            operation_ids.append(
-                self._operation(f"/api/{plural}/{{handle}}", "delete").get(
-                    "operationId"
-                )
-            )
-        self.assertTrue(all(operation_ids), "Every CRUD operation needs an operationId")
+    def test_every_operation_has_a_unique_operation_id(self):
+        """Every operation in the spec has a non-null, unique operationId."""
+        operation_ids = [
+            operation.get("operationId")
+            for methods in self.spec["paths"].values()
+            for method, operation in methods.items()
+            if method in ("get", "post", "put", "delete", "patch")
+        ]
+        self.assertTrue(all(operation_ids), "Every operation needs an operationId")
         self.assertEqual(
             len(operation_ids),
             len(set(operation_ids)),
-            "operationIds must be unique across object types",
+            "operationIds must be unique across the whole spec",
         )
+
+    def test_object_crud_operation_ids_match_expected_names(self):
+        """Object CRUD operationIds follow the `{verb}_{route_name}` scheme."""
+        for gramps_class_name, (url_segment, singular, plural) in OBJECT_ROUTES.items():
+            with self.subTest(gramps_class_name=gramps_class_name):
+                self.assertEqual(
+                    self._operation(f"/api/{url_segment}/{{handle}}", "get").get(
+                        "operationId"
+                    ),
+                    f"get_{singular}",
+                )
+                self.assertEqual(
+                    self._operation(f"/api/{url_segment}/{{handle}}", "put").get(
+                        "operationId"
+                    ),
+                    f"put_{singular}",
+                )
+                self.assertEqual(
+                    self._operation(f"/api/{url_segment}/{{handle}}", "delete").get(
+                        "operationId"
+                    ),
+                    f"delete_{singular}",
+                )
+                self.assertEqual(
+                    self._operation(f"/api/{url_segment}/", "get").get("operationId"),
+                    f"get_{plural}",
+                )
+                self.assertEqual(
+                    self._operation(f"/api/{url_segment}/", "post").get("operationId"),
+                    f"post_{plural}",
+                )
 
     def test_mutation_endpoints_document_a_request_body(self):
         """POST/PUT on object endpoints advertise the expected JSON payload."""
-        for gramps_class_name, plural in GRAMPS_OBJECT_PLURAL.items():
+        for gramps_class_name, (url_segment, _, _) in OBJECT_ROUTES.items():
             with self.subTest(gramps_class_name=gramps_class_name):
-                post_op = self._operation(f"/api/{plural}/", "post")
+                expected_ref = f"#/components/schemas/{gramps_class_name}"
+                post_op = self._operation(f"/api/{url_segment}/", "post")
                 if gramps_class_name != "Media":
                     # Media upload takes a raw file, not a JSON object.
-                    self.assertIn("requestBody", post_op)
-                put_op = self._operation(f"/api/{plural}/{{handle}}", "put")
-                self.assertIn("requestBody", put_op)
+                    self.assertEqual(
+                        post_op["requestBody"]["content"]["application/json"]["schema"][
+                            "$ref"
+                        ],
+                        expected_ref,
+                    )
+                else:
+                    self.assertNotIn("requestBody", post_op)
+                put_op = self._operation(f"/api/{url_segment}/{{handle}}", "put")
+                self.assertEqual(
+                    put_op["requestBody"]["content"]["application/json"]["schema"][
+                        "$ref"
+                    ],
+                    expected_ref,
+                )


### PR DESCRIPTION
## Summary
Follow-up to #943. The generic get/post/put/delete methods for Person, Family, Event, ... are defined once in `GrampsObjectResource`/`GrampsObjectsResource`/`_SimpleMergeResource` and inherited unchanged by every object type, so the generated OpenAPI spec has no `operationId`, duplicated `summary` text across types, and no `requestBody` on the mutating endpoints - making it hard to generate a client, or an MCP server, from `openapi.json`.

## What changed
This went through a review round; the current approach is smaller and different from the first attempt.

- `register_endpt()` (`gramps_webapi/api/__init__.py`) now derives `operationId = f"{verb}_{name}"` for every HTTP method of every resource it registers, from the `name` each call site already passes - one place covering all 193 operations, instead of three near-identical `__init_subclass__` hooks scattered across `base.py`/`merge.py`. E.g. `GET /api/people/{handle}` -> `get_person`, `POST /api/people/` -> `post_people`, `POST /api/events/{phoenix}/merge/{titanic}` -> `post_merge-event`.
- `merge.py` is untouched by this PR: `MergePersonResource`/`MergeFamilyResource`/`_SimpleMergeResource`'s 7 subclasses all get a correct, distinct operationId for free just by going through `register_endpt()` like every other resource.
- The 19 create/update call sites for a typed object (10 PUT + 9 POST, excluding Media's raw-upload POST) also pass `request_body=object_request_body(...)`, documenting the payload via the object's component schema (`#/components/schemas/Person`, ...) instead of an opaque `type: object`.
- The 4 media routes that serve tiles/thumbnails/crops (plain `@api_blueprint.route` views, never covered by `register_endpt()`) get an explicit operationId too, closing the gap to a full 193/193.
- `backlinks`/`extended`/`profile` are `dump_only` (renders as `readOnly` in the spec) since they're server-added, response-only fields sharing a schema with the new request bodies.
- The `gql` filter's description links to the [gramps-ql README](https://github.com/DavidMStraub/gramps-ql/blob/main/README.md) for its query syntax.

No request-handling behaviour changes - this only adds OpenAPI metadata via `flask_smorest.Blueprint.doc()`.

## Diff size vs. the first attempt
| File | Then | Now |
|---|---|---|
| `merge.py` | +25 (its own `__init_subclass__` hook) | unchanged |
| `base.py` | +99/-1 (two `__init_subclass__` hooks, `_indefinite_article`) | +30/-1 (one small helper, no hooks) |
| `api/__init__.py` | untouched | +155/-21 (`register_endpt` + 19 explicit call sites + 4 media routes) |

## Verified against the real app
Set up a full local venv (`gramps`, `sentence-transformers`, `pydantic-ai` - the `[ai]`/`[all]` extras) rather than relying on inspection:
- mypy and black both clean
- hit `/api/openapi.json` directly: all 193 operations have a non-null, unique `operationId`; the 19 typed request bodies resolve to the expected `$ref`; all 10 object component schemas are present in `components.schemas`

That last check caught a regression along the way: I first removed the `app.py` schema-registration loop as a no-op, based on a local diff of two spec snapshots that (I didn't realize) had both been generated with the loop still active - so of course they matched. CI's `check_conforms_to_openapi_schema` failed with `KeyError: 'Citation'`, real signal that only `Person` is pulled into `components.schemas` on its own (via `LivingDates`, as the original comment on that loop said) - the other 9 types need it registered explicitly. Restored the loop and re-verified directly against the running app before pushing again.

## Test plan
- [x] `tests/test_openapi_operation_ids.py` rewritten: checks the whole spec (not just the 10 object types) for a unique operationId on every operation, asserts the exact expected operationId per verb/type instead of just uniqueness, and checks the requestBody's actual `$ref` instead of just presence
- [x] `tests/test_version.py` still passes
- [x] CI green: mypy + pytest on Python 3.10 and 3.14, plus `test-base-image` against `ghcr.io/gramps-project/grampsweb:latest`
