### PR TITLE
Add formatted address dates to the person profile

### DIFF
--- a/gramps_webapi/api/resources/repositories.py
+++ b/gramps_webapi/api/resources/repositories.py
@@ -20,11 +20,18 @@
 
 """Repository API resource."""
 
+from typing import Dict
+
+from gramps.gen.const import GRAMPS_LOCALE as glocale
+from gramps.gen.lib import Repository
+from gramps.gen.utils.grampslocale import GrampsLocale
+
 from .base import (
     GrampsObjectProtectedResource,
     GrampsObjectResourceHelper,
     GrampsObjectsProtectedResource,
 )
+from .util import get_repository_profile_for_object
 
 
 
@@ -32,6 +39,16 @@ class RepositoryResourceHelper(GrampsObjectResourceHelper):
     """Repository resource helper."""
 
     gramps_class_name = "Repository"
+
+    def object_extend(
+        self, obj: Repository, args: Dict, locale: GrampsLocale = glocale
+    ) -> Repository:
+        """Extend repository attributes as needed."""
+        if "profile" in args:
+            obj.profile = get_repository_profile_for_object(
+                self.db_handle, obj, args["profile"], locale=locale
+            )
+        return super().object_extend(obj, args, locale=locale)
 
 
 class RepositoryResource(GrampsObjectProtectedResource, RepositoryResourceHelper):

--- a/gramps_webapi/api/resources/schemas.py
+++ b/gramps_webapi/api/resources/schemas.py
@@ -316,6 +316,14 @@ class NameSchema(_Base):
 # ===========================================================================
 
 
+class AddressProfileSchema(_Base):
+    """A summary of an address, used within profile responses."""
+
+    date_str = fields.Str(
+        metadata={"description": "Date of the address as a formatted string."},
+    )
+
+
 class EventProfileSchema(_Base):
     """A summary of a Gramps event, used within profile responses."""
 
@@ -351,7 +359,7 @@ class PersonProfileSchema(_Base):
     """A summary of a person's key biographical information."""
 
     addresses = fields.List(
-        fields.Raw(),
+        fields.Nested(AddressProfileSchema),
         metadata={
             "description": "Addresses with formatted dates, parallel to address_list."
         },
@@ -551,7 +559,7 @@ class RepositoryProfileSchema(_Base):
     """A summary of a repository record."""
 
     addresses = fields.List(
-        fields.Raw(),
+        fields.Nested(AddressProfileSchema),
         metadata={
             "description": "Addresses with formatted dates, parallel to address_list."
         },

--- a/gramps_webapi/api/resources/schemas.py
+++ b/gramps_webapi/api/resources/schemas.py
@@ -350,6 +350,12 @@ class EventProfileSchema(_Base):
 class PersonProfileSchema(_Base):
     """A summary of a person's key biographical information."""
 
+    addresses = fields.List(
+        fields.Raw(),
+        metadata={
+            "description": "Addresses with formatted dates, parallel to address_list."
+        },
+    )
     birth = fields.Nested(
         EventProfileSchema,
         metadata={"description": "Birth event profile (or best available fallback)."},

--- a/gramps_webapi/api/resources/schemas.py
+++ b/gramps_webapi/api/resources/schemas.py
@@ -547,6 +547,34 @@ class MediaProfileSchema(_Base):
     )
 
 
+class RepositoryProfileSchema(_Base):
+    """A summary of a repository record."""
+
+    addresses = fields.List(
+        fields.Raw(),
+        metadata={
+            "description": "Addresses with formatted dates, parallel to address_list."
+        },
+    )
+    gramps_id = fields.Str(
+        metadata={
+            "description": "Alternate user-managed identifier for the repository."
+        },
+    )
+    handle = fields.Str(
+        metadata={"description": "Unique handle for the repository."},
+    )
+    name = fields.Str(
+        metadata={"description": "Name of the repository."},
+    )
+    references = fields.Dict(
+        metadata={"description": "References to this repository from other objects."},
+    )
+    type = fields.Str(
+        metadata={"description": "Localized type of repository."},
+    )
+
+
 # ===========================================================================
 # 4. Reference schemas
 # ===========================================================================
@@ -891,6 +919,10 @@ class RepositorySchema(_Base):
         },
     )
     private = fields.Bool(metadata={"description": "Private object indicator."})
+    profile = fields.Nested(
+        RepositoryProfileSchema,
+        metadata={"description": "Optional summary of repository information."},
+    )
     tag_list = fields.List(
         fields.Str(),
         metadata={"description": "Handles of tags attached to this repository."},

--- a/gramps_webapi/api/resources/search.py
+++ b/gramps_webapi/api/resources/search.py
@@ -68,6 +68,7 @@ from .util import (
     get_media_profile_for_object,
     get_person_profile_for_object,
     get_place_profile_for_object,
+    get_repository_profile_for_object,
 )
 
 
@@ -204,6 +205,10 @@ class SearchResource(GrampsJSONEncoder, ProtectedResource):
                 )
             elif class_name == "media":
                 obj.profile = get_media_profile_for_object(
+                    self.db_handle, obj, args["profile"], locale=locale
+                )
+            elif class_name == "repository":
+                obj.profile = get_repository_profile_for_object(
                     self.db_handle, obj, args["profile"], locale=locale
                 )
 

--- a/gramps_webapi/api/resources/util.py
+++ b/gramps_webapi/api/resources/util.py
@@ -54,6 +54,7 @@ from gramps.gen.lib import (
     Person,
     Place,
     PlaceType,
+    Repository,
     Source,
     Span,
 )
@@ -969,6 +970,25 @@ def get_media_profile_for_handle(
     except HandleError:
         return {}
     return get_media_profile_for_object(db_handle, obj, args, locale=locale)
+
+
+def get_repository_profile_for_object(
+    db_handle: DbReadBase,
+    repository: Repository,
+    args: list,
+    locale: GrampsLocale = glocale,
+) -> dict[str, Any]:
+    """Get repository profile given a Repository."""
+    return {
+        "handle": repository.handle,
+        "gramps_id": repository.gramps_id,
+        "name": repository.name,
+        "type": locale.translation.sgettext(repository.type.xml_str()),
+        "addresses": [
+            {"date_str": locale.date_displayer.display(address.date)}
+            for address in repository.address_list
+        ],
+    }
 
 
 def catch_handle_error(method, handle):

--- a/gramps_webapi/api/resources/util.py
+++ b/gramps_webapi/api/resources/util.py
@@ -709,6 +709,10 @@ def get_person_profile_for_object(
             else name_displayer.display(person)
         ),
         "name_suffix": person.primary_name.get_suffix(),
+        "addresses": [
+            {"date_str": locale.date_displayer.display(address.date)}
+            for address in person.address_list
+        ],
     }
     if "all" in args or "span" in args:
         options.append("span")

--- a/tests/test_endpoints/test_events.py
+++ b/tests/test_endpoints/test_events.py
@@ -387,6 +387,7 @@ class TestEvents(unittest.TestCase):
                     "people": [
                         {
                             "person": {
+                                "addresses": [],
                                 "birth": {
                                     "date": "1987-08-29",
                                     "place": "Gainesville, Llano, TX, USA",
@@ -410,6 +411,7 @@ class TestEvents(unittest.TestCase):
                 "references": {
                     "person": [
                         {
+                            "addresses": [],
                             "birth": {
                                 "date": "1987-08-29",
                                 "place": "Gainesville, Llano, TX, USA",
@@ -674,6 +676,7 @@ class TestEventsHandle(unittest.TestCase):
                     "people": [
                         {
                             "person": {
+                                "addresses": [],
                                 "birth": {
                                     "date": "1250",
                                     "place": "Atchison, Atchison, KS, USA",
@@ -703,6 +706,7 @@ class TestEventsHandle(unittest.TestCase):
                 "references": {
                     "person": [
                         {
+                            "addresses": [],
                             "birth": {
                                 "date": "1250",
                                 "place": "Atchison, Atchison, KS, USA",
@@ -748,6 +752,7 @@ class TestEventsHandle(unittest.TestCase):
                     "people": [
                         {
                             "person": {
+                                "addresses": [],
                                 "birth": {
                                     "date": "1250",
                                     "place": "Atchison, Atchison, KS, USA",
@@ -777,6 +782,7 @@ class TestEventsHandle(unittest.TestCase):
                 "references": {
                     "person": [
                         {
+                            "addresses": [],
                             "birth": {
                                 "date": "1250",
                                 "place": "Atchison, Atchison, KS, USA",
@@ -825,6 +831,7 @@ class TestEventsHandle(unittest.TestCase):
                     "people": [
                         {
                             "person": {
+                                "addresses": [],
                                 "birth": {
                                     "date": "1250",
                                     "place": "Atchison, Atchison, KS, USA",
@@ -854,6 +861,7 @@ class TestEventsHandle(unittest.TestCase):
                 "references": {
                     "person": [
                         {
+                            "addresses": [],
                             "birth": {
                                 "date": "1250",
                                 "place": "Atchison, Atchison, KS, USA",

--- a/tests/test_endpoints/test_families.py
+++ b/tests/test_endpoints/test_families.py
@@ -417,6 +417,7 @@ class TestFamilies(unittest.TestCase):
             {
                 "children": [
                     {
+                        "addresses": [],
                         "birth": {
                             "age": "0 days",
                             "citations": 0,
@@ -441,6 +442,7 @@ class TestFamilies(unittest.TestCase):
                 "events": [],
                 "family_surname": "",
                 "father": {
+                    "addresses": [],
                     "birth": {
                         "age": "0 days",
                         "citations": 0,
@@ -473,6 +475,7 @@ class TestFamilies(unittest.TestCase):
                 "handle": "cc82060505948b9e57f",
                 "marriage": {},
                 "mother": {
+                    "addresses": [],
                     "birth": {},
                     "death": {
                         "citations": 0,
@@ -494,6 +497,7 @@ class TestFamilies(unittest.TestCase):
                 "references": {
                     "person": [
                         {
+                            "addresses": [],
                             "birth": {
                                 "date": "164-03 (Islamic)",
                                 "place": "",
@@ -517,6 +521,7 @@ class TestFamilies(unittest.TestCase):
                             "sex": "M",
                         },
                         {
+                            "addresses": [],
                             "birth": {},
                             "death": {
                                 "date": "234 (Islamic)",
@@ -534,6 +539,7 @@ class TestFamilies(unittest.TestCase):
                             "sex": "F",
                         },
                         {
+                            "addresses": [],
                             "birth": {
                                 "date": "203 (Islamic)",
                                 "place": "",
@@ -789,6 +795,7 @@ class TestFamiliesHandle(unittest.TestCase):
             {
                 "children": [
                     {
+                        "addresses": [],
                         "birth": {
                             "age": "0 days",
                             "citations": 0,
@@ -809,6 +816,7 @@ class TestFamiliesHandle(unittest.TestCase):
                         "sex": "M",
                     },
                     {
+                        "addresses": [],
                         "birth": {
                             "age": "0 days",
                             "citations": 0,
@@ -844,6 +852,7 @@ class TestFamiliesHandle(unittest.TestCase):
                 ],
                 "family_surname": "Garner",
                 "father": {
+                    "addresses": [],
                     "birth": {
                         "age": "0 days",
                         "citations": 0,
@@ -876,6 +885,7 @@ class TestFamiliesHandle(unittest.TestCase):
                     "summary": "Marriage - Garner, Gerard Stephen and George, Elizabeth",
                 },
                 "mother": {
+                    "addresses": [],
                     "birth": {
                         "age": "0 days",
                         "citations": 0,
@@ -898,6 +908,7 @@ class TestFamiliesHandle(unittest.TestCase):
                 "references": {
                     "person": [
                         {
+                            "addresses": [],
                             "birth": {
                                 "date": "1983-10-05",
                                 "place": "Ottawa, La Salle, IL, USA",
@@ -915,6 +926,7 @@ class TestFamiliesHandle(unittest.TestCase):
                             "sex": "M",
                         },
                         {
+                            "addresses": [],
                             "birth": {
                                 "date": "1985-02-11",
                                 "place": "Ottawa, La Salle, IL, USA",
@@ -932,6 +944,7 @@ class TestFamiliesHandle(unittest.TestCase):
                             "sex": "M",
                         },
                         {
+                            "addresses": [],
                             "birth": {
                                 "date": "1957-01-31",
                                 "place": "",
@@ -949,6 +962,7 @@ class TestFamiliesHandle(unittest.TestCase):
                             "sex": "F",
                         },
                         {
+                            "addresses": [],
                             "birth": {
                                 "date": "1955-07-31",
                                 "place": "Ottawa, La Salle, IL, USA",

--- a/tests/test_endpoints/test_people.py
+++ b/tests/test_endpoints/test_people.py
@@ -1190,6 +1190,7 @@ class TestPeopleHandle(unittest.TestCase):
         self.assertEqual(
             rv["profile"],
             {
+                "addresses": [],
                 "birth": {
                     "date": "1906-09-05",
                     "place": "Central City, Muhlenberg, KY, USA",
@@ -1213,6 +1214,11 @@ class TestPeopleHandle(unittest.TestCase):
                 "sex": "F",
             },
         )
+
+    def test_get_people_handle_parameter_profile_expected_result_addresses(self):
+        """Test address dates are formatted in the profile."""
+        rv = check_success(self, TEST_URL + "GNUJQCL9MD64AM56OH?profile=self")
+        self.assertEqual(rv["profile"]["addresses"], [{"date_str": "2000-01-02"}])
 
     def test_get_people_handle_parameter_profile_expected_result_age(self):
         """Test profile parameter age option."""

--- a/tests/test_endpoints/test_repositories.py
+++ b/tests/test_endpoints/test_repositories.py
@@ -461,6 +461,26 @@ class TestRepositoriesHandle(unittest.TestCase):
         self.assertIn("notes", rv["extended"])
         self.assertIn("tags", rv["extended"])
 
+    def test_get_repositories_handle_parameter_profile_validate_semantics(self):
+        """Test invalid profile parameter and values."""
+        check_invalid_semantics(
+            self, TEST_URL + "b39fe38593f3f8c4f12?profile", check="list"
+        )
+
+    def test_get_repositories_handle_parameter_profile_expected_result(self):
+        """Test profile parameter expected result."""
+        rv = check_success(self, TEST_URL + "b39fe38593f3f8c4f12?profile=self")
+        self.assertEqual(
+            rv["profile"],
+            {
+                "addresses": [{"date_str": ""}],
+                "gramps_id": "R0000",
+                "handle": "b39fe38593f3f8c4f12",
+                "name": "Public Library Great Falls",
+                "type": "Library",
+            },
+        )
+
     def test_get_repositories_handle_parameter_backlinks_validate_semantics(self):
         """Test invalid backlinks parameter and values."""
         check_invalid_semantics(


### PR DESCRIPTION
Used by gramps-project/gramps-web#1352 and fixes gramps-project/gramps-web#1353.

`Address` has a date (from `DateBase`), but no profile exposes it as a formatted string. Clients that want to display it have to format the raw `dateval` themselves, which loses modifiers (`about`, `between`), non-Gregorian calendars, and the user's locale and date-format preference.

This adds `addresses` to the person profile using `date_displayer`, paralleling `address_list`:

```json
"profile": {
  "addresses": [{"date_str": "2000-01-02"}]
}
```

This follows the existing `alternate_place_names` / `direct_parent_places` precedent in the place profile.

I'm working on a PR for the frontend to take advantage of this change.

### Repositories

`address_list` is on **Person** and **Repository** but repositories don't have a profile. If you're open to it, I'm happy to add a profile for repository so this same change can apply there. That would produce symmetry in the frontend too.

### Testing

Added a test covering the one person in the example database with an address (I0044). Updated the existing exact-match profile fixtures in `test_people.py`, `test_families.py` and `test_events.py` to include the new key.