### PR TITLE
Add indexed object-scoped change history

### DIFF
--- a/gramps_webapi/api/__init__.py
+++ b/gramps_webapi/api/__init__.py
@@ -56,6 +56,7 @@ from .resources.families import FamiliesResource, FamilyResource
 from .resources.file import MediaFileResource
 from .resources.filters import FilterResource, FiltersResource, FiltersResources
 from .resources.history import (
+    ObjectHistoryResource,
     TransactionHistoryResource,
     TransactionsHistoryResource,
     TransactionUndoResource,
@@ -219,6 +220,12 @@ register_endpt(
     TransactionUndoResource,
     "/transactions/history/<int:transaction_id>/undo",
     "transaction_undo",
+    tags=["Transactions"],
+)
+register_endpt(
+    ObjectHistoryResource,
+    "/transactions/history/objects/<string:obj_class>/<string:obj_handle>",
+    "object_history",
     tags=["Transactions"],
 )
 # Token

--- a/gramps_webapi/api/resources/history.py
+++ b/gramps_webapi/api/resources/history.py
@@ -26,7 +26,7 @@ from typing import Dict
 from flask import Response
 from flask_jwt_extended import get_jwt_identity
 from gramps.gen.db import REFERENCE_KEY
-from gramps.gen.db.dbconst import TXNADD, TXNDEL, TXNUPD
+from gramps.gen.db.dbconst import KEY_TO_CLASS_MAP, TXNADD, TXNDEL, TXNUPD
 from marshmallow import Schema
 from webargs import fields, validate
 
@@ -52,6 +52,7 @@ from .schemas import UndoTransactionSchema
 from .util import etag_unchanged, reverse_transaction
 
 trans_code = {"delete": TXNDEL, "add": TXNADD, "update": TXNUPD}
+OBJECT_CLASSES = sorted(set(KEY_TO_CLASS_MAP.values()))
 
 
 class TransactionsHistoryQueryArgs(Schema):
@@ -113,6 +114,20 @@ class TransactionsHistoryQueryArgs(Schema):
             "description": "Transaction ID; if provided, return only transactions with an id strictly greater than this value. Unlike the timestamp-based `before`/`after` cursor, this is exact and has no floating-point precision loss. 0 means 'from the beginning'."
         },
     )
+    obj_class = fields.Str(
+        load_default=None,
+        validate=validate.OneOf(OBJECT_CLASSES),
+        metadata={
+            "description": "Object class to scope the history to, e.g. 'Person'. Must be given together with `obj_handle`; when both are set, only that object's own changes are returned (as a flat list of changes rather than transactions), instead of every transaction in the tree."
+        },
+    )
+    obj_handle = fields.Str(
+        load_default=None,
+        validate=validate.Length(min=1),
+        metadata={
+            "description": "Handle of the object to scope the history to. Must be given together with `obj_class`."
+        },
+    )
 
 
 class TransactionsHistoryResource(ProtectedResource):
@@ -121,10 +136,17 @@ class TransactionsHistoryResource(ProtectedResource):
     @api_blueprint.response(200, UndoTransactionSchema(many=True))
     @api_blueprint.arguments(TransactionsHistoryQueryArgs, location="query")
     def get(self, args: Dict) -> Response:
-        """Return a list of transactions."""
+        """Return a list of transactions, or a single object's change history."""
         require_permissions([PERM_VIEW_PRIVATE])
         db_handle = get_db_handle()
         undodb = db_handle.undodb
+
+        if args["obj_class"] or args["obj_handle"]:
+            if not (args["obj_class"] and args["obj_handle"]):
+                abort_with_message(
+                    422, "`obj_class` and `obj_handle` must be given together"
+                )
+            return object_history_response(undodb, args)
 
         max_id, count = undodb.get_transactions_state(
             before=args["before"],
@@ -156,6 +178,40 @@ class TransactionsHistoryResource(ProtectedResource):
             fix_transaction_user(transaction, user_dict) for transaction in transactions
         ]
         return transactions_response(json.dumps(transactions), count=count, etag=etag)
+
+
+def object_history_response(undodb, args: Dict) -> Response:
+    """Return the change history of a single object as a flat list of changes."""
+    obj_class = args["obj_class"]
+    obj_handle = args["obj_handle"]
+    max_ts, count = undodb.get_object_changes_state(
+        obj_class=obj_class,
+        obj_handle=obj_handle,
+        before=args["before"],
+        after=args["after"],
+    )
+    etag = transactions_etag(args, max_ts, count)
+    if etag_unchanged(etag):
+        return transactions_response(None, count=count, etag=etag)
+
+    ascending = args.get("sort") != "-id"
+    changes, count = undodb.get_object_changes(
+        obj_class=obj_class,
+        obj_handle=obj_handle,
+        page=args["page"],
+        pagesize=args["pagesize"],
+        old_data=args["old"],
+        new_data=args["new"],
+        ascending=ascending,
+        before=args["before"],
+        after=args["after"],
+        known_count=count,
+    )
+
+    # replace user IDs by user name
+    user_dict = get_user_dict(transaction_user_ids(changes))
+    changes = [fix_transaction_user(change, user_dict) for change in changes]
+    return transactions_response(json.dumps(changes), count=count, etag=etag)
 
 
 class TransactionHistoryQueryArgs(Schema):

--- a/gramps_webapi/api/resources/history.py
+++ b/gramps_webapi/api/resources/history.py
@@ -48,7 +48,7 @@ from ..util import (
 )
 from ..blueprint import api_blueprint
 from . import ProtectedResource
-from .schemas import UndoTransactionSchema
+from .schemas import ObjectChangeSchema, UndoTransactionSchema
 from .util import etag_unchanged, reverse_transaction
 
 trans_code = {"delete": TXNDEL, "add": TXNADD, "update": TXNUPD}
@@ -114,20 +114,6 @@ class TransactionsHistoryQueryArgs(Schema):
             "description": "Transaction ID; if provided, return only transactions with an id strictly greater than this value. Unlike the timestamp-based `before`/`after` cursor, this is exact and has no floating-point precision loss. 0 means 'from the beginning'."
         },
     )
-    obj_class = fields.Str(
-        load_default=None,
-        validate=validate.OneOf(OBJECT_CLASSES),
-        metadata={
-            "description": "Object class to scope the history to, e.g. 'Person'. Must be given together with `obj_handle`; when both are set, only that object's own changes are returned (as a flat list of changes rather than transactions), instead of every transaction in the tree."
-        },
-    )
-    obj_handle = fields.Str(
-        load_default=None,
-        validate=validate.Length(min=1),
-        metadata={
-            "description": "Handle of the object to scope the history to. Must be given together with `obj_class`."
-        },
-    )
 
 
 class TransactionsHistoryResource(ProtectedResource):
@@ -136,17 +122,10 @@ class TransactionsHistoryResource(ProtectedResource):
     @api_blueprint.response(200, UndoTransactionSchema(many=True))
     @api_blueprint.arguments(TransactionsHistoryQueryArgs, location="query")
     def get(self, args: Dict) -> Response:
-        """Return a list of transactions, or a single object's change history."""
+        """Return a list of transactions."""
         require_permissions([PERM_VIEW_PRIVATE])
         db_handle = get_db_handle()
         undodb = db_handle.undodb
-
-        if args["obj_class"] or args["obj_handle"]:
-            if not (args["obj_class"] and args["obj_handle"]):
-                abort_with_message(
-                    422, "`obj_class` and `obj_handle` must be given together"
-                )
-            return object_history_response(undodb, args)
 
         max_id, count = undodb.get_transactions_state(
             before=args["before"],
@@ -180,38 +159,94 @@ class TransactionsHistoryResource(ProtectedResource):
         return transactions_response(json.dumps(transactions), count=count, etag=etag)
 
 
-def object_history_response(undodb, args: Dict) -> Response:
-    """Return the change history of a single object as a flat list of changes."""
-    obj_class = args["obj_class"]
-    obj_handle = args["obj_handle"]
-    max_ts, count = undodb.get_object_changes_state(
-        obj_class=obj_class,
-        obj_handle=obj_handle,
-        before=args["before"],
-        after=args["after"],
-    )
-    etag = transactions_etag(args, max_ts, count)
-    if etag_unchanged(etag):
-        return transactions_response(None, count=count, etag=etag)
+class ObjectHistoryQueryArgs(Schema):
+    """Query arguments for GET /history/transactions/objects/<class>/<handle>/."""
 
-    ascending = args.get("sort") != "-id"
-    changes, count = undodb.get_object_changes(
-        obj_class=obj_class,
-        obj_handle=obj_handle,
-        page=args["page"],
-        pagesize=args["pagesize"],
-        old_data=args["old"],
-        new_data=args["new"],
-        ascending=ascending,
-        before=args["before"],
-        after=args["after"],
-        known_count=count,
+    old = fields.Boolean(
+        load_default=False,
+        metadata={
+            "description": "If true, include the raw object data before the change."
+        },
+    )
+    new = fields.Boolean(
+        load_default=False,
+        metadata={
+            "description": "If true, include the raw object data after the change."
+        },
+    )
+    page = fields.Integer(
+        load_default=0,
+        validate=validate.Range(min=1),
+        metadata={
+            "description": "Page number of the result subset to return. If omitted, all results are returned."
+        },
+    )
+    pagesize = fields.Integer(
+        load_default=20,
+        validate=validate.Range(min=1),
+        metadata={"description": "Number of items per page when pagination is active."},
+    )
+    sort = fields.Str(
+        validate=validate.Length(min=1),
+        metadata={
+            "description": "Sort order for changes. Use 'id' for ascending or '-id' for descending (by timestamp)."
+        },
+    )
+    before = fields.Float(
+        load_default=None,
+        metadata={
+            "description": "Unix timestamp; if provided, return only changes committed before this time."
+        },
+    )
+    after = fields.Float(
+        load_default=None,
+        metadata={
+            "description": "Unix timestamp; if provided, return only changes committed after this time."
+        },
     )
 
-    # replace user IDs by user name
-    user_dict = get_user_dict(transaction_user_ids(changes))
-    changes = [fix_transaction_user(change, user_dict) for change in changes]
-    return transactions_response(json.dumps(changes), count=count, etag=etag)
+
+class ObjectHistoryResource(ProtectedResource):
+    """Resource for the change history of a single object."""
+
+    @api_blueprint.response(200, ObjectChangeSchema(many=True))
+    @api_blueprint.arguments(ObjectHistoryQueryArgs, location="query")
+    def get(self, args: Dict, obj_class: str, obj_handle: str) -> Response:
+        """Return the change history of a single object as a flat list of changes."""
+        require_permissions([PERM_VIEW_PRIVATE])
+        if obj_class not in OBJECT_CLASSES:
+            abort_with_message(422, f"Unknown object class: {obj_class}")
+        db_handle = get_db_handle()
+        undodb = db_handle.undodb
+
+        max_ts, count = undodb.get_object_changes_state(
+            obj_class=obj_class,
+            obj_handle=obj_handle,
+            before=args["before"],
+            after=args["after"],
+        )
+        etag = transactions_etag(args, max_ts, count)
+        if etag_unchanged(etag):
+            return transactions_response(None, count=count, etag=etag)
+
+        ascending = args.get("sort") != "-id"
+        changes, count = undodb.get_object_changes(
+            obj_class=obj_class,
+            obj_handle=obj_handle,
+            page=args["page"],
+            pagesize=args["pagesize"],
+            old_data=args["old"],
+            new_data=args["new"],
+            ascending=ascending,
+            before=args["before"],
+            after=args["after"],
+            known_count=count,
+        )
+
+        # replace user IDs by user name
+        user_dict = get_user_dict(transaction_user_ids(changes))
+        changes = [fix_transaction_user(change, user_dict) for change in changes]
+        return transactions_response(json.dumps(changes), count=count, etag=etag)
 
 
 class TransactionHistoryQueryArgs(Schema):

--- a/gramps_webapi/api/resources/history.py
+++ b/gramps_webapi/api/resources/history.py
@@ -56,7 +56,7 @@ OBJECT_CLASSES = sorted(set(KEY_TO_CLASS_MAP.values()))
 
 
 class TransactionsHistoryQueryArgs(Schema):
-    """Query arguments for GET /history/transactions/."""
+    """Query arguments for GET /transactions/history/."""
 
     old = fields.Boolean(
         load_default=False,
@@ -160,7 +160,7 @@ class TransactionsHistoryResource(ProtectedResource):
 
 
 class ObjectHistoryQueryArgs(Schema):
-    """Query arguments for GET /history/transactions/objects/<class>/<handle>/."""
+    """Query arguments for GET /transactions/history/objects/<obj_class>/<obj_handle>/."""
 
     old = fields.Boolean(
         load_default=False,
@@ -225,7 +225,7 @@ class ObjectHistoryResource(ProtectedResource):
             before=args["before"],
             after=args["after"],
         )
-        etag = transactions_etag(args, max_ts, count)
+        etag = transactions_etag(args, max_ts, count, obj_key=(obj_class, obj_handle))
         if etag_unchanged(etag):
             return transactions_response(None, count=count, etag=etag)
 
@@ -250,7 +250,7 @@ class ObjectHistoryResource(ProtectedResource):
 
 
 class TransactionHistoryQueryArgs(Schema):
-    """Query arguments for GET /history/transactions/<id>/."""
+    """Query arguments for GET /transactions/history/<id>/."""
 
     old = fields.Boolean(
         load_default=False,
@@ -470,14 +470,21 @@ def transaction_user_ids(transactions: list[Dict]) -> set[str]:
     return {transaction["connection"]["user_id"] for transaction in transactions}
 
 
-def transactions_etag(args: Dict, max_id: int | None, count: int) -> str:
+def transactions_etag(
+    args: Dict, max_id: int | None, count: int, obj_key: tuple | None = None
+) -> str:
     """Build a cache validator for a page of the transaction history.
+
+    `obj_key` (obj_class, obj_handle) scopes the ETag to a single object's
+    history so it cannot collide with the ETag of another object's history.
 
     The user names resolved into the response are not covered: a rename becomes
     visible only once the next transaction is written.
     """
     tree_id = get_tree_from_jwt_or_fail()
-    state = json.dumps([tree_id, max_id, count, args], sort_keys=True, default=str)
+    state = json.dumps(
+        [tree_id, obj_key, max_id, count, args], sort_keys=True, default=str
+    )
     return hashlib.sha256(state.encode()).hexdigest()
 
 

--- a/gramps_webapi/api/resources/schemas.py
+++ b/gramps_webapi/api/resources/schemas.py
@@ -1844,6 +1844,38 @@ class UndoTransactionSchema(_Base):
     )
 
 
+class ObjectChangeSchema(_Base):
+    """A single change to one object, as returned by the object history endpoint."""
+
+    id = fields.Int(
+        metadata={"description": "Change ID (unique only within its connection)."},
+    )
+    connection = fields.Raw(
+        metadata={"description": "Internal connection object."},
+    )
+    obj_class = fields.Str(
+        metadata={"description": "Object class name (e.g. 'Person', 'Event')."},
+    )
+    obj_handle = fields.Str(
+        metadata={"description": "Handle of the changed object."},
+    )
+    ref_handle = fields.Str(
+        metadata={"description": "Handle of a referenced object, if this change is a reference update."},
+    )
+    trans_type = fields.Int(
+        metadata={"description": "Change type: 0 (add), 1 (update), or 2 (delete)."},
+    )
+    timestamp = fields.Float(
+        metadata={"description": "Unix timestamp when the change was committed."},
+    )
+    old_data = fields.Raw(
+        metadata={"description": "Object state before the change (only included if requested)."},
+    )
+    new_data = fields.Raw(
+        metadata={"description": "Object state after the change (only included if requested)."},
+    )
+
+
 class FilterRuleDescriptionSchema(_Base):
     """Description of a built-in Gramps filter rule."""
 

--- a/gramps_webapi/undodb.py
+++ b/gramps_webapi/undodb.py
@@ -44,6 +44,7 @@ from gramps.gen.lib.json_utils import (
 from sqlalchemy import (
     BigInteger,
     ForeignKey,
+    Index,
     Integer,
     LargeBinary,
     PrimaryKeyConstraint,
@@ -89,7 +90,12 @@ class Change(Base):
     """A change is a single addition, deletion, or modification of a Gramps object."""
 
     __tablename__ = "changes"
-    __table_args__ = (PrimaryKeyConstraint("id", "connection_id"),)
+    __table_args__ = (
+        PrimaryKeyConstraint("id", "connection_id"),
+        # handles aren't guaranteed unique across object classes, so both
+        # columns are needed to look up a single object's change history
+        Index("ix_changes_obj_class_obj_handle", "obj_class", "obj_handle"),
+    )
 
     id = mapped_column(Integer)
     connection_id = mapped_column(Integer, ForeignKey("connections.id"), index=True)
@@ -333,7 +339,7 @@ class DbUndoSQL(DbUndo):
 
     def append(self, value) -> None:
         """Add a new entry on the end."""
-        (obj_type, trans_type, handle, old_data, new_data) = pickle.loads(value)
+        obj_type, trans_type, handle, old_data, new_data = pickle.loads(value)
         if isinstance(handle, tuple):
             obj_handle, ref_handle = handle
         else:
@@ -432,7 +438,7 @@ class DbUndoSQL(DbUndo):
         """
         Set an entry to a value.
         """
-        (obj_type, trans_type, handle, old_data, new_data) = pickle.loads(value)
+        obj_type, trans_type, handle, old_data, new_data = pickle.loads(value)
         if isinstance(handle, tuple):
             obj_handle, ref_handle = handle
         else:
@@ -489,7 +495,7 @@ class DbUndoSQL(DbUndo):
         try:
             self.db._txn_begin()
             for record_id in subitems:
-                (key, trans_type, handle, old_data, new_data) = pickle.loads(
+                key, trans_type, handle, old_data, new_data = pickle.loads(
                     records[record_id]
                 )
 
@@ -544,7 +550,7 @@ class DbUndoSQL(DbUndo):
         try:
             self.db._txn_begin()
             for record_id in subitems:
-                (key, trans_type, handle, old_data, new_data) = pickle.loads(
+                key, trans_type, handle, old_data, new_data = pickle.loads(
                     records[record_id]
                 )
 
@@ -724,6 +730,111 @@ class DbUndoSQLWeb(DbUndoSQL):
             changes = _get_changes(session, [transaction], old_data, new_data)
             return transaction._to_dict(changes[transaction.id])
 
+    def _object_changes_query(
+        self,
+        session: Session,
+        obj_class: str,
+        obj_handle: str,
+        before: float | None = None,
+        after: float | None = None,
+    ):
+        """Build the base query for a single object's changes in this tree.
+
+        Filters on the indexed (obj_class, obj_handle) pair, so this is a
+        direct lookup rather than a scan of every change ever made.
+        """
+        query = (
+            session.query(Change)
+            .join(Change.connection)
+            .filter(Connection.tree_id == self.tree_id)
+            .filter(Change.obj_class == obj_class, Change.obj_handle == obj_handle)
+        )
+        if before:
+            query = query.filter(Change.timestamp < before * 1e9)
+        if after:
+            query = query.filter(Change.timestamp > after * 1e9)
+        return query
+
+    def get_object_changes_state(
+        self,
+        obj_class: str,
+        obj_handle: str,
+        before: float | None = None,
+        after: float | None = None,
+    ) -> tuple[int | None, int]:
+        """Get the latest change timestamp and count for a single object.
+
+        Changes are append-only and immutable, so this pair changes whenever
+        the result of an object history query changes.
+        """
+        with self.session_scope() as session:
+            query = self._object_changes_query(
+                session, obj_class, obj_handle, before=before, after=after
+            )
+            return query.with_entities(
+                func.max(Change.timestamp), func.count(Change.id)
+            ).one()
+
+    def get_object_changes(
+        self,
+        obj_class: str,
+        obj_handle: str,
+        page: int = 1,
+        pagesize: int = 20,
+        old_data: bool = True,
+        new_data: bool = True,
+        ascending: bool = True,
+        before: float | None = None,
+        after: float | None = None,
+        known_count: int | None = None,
+    ) -> tuple[list[dict[str, Any]], int]:
+        """Get a single object's own change history as a JSONifiable list.
+
+        Unlike `get_transactions`, this queries `Change` directly instead of
+        resolving through `Transaction`'s first/last id-range logic: it's the
+        object's own change rows that a history view wants, not the sibling
+        changes that happened to share a transaction with them.
+
+        `Change.id` is only unique within a connection (it is part of a
+        composite primary key together with `connection_id`), so unlike
+        `Transaction.id` it cannot be used as a global ordering key or
+        cursor here; changes are ordered/filtered by timestamp instead.
+
+        `known_count` is returned in place of counting the matching changes
+        again.
+        """
+        with self.session_scope() as session:
+            query = self._object_changes_query(
+                session, obj_class, obj_handle, before=before, after=after
+            )
+            count = query.count() if known_count is None else known_count
+            if ascending:
+                query = query.order_by(
+                    Change.timestamp, Change.connection_id, Change.id
+                )
+            else:
+                query = query.order_by(
+                    Change.timestamp.desc(),
+                    Change.connection_id.desc(),
+                    Change.id.desc(),
+                )
+            if page and pagesize:
+                query = query.limit(pagesize).offset((page - 1) * pagesize)
+            # the legacy binary columns are never serialised, the JSON ones only on demand
+            deferred = [defer(Change.old_data), defer(Change.new_data)]
+            if not old_data:
+                deferred.append(defer(Change.old_json))
+            if not new_data:
+                deferred.append(defer(Change.new_json))
+            changes = query.options(contains_eager(Change.connection), *deferred).all()
+            return [
+                {
+                    **change._to_dict(old_data=old_data, new_data=new_data),
+                    "connection": change.connection._to_dict(),
+                }
+                for change in changes
+            ], count
+
 
 def _add_json_columns(undodb: DbUndoSQL) -> None:
     """Add old_json/new_json columns to the changes table if not already present.
@@ -744,10 +855,32 @@ def _add_json_columns(undodb: DbUndoSQL) -> None:
                 )
 
 
+def _add_object_index(undodb: DbUndoSQL) -> None:
+    """Add an index on (obj_class, obj_handle) to the changes table if absent.
+
+    Only needed when migrating a database created before this index was
+    added to the schema. Unlike `_add_json_columns`'s row-by-row JSON
+    backfill below, this needs no data migration: a single
+    `CREATE INDEX IF NOT EXISTS` is built natively by the database engine,
+    without reading or rewriting any row data through the ORM.
+    """
+    inspector = inspect(undodb.engine)
+    index_names = {idx["name"] for idx in inspector.get_indexes("changes")}
+    if "ix_changes_obj_class_obj_handle" not in index_names:
+        with undodb.engine.begin() as conn:
+            conn.execute(
+                text(
+                    "CREATE INDEX IF NOT EXISTS ix_changes_obj_class_obj_handle "
+                    "ON changes (obj_class, obj_handle)"
+                )
+            )
+
+
 def migrate(undodb: DbUndoSQL) -> None:
     """Migrate the undo db to a new schema if needed."""
     undodb._ensure_schema()
     _add_json_columns(undodb)
+    _add_object_index(undodb)
     with undodb.session_scope() as session:
         # return all rows where old_json AND new_json are NULL
         rows = (

--- a/gramps_webapi/undodb.py
+++ b/gramps_webapi/undodb.py
@@ -749,10 +749,10 @@ class DbUndoSQLWeb(DbUndoSQL):
             .filter(Connection.tree_id == self.tree_id)
             .filter(Change.obj_class == obj_class, Change.obj_handle == obj_handle)
         )
-        if before:
-            query = query.filter(Change.timestamp < before * 1e9)
-        if after:
-            query = query.filter(Change.timestamp > after * 1e9)
+        if before is not None:
+            query = query.filter(Change.timestamp < int(before * 1e9))
+        if after is not None:
+            query = query.filter(Change.timestamp > int(after * 1e9))
         return query
 
     def get_object_changes_state(

--- a/tests/test_endpoints/test_history.py
+++ b/tests/test_endpoints/test_history.py
@@ -861,25 +861,10 @@ class TestTransactionHistoryResource(unittest.TestCase):
         assert rv.status_code == 200
         assert rv.json[-1]["description"] == "Undo"
 
-    def test_object_history_requires_both_params(self):
-        headers = get_headers(self.client, "editor", "123")
-        rv = self.client.post("/api/people/", json={}, headers=headers)
-        assert rv.status_code == 201
-        person_handle = rv.json[0]["new"]["handle"]
-
-        rv = self.client.get(
-            "/api/transactions/history/?obj_class=Person", headers=headers
-        )
-        assert rv.status_code == 422
-        rv = self.client.get(
-            f"/api/transactions/history/?obj_handle={person_handle}", headers=headers
-        )
-        assert rv.status_code == 422
-
     def test_object_history_invalid_class(self):
         headers = get_headers(self.client, "editor", "123")
         rv = self.client.get(
-            "/api/transactions/history/?obj_class=NotAClass&obj_handle=abc",
+            "/api/transactions/history/objects/NotAClass/abc",
             headers=headers,
         )
         assert rv.status_code == 422
@@ -905,7 +890,7 @@ class TestTransactionHistoryResource(unittest.TestCase):
         assert other_handle != person_handle
 
         rv = self.client.get(
-            f"/api/transactions/history/?obj_class=Person&obj_handle={person_handle}",
+            f"/api/transactions/history/objects/Person/{person_handle}",
             headers=headers,
         )
         assert rv.status_code == 200
@@ -917,7 +902,7 @@ class TestTransactionHistoryResource(unittest.TestCase):
         assert "new_data" not in changes[0]
 
         rv = self.client.get(
-            f"/api/transactions/history/?obj_class=Person&obj_handle={other_handle}",
+            f"/api/transactions/history/objects/Person/{other_handle}",
             headers=headers,
         )
         assert rv.status_code == 200
@@ -933,7 +918,7 @@ class TestTransactionHistoryResource(unittest.TestCase):
         person_handle = person["handle"]
 
         rv = self.client.get(
-            f"/api/transactions/history/?obj_class=Person&obj_handle={person_handle}&old=1&new=1",
+            f"/api/transactions/history/objects/Person/{person_handle}?old=1&new=1",
             headers=headers,
         )
         assert rv.status_code == 200
@@ -944,12 +929,34 @@ class TestTransactionHistoryResource(unittest.TestCase):
     def test_object_history_unknown_handle(self):
         headers = get_headers(self.client, "editor", "123")
         rv = self.client.get(
-            "/api/transactions/history/?obj_class=Person&obj_handle=doesnotexist",
+            "/api/transactions/history/objects/Person/doesnotexist",
             headers=headers,
         )
         assert rv.status_code == 200
         assert rv.json == []
         assert rv.headers["X-Total-Count"] == "0"
+
+    def test_object_history_before_zero_not_treated_as_unset(self):
+        """`before=0`/`after=0` are real cursor values, not 'no filter'."""
+        headers = get_headers(self.client, "editor", "123")
+        rv = self.client.post("/api/people/", json={}, headers=headers)
+        assert rv.status_code == 201
+        person_handle = rv.json[0]["new"]["handle"]
+
+        rv = self.client.get(
+            f"/api/transactions/history/objects/Person/{person_handle}?before=0",
+            headers=headers,
+        )
+        assert rv.status_code == 200
+        assert rv.json == []
+        assert rv.headers["X-Total-Count"] == "0"
+
+        rv = self.client.get(
+            f"/api/transactions/history/objects/Person/{person_handle}?after=0",
+            headers=headers,
+        )
+        assert rv.status_code == 200
+        assert len(rv.json) == 1
 
     def test_object_history_etag_revalidation(self):
         headers = get_headers(self.client, "editor", "123")
@@ -957,7 +964,7 @@ class TestTransactionHistoryResource(unittest.TestCase):
         assert rv.status_code == 201
         person_handle = rv.json[0]["new"]["handle"]
 
-        url = f"/api/transactions/history/?obj_class=Person&obj_handle={person_handle}"
+        url = f"/api/transactions/history/objects/Person/{person_handle}"
         rv = self.client.get(url, headers=headers)
         assert rv.status_code == 200
         etag = rv.headers["ETag"]
@@ -981,7 +988,7 @@ class TestTransactionHistoryResource(unittest.TestCase):
     def test_object_history_guest_forbidden(self):
         headers = get_headers(self.client, "user", "123")
         rv = self.client.get(
-            "/api/transactions/history/?obj_class=Person&obj_handle=abc",
+            "/api/transactions/history/objects/Person/abc",
             headers=headers,
         )
         assert rv.status_code == 403

--- a/tests/test_endpoints/test_history.py
+++ b/tests/test_endpoints/test_history.py
@@ -757,7 +757,6 @@ class TestTransactionHistoryResource(unittest.TestCase):
         assert rv.status_code == 200
         result = rv.json
 
-
         # Should NOT be able to undo without force due to changes
         assert result["can_undo_without_force"] is False
         assert result["conflicts_count"] > 0
@@ -861,6 +860,131 @@ class TestTransactionHistoryResource(unittest.TestCase):
         rv = self.client.get("/api/transactions/history/", headers=headers)
         assert rv.status_code == 200
         assert rv.json[-1]["description"] == "Undo"
+
+    def test_object_history_requires_both_params(self):
+        headers = get_headers(self.client, "editor", "123")
+        rv = self.client.post("/api/people/", json={}, headers=headers)
+        assert rv.status_code == 201
+        person_handle = rv.json[0]["new"]["handle"]
+
+        rv = self.client.get(
+            "/api/transactions/history/?obj_class=Person", headers=headers
+        )
+        assert rv.status_code == 422
+        rv = self.client.get(
+            f"/api/transactions/history/?obj_handle={person_handle}", headers=headers
+        )
+        assert rv.status_code == 422
+
+    def test_object_history_invalid_class(self):
+        headers = get_headers(self.client, "editor", "123")
+        rv = self.client.get(
+            "/api/transactions/history/?obj_class=NotAClass&obj_handle=abc",
+            headers=headers,
+        )
+        assert rv.status_code == 422
+
+    def test_object_history_returns_only_this_object(self):
+        headers = get_headers(self.client, "editor", "123")
+
+        # add a person, then update it (2 changes for this object)
+        rv = self.client.post("/api/people/", json={}, headers=headers)
+        assert rv.status_code == 201
+        person = rv.json[0]["new"]
+        person_handle = person["handle"]
+        person["gramps_id"] = "updated"
+        rv = self.client.put(
+            f"/api/people/{person_handle}", json=person, headers=headers
+        )
+        assert rv.status_code == 200
+
+        # add a second, unrelated person -- must not show up in the first one's history
+        rv = self.client.post("/api/people/", json={}, headers=headers)
+        assert rv.status_code == 201
+        other_handle = rv.json[0]["new"]["handle"]
+        assert other_handle != person_handle
+
+        rv = self.client.get(
+            f"/api/transactions/history/?obj_class=Person&obj_handle={person_handle}",
+            headers=headers,
+        )
+        assert rv.status_code == 200
+        changes = rv.json
+        assert len(changes) == 2
+        assert [change["trans_type"] for change in changes] == [0, 1]
+        assert all(change["obj_handle"] == person_handle for change in changes)
+        assert "old_data" not in changes[0]
+        assert "new_data" not in changes[0]
+
+        rv = self.client.get(
+            f"/api/transactions/history/?obj_class=Person&obj_handle={other_handle}",
+            headers=headers,
+        )
+        assert rv.status_code == 200
+        changes = rv.json
+        assert len(changes) == 1
+        assert changes[0]["obj_handle"] == other_handle
+
+    def test_object_history_old_new_data(self):
+        headers = get_headers(self.client, "editor", "123")
+        rv = self.client.post("/api/people/", json={}, headers=headers)
+        assert rv.status_code == 201
+        person = rv.json[0]["new"]
+        person_handle = person["handle"]
+
+        rv = self.client.get(
+            f"/api/transactions/history/?obj_class=Person&obj_handle={person_handle}&old=1&new=1",
+            headers=headers,
+        )
+        assert rv.status_code == 200
+        change = rv.json[0]
+        assert change["old_data"] == {}
+        assert change["new_data"]["handle"] == person_handle
+
+    def test_object_history_unknown_handle(self):
+        headers = get_headers(self.client, "editor", "123")
+        rv = self.client.get(
+            "/api/transactions/history/?obj_class=Person&obj_handle=doesnotexist",
+            headers=headers,
+        )
+        assert rv.status_code == 200
+        assert rv.json == []
+        assert rv.headers["X-Total-Count"] == "0"
+
+    def test_object_history_etag_revalidation(self):
+        headers = get_headers(self.client, "editor", "123")
+        rv = self.client.post("/api/people/", json={}, headers=headers)
+        assert rv.status_code == 201
+        person_handle = rv.json[0]["new"]["handle"]
+
+        url = f"/api/transactions/history/?obj_class=Person&obj_handle={person_handle}"
+        rv = self.client.get(url, headers=headers)
+        assert rv.status_code == 200
+        etag = rv.headers["ETag"]
+
+        rv = self.client.get(url, headers={**headers, "If-None-Match": etag})
+        assert rv.status_code == 304
+
+        # a new change to this object invalidates the client's copy
+        person = self.client.get(f"/api/people/{person_handle}", headers=headers).json
+        person["gramps_id"] = "changed"
+        rv = self.client.put(
+            f"/api/people/{person_handle}", json=person, headers=headers
+        )
+        assert rv.status_code == 200
+
+        rv = self.client.get(url, headers={**headers, "If-None-Match": etag})
+        assert rv.status_code == 200
+        assert len(rv.json) == 2
+        assert rv.headers["ETag"] != etag
+
+    def test_object_history_guest_forbidden(self):
+        headers = get_headers(self.client, "user", "123")
+        rv = self.client.get(
+            "/api/transactions/history/?obj_class=Person&obj_handle=abc",
+            headers=headers,
+        )
+        assert rv.status_code == 403
 
     def test_undo_message_custom(self):
         """Custom message param is stored in the undo log."""

--- a/tests/test_undodb.py
+++ b/tests/test_undodb.py
@@ -304,6 +304,103 @@ class TestGetTransactions(unittest.TestCase):
         assert change["new_data"]["_class"] == "Person"
 
 
+class TestGetObjectChanges(unittest.TestCase):
+    """Tests for the object-scoped change history queries of `DbUndoSQLWeb`."""
+
+    def setUp(self):
+        self.dbdir = tempfile.mkdtemp()
+        self.db: DbWriteBase = make_database("sqlite")
+
+        def create_undo_manager():
+            path = self.db.undolog
+            return DbUndoSQLWeb(grampsdb=self.db, dburl=f"sqlite:///{path}", tree_id=1)
+
+        self.db._create_undo_manager = create_undo_manager
+        self.db.load(self.dbdir)
+
+        with DbTxn("Add person and note", self.db) as trans:
+            person = Person()
+            self.db.add_person(person, trans)
+            note = Note()
+            self.db.add_note(note, trans)
+        self.person_handle = person.handle
+        self.note_handle = note.handle
+
+        person.gramps_id = "modified"
+        with DbTxn("Modify person", self.db) as trans:
+            self.db.commit_person(person, trans)
+
+    def tearDown(self):
+        self.db.close(update=False)
+        shutil.rmtree(self.dbdir)
+
+    def test_returns_only_this_object_changes(self):
+        undodb = self.db.get_undodb()
+        changes, count = undodb.get_object_changes("Person", self.person_handle)
+        assert count == 2
+        assert [change["trans_type"] for change in changes] == [0, 1]  # add, modify
+        assert all(change["obj_handle"] == self.person_handle for change in changes)
+        assert all(change["obj_class"] == "Person" for change in changes)
+
+    def test_excludes_sibling_changes_from_same_transaction(self):
+        undodb = self.db.get_undodb()
+        changes, count = undodb.get_object_changes("Note", self.note_handle)
+        assert count == 1
+        assert changes[0]["obj_handle"] == self.note_handle
+
+    def test_unknown_handle_returns_empty(self):
+        undodb = self.db.get_undodb()
+        changes, count = undodb.get_object_changes("Person", "nonexistent")
+        assert changes == []
+        assert count == 0
+
+    def test_state(self):
+        undodb = self.db.get_undodb()
+        max_ts, count = undodb.get_object_changes_state("Person", self.person_handle)
+        assert count == 2
+        assert isinstance(max_ts, int)
+        with DbTxn("Modify person again", self.db) as trans:
+            person = self.db.get_person_from_handle(self.person_handle)
+            person.gramps_id = "modified again"
+            self.db.commit_person(person, trans)
+        new_max_ts, new_count = undodb.get_object_changes_state(
+            "Person", self.person_handle
+        )
+        assert new_count == 3
+        assert new_max_ts >= max_ts
+
+    def test_data_only_included_on_demand(self):
+        undodb = self.db.get_undodb()
+        changes, _ = undodb.get_object_changes(
+            "Person", self.person_handle, old_data=False, new_data=False
+        )
+        assert "old_data" not in changes[0]
+        assert "new_data" not in changes[0]
+        changes, _ = undodb.get_object_changes(
+            "Person", self.person_handle, old_data=True, new_data=True
+        )
+        assert changes[1]["old_data"]["gramps_id"] != "modified"
+        assert changes[1]["new_data"]["gramps_id"] == "modified"
+
+    def test_pagination_and_descending(self):
+        undodb = self.db.get_undodb()
+        changes, count = undodb.get_object_changes(
+            "Person", self.person_handle, page=1, pagesize=1
+        )
+        assert count == 2
+        assert len(changes) == 1
+        assert changes[0]["trans_type"] == 0  # add, ascending default
+        changes, _ = undodb.get_object_changes(
+            "Person", self.person_handle, ascending=False
+        )
+        assert [change["trans_type"] for change in changes] == [1, 0]
+
+    def test_connection_included(self):
+        undodb = self.db.get_undodb()
+        changes, _ = undodb.get_object_changes("Person", self.person_handle)
+        assert changes[0]["connection"]["id"] == 1
+
+
 class TestMigrate(unittest.TestCase):
     """Tests for the migrate() function (pre-v3.0 → v3.0 undo DB migration)."""
 
@@ -360,8 +457,7 @@ class TestMigrate(unittest.TestCase):
         undodb = self._get_undodb()
 
         cols_before = {
-            col["name"]
-            for col in sa_inspect(undodb.engine).get_columns("changes")
+            col["name"] for col in sa_inspect(undodb.engine).get_columns("changes")
         }
         self.assertNotIn("old_json", cols_before)
         self.assertNotIn("new_json", cols_before)
@@ -369,8 +465,7 @@ class TestMigrate(unittest.TestCase):
         migrate(undodb)
 
         cols_after = {
-            col["name"]
-            for col in sa_inspect(undodb.engine).get_columns("changes")
+            col["name"] for col in sa_inspect(undodb.engine).get_columns("changes")
         }
         self.assertIn("old_json", cols_after)
         self.assertIn("new_json", cols_after)
@@ -383,9 +478,12 @@ class TestMigrate(unittest.TestCase):
         undodb = self._get_undodb()
 
         with undodb.session_scope() as session:
-            nulls: int = session.execute(
-                text("SELECT COUNT(*) FROM changes WHERE new_json IS NULL")
-            ).scalar() or 0
+            nulls: int = (
+                session.execute(
+                    text("SELECT COUNT(*) FROM changes WHERE new_json IS NULL")
+                ).scalar()
+                or 0
+            )
         self.assertGreater(nulls, 0)
 
         migrate(undodb)
@@ -405,10 +503,46 @@ class TestMigrate(unittest.TestCase):
 
         undodb = self._get_undodb()
         with undodb.session_scope() as session:
-            count: int = session.execute(
-                text("SELECT COUNT(*) FROM changes")
-            ).scalar() or 0
+            count: int = (
+                session.execute(text("SELECT COUNT(*) FROM changes")).scalar() or 0
+            )
         self.assertGreater(count, 0)
+
+    def test_migrate_adds_missing_object_index(self):
+        """migrate() adds the (obj_class, obj_handle) index when absent."""
+        from gramps_webapi.undodb import migrate
+        from sqlalchemy import inspect as sa_inspect
+
+        undodb = self._get_undodb()
+        with undodb.engine.begin() as conn:
+            conn.execute(text("DROP INDEX ix_changes_obj_class_obj_handle"))
+
+        index_names_before = {
+            idx["name"] for idx in sa_inspect(undodb.engine).get_indexes("changes")
+        }
+        self.assertNotIn("ix_changes_obj_class_obj_handle", index_names_before)
+
+        migrate(undodb)
+
+        index_names_after = {
+            idx["name"] for idx in sa_inspect(undodb.engine).get_indexes("changes")
+        }
+        self.assertIn("ix_changes_obj_class_obj_handle", index_names_after)
+
+    def test_migrate_object_index_idempotent(self):
+        """Calling migrate() when the index already exists does not raise."""
+        from gramps_webapi.undodb import migrate
+
+        undodb = self._get_undodb()
+        migrate(undodb)
+        migrate(undodb)  # second call must not crash
+
+        from sqlalchemy import inspect as sa_inspect
+
+        index_names = {
+            idx["name"] for idx in sa_inspect(undodb.engine).get_indexes("changes")
+        }
+        self.assertIn("ix_changes_obj_class_obj_handle", index_names)
 
     def test_migrate_noop_when_current(self):
         """migrate() on an already-current DB (all JSON populated) is a no-op."""

--- a/tests/test_undodb.py
+++ b/tests/test_undodb.py
@@ -400,6 +400,20 @@ class TestGetObjectChanges(unittest.TestCase):
         changes, _ = undodb.get_object_changes("Person", self.person_handle)
         assert changes[0]["connection"]["id"] == 1
 
+    def test_before_after_zero_is_a_real_cursor_not_unset(self):
+        """`before=0`/`after=0` must filter, not be treated as 'no filter'."""
+        undodb = self.db.get_undodb()
+        changes, count = undodb.get_object_changes(
+            "Person", self.person_handle, before=0
+        )
+        assert changes == []
+        assert count == 0
+
+        changes, count = undodb.get_object_changes(
+            "Person", self.person_handle, after=0
+        )
+        assert count == 2
+
 
 class TestMigrate(unittest.TestCase):
     """Tests for the migrate() function (pre-v3.0 → v3.0 undo DB migration)."""


### PR DESCRIPTION
## Summary

Implements the proposal from #955: adds a way to efficiently query the change history of a single object, backed by an index, instead of paging through every transaction in the tree.

- Adds an index on `changes(obj_class, obj_handle)` (declared on the `Change` model for new databases, plus an idempotent `CREATE INDEX IF NOT EXISTS` migration step in `migrate()` for existing ones — a single DDL statement, no per-row backfill needed).
- Adds `DbUndoSQLWeb.get_object_changes()` / `get_object_changes_state()`, querying `Change` directly (scoped to the tree via `Connection`) rather than resolving through `Transaction`'s id-range logic, so only the object's own change rows come back — not sibling changes from the same transaction.
- Adds a dedicated `GET /transactions/history/objects/<obj_class>/<obj_handle>/` endpoint (reusing the existing pagination/sort/ETag/`X-Total-Count` conventions) rather than overloading `GET /transactions/history/` with optional params, per review feedback from @DavidMStraub and Copilot — a response whose schema depends on query arguments would make the OpenAPI spec ambiguous. The new endpoint returns a flat list of the object's changes (`ObjectChangeSchema`), while `GET /transactions/history/` is unchanged and always returns `UndoTransactionSchema`.

Since `Change.id` is only unique within a connection (composite PK with `connection_id`, unlike `Transaction.id`), object-history ordering/filtering uses `timestamp` rather than `before_id`/`after_id`.

## Test plan

- [x] `pytest tests/test_undodb.py tests/test_endpoints/test_history.py` — new tests covering the index migration, direct query methods, and the new endpoint's query params/etag/permissions
- [x] `pytest tests/test_cli.py tests/test_migrate_grampsdb.py` — unaffected
- [x] Verified OpenAPI spec generation picks up the new endpoint and `ObjectChangeSchema` correctly

Closes discussion #955.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XhwF542v4KNGzEGvtU6Rop