### PR TITLE
Speed up full search reindex: throttle progress reporting, bulk-load event backlinks

### DIFF
--- a/gramps_webapi/api/resources/db_backend.py
+++ b/gramps_webapi/api/resources/db_backend.py
@@ -1,0 +1,59 @@
+#
+# Gramps Web API - A RESTful API for the Gramps genealogy program
+#
+# Copyright (C) 2026      Douglas Blank
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+#
+
+"""Database backend class names, shared by every module that needs to tell
+DBAPI-based backends apart for raw-SQL purposes (`object_query.py`'s
+`_resolve_dialect`/`_resolve_treeid`, `util.py`'s `preload_event_backlinks`).
+
+Checked by class *name*, not `isinstance`: Gramps' plugin loader imports
+database backend plugins (including core ones) as freestanding modules under
+a bare name (`sqlite`, not `gramps.plugins.db.dbapi.sqlite`) rather than via
+a normal package import, so a real request's `db_handle`/`basedb` is a
+*different* class object than this module's own `from
+gramps.plugins.db.dbapi.sqlite import SQLite` -- same name, same behavior,
+different identity. `isinstance(basedb, SQLite)` silently returns `False`
+for it every time; see `object_query.py`'s `_resolve_dialect` docstring for
+the concrete failure this caused. `isinstance` is kept first for `SQLite`
+since it's the correct, more specific check when it *does* match (e.g. a
+`SQLite()` constructed directly in-process, as tests do).
+
+This module only centralizes the *names* -- each caller keeps its own
+failure policy for "unrecognized backend" (silent fallback in
+`preload_event_backlinks`, an HTTP 501 in `object_query.py`), since what's
+safe to do differs by call site.
+"""
+
+from typing import Any
+
+from gramps.plugins.db.dbapi.sqlite import SQLite
+
+SQLITE_CLASS_NAME = "SQLite"
+SINGLE_TREE_POSTGRES_CLASS_NAME = "PostgreSQL"
+SHARED_POSTGRES_CLASS_NAME = "SharedPostgreSQL"
+
+# Single-tree-per-database backends: no `treeid` column/concept at all, as
+# opposed to `SharedPostgreSQL`, which stores every tree in the same tables.
+SINGLE_TREE_DBAPI_CLASS_NAMES = frozenset(
+    {SQLITE_CLASS_NAME, SINGLE_TREE_POSTGRES_CLASS_NAME}
+)
+
+
+def is_sqlite(basedb: Any) -> bool:
+    """Whether `basedb` (or its `.dbapi`) is a core SQLite backend."""
+    return isinstance(basedb, SQLite) or type(basedb).__name__ == SQLITE_CLASS_NAME

--- a/gramps_webapi/api/resources/object_query.py
+++ b/gramps_webapi/api/resources/object_query.py
@@ -38,7 +38,6 @@ import json
 from typing import Any, Optional, Sequence, Tuple
 
 from gramps.gen.proxy.proxybase import ProxyDbBase
-from gramps.plugins.db.dbapi.sqlite import SQLite
 from marshmallow import Schema, ValidationError, validate, validates_schema
 from webargs import fields as wf
 
@@ -85,6 +84,11 @@ from ..auth import require_permissions
 from ..blueprint import api_blueprint
 from ..util import abort_with_message, get_db_handle, get_locale_for_language
 from . import ProtectedResource
+from .db_backend import (
+    SHARED_POSTGRES_CLASS_NAME,
+    SINGLE_TREE_POSTGRES_CLASS_NAME,
+    is_sqlite,
+)
 from .schemas import ObjectQueryResponseSchema
 
 
@@ -733,18 +737,6 @@ _DIALECT_BY_NAME: dict[str, Dialect] = {
 }
 
 
-# Backends known to have no `treeid`/dialect concept of their own, checked
-# by class *name* rather than `isinstance` -- see `_resolve_dialect`'s
-# docstring for why `isinstance` is unreliable for a plugin-loaded class.
-_SQLITE_CLASS_NAME = "SQLite"
-_SINGLE_TREE_POSTGRES_CLASS_NAME = "PostgreSQL"
-_SHARED_POSTGRES_CLASS_NAME = "SharedPostgreSQL"
-
-
-def _is_sqlite(basedb: Any) -> bool:
-    return isinstance(basedb, SQLite) or type(basedb).__name__ == _SQLITE_CLASS_NAME
-
-
 def _resolve_dialect(basedb: Any) -> Dialect:
     """Backend SQL dialect for rendering a `JsonPath` (see `query.py`).
 
@@ -770,12 +762,14 @@ def _resolve_dialect(basedb: Any) -> Dialect:
     new backend needs this module updated before structured query works
     against it, rather than working by accident until it doesn't.
 
-    The `SQLite`/`SharedPostgreSQL` checks are by class *name*, not
-    `isinstance`, deliberately: Gramps' plugin loader imports database
-    backend plugins (including core ones) as freestanding modules under a
-    bare name (`sqlite`, not `gramps.plugins.db.dbapi.sqlite`) rather than
-    via a normal package import, so a real request's `basedb` is a
-    *different* class object than this file's own `from
+    The `SQLite`/`SharedPostgreSQL` checks (`is_sqlite`, in `db_backend.py`,
+    shared with `_resolve_treeid` below and `util.py`'s
+    `preload_event_backlinks`) are by class *name*, not `isinstance`,
+    deliberately: Gramps' plugin loader imports database backend plugins
+    (including core ones) as freestanding modules under a bare name
+    (`sqlite`, not `gramps.plugins.db.dbapi.sqlite`) rather than via a
+    normal package import, so a real request's `basedb` is a *different*
+    class object than `db_backend.py`'s own `from
     gramps.plugins.db.dbapi.sqlite import SQLite` -- same name, same
     behavior, different identity. `isinstance(basedb, SQLite)` silently
     returns `False` for it every time, which was live (not just
@@ -795,10 +789,10 @@ def _resolve_dialect(basedb: Any) -> Dialect:
         dialect = _DIALECT_BY_NAME.get(name)
         if dialect is not None:
             return dialect
-    if _is_sqlite(basedb):
+    if is_sqlite(basedb):
         return Dialect.SQLITE
     class_name = type(basedb).__name__
-    if class_name in (_SINGLE_TREE_POSTGRES_CLASS_NAME, _SHARED_POSTGRES_CLASS_NAME):
+    if class_name in (SINGLE_TREE_POSTGRES_CLASS_NAME, SHARED_POSTGRES_CLASS_NAME):
         return Dialect.POSTGRESQL
     abort_with_message(
         501,
@@ -837,7 +831,7 @@ def _resolve_treeid(basedb: Any) -> Optional[int]:
     if treeid is not None:
         return treeid
     class_name = type(basedb).__name__
-    if _is_sqlite(basedb) or class_name == _SINGLE_TREE_POSTGRES_CLASS_NAME:
+    if is_sqlite(basedb) or class_name == SINGLE_TREE_POSTGRES_CLASS_NAME:
         return None
     abort_with_message(
         501,

--- a/gramps_webapi/api/resources/util.py
+++ b/gramps_webapi/api/resources/util.py
@@ -274,12 +274,59 @@ def get_participant_from_event_localized(
     return participant
 
 
+def preload_event_backlinks(
+    db_handle: DbReadBase,
+) -> Optional[dict[Handle, list[tuple[str, Handle]]]]:
+    """Bulk-load every Event's (obj_class, obj_handle) backlinks in one
+    query, for get_event_participants_for_handle() to consult via
+    `backlink_index` instead of calling find_backlink_handles() once per
+    event -- see that function's docstring, and search/indexer.py's
+    reindex_full(), the intended caller (many events, each needing its
+    own participant list, in one pass).
+
+    Reaches into db_handle.dbapi directly rather than going through
+    find_backlink_handles() event by event, so only DBAPI-backed
+    backends (sqlite, postgresql, sharedpostgresql -- anything sharing
+    the reference table's (obj_handle, obj_class, ref_handle, ref_class)
+    shape) support this. Returns None for anything else (no `dbapi`
+    attribute), so callers must fall back to the per-event query path on
+    a None result.
+    """
+    dbapi = getattr(db_handle, "dbapi", None)
+    if dbapi is None:
+        return None
+    treeid = getattr(dbapi, "treeid", None)
+    sql = "SELECT ref_handle, obj_class, obj_handle FROM reference WHERE ref_class = ?"
+    params: list = ["Event"]
+    if treeid is not None:
+        sql += " AND treeid = ?"
+        params.append(treeid)
+    index: dict[Handle, list[tuple[str, Handle]]] = {}
+    with dbapi.cursor() as cur:
+        cur.execute(sql, params)
+        while True:
+            rows = cur.fetchmany()
+            if not rows:
+                break
+            for ref_handle, obj_class, obj_handle in rows:
+                index.setdefault(ref_handle, []).append((obj_class, obj_handle))
+    return index
+
+
 def get_event_participants_for_handle(
     db_handle: DbReadBase,
     handle: Handle,
     locale: GrampsLocale = glocale,
+    backlink_index: Optional[dict[Handle, list[tuple[str, Handle]]]] = None,
 ) -> dict[Literal["people", "families"], list[tuple[EventRoleType, Person | Family]]]:
-    """Get event participants given a handle."""
+    """Get event participants given a handle.
+
+    `backlink_index`, if given (see preload_event_backlinks()), is
+    consulted instead of calling db_handle.find_backlink_handles() --
+    useful for a caller that looks up participants for many events in
+    one pass (e.g. a full search reindex), where querying per event
+    would otherwise mean one query per event in the tree.
+    """
     result: dict[
         Literal["people", "families"], list[tuple[EventRoleType, Person | Family]]
     ] = {
@@ -287,9 +334,14 @@ def get_event_participants_for_handle(
         "families": [],
     }
     seen = set()  # to avoid duplicates
-    for class_name, backref_handle in db_handle.find_backlink_handles(
-        handle, include_classes=["Person", "Family"]
-    ):
+    backrefs = (
+        backlink_index.get(handle, [])
+        if backlink_index is not None
+        else db_handle.find_backlink_handles(
+            handle, include_classes=["Person", "Family"]
+        )
+    )
+    for class_name, backref_handle in backrefs:
         if backref_handle in seen:
             continue
         seen.add(backref_handle)

--- a/gramps_webapi/api/resources/util.py
+++ b/gramps_webapi/api/resources/util.py
@@ -89,23 +89,11 @@ from ..util import (
     get_db_handle,
     get_tree_from_jwt,
 )
+from .db_backend import SINGLE_TREE_DBAPI_CLASS_NAMES
 
 pd = PlaceDisplay()
 _ = glocale.translation.gettext
 _LOG = logging.getLogger(__name__)
-
-# Single-tree-per-database DBAPI backends whose `.dbapi` has no `treeid`
-# because there's only ever one tree in the database -- checked by class
-# *name*, not `isinstance`, since Gramps' plugin loader imports database
-# backend plugins as freestanding modules under a bare name, so a real
-# request's `db_handle` is a different class object than one imported
-# directly here (see object_query.py's `_resolve_dialect` docstring for
-# the full explanation of why `isinstance` is unreliable for this check).
-# Used by preload_event_backlinks() to decide when a missing `treeid`
-# safely means "no tree scoping needed" versus "unknown backend, don't
-# guess" -- mirrors object_query.py's `_resolve_treeid()`, which faces
-# the identical hazard for its own raw SQL against `.dbapi`.
-_SINGLE_TREE_DBAPI_CLASS_NAMES = frozenset({"SQLite", "PostgreSQL"})
 
 
 def get_person_by_handle(db_handle: DbReadBase, handle: Handle) -> Union[Person, dict]:
@@ -323,8 +311,10 @@ def preload_event_backlinks(
     Tree scoping: a `.dbapi.treeid` (SharedPostgreSQL) scopes the query
     explicitly. Its absence is only trusted to mean "no tree scoping
     needed" for the known single-tree-per-database backends in
-    `_SINGLE_TREE_DBAPI_CLASS_NAMES` (SQLite, the single-user PostgreSQL
-    addon) -- anything else falls back to `None` (the safe, per-event
+    `db_backend.SINGLE_TREE_DBAPI_CLASS_NAMES` (SQLite, the single-user
+    PostgreSQL addon; shared with object_query.py's `_resolve_treeid()`,
+    which faces the identical hazard for its own raw SQL against
+    `.dbapi`) -- anything else falls back to `None` (the safe, per-event
     path) rather than guessing, since guessing wrong here means silently
     mixing another tenant's event participants into this tree's index,
     not just an error.
@@ -335,7 +325,7 @@ def preload_event_backlinks(
     treeid = getattr(dbapi, "treeid", None)
     if (
         treeid is None
-        and type(db_handle).__name__ not in _SINGLE_TREE_DBAPI_CLASS_NAMES
+        and type(db_handle).__name__ not in SINGLE_TREE_DBAPI_CLASS_NAMES
     ):
         return None
     sql = "SELECT ref_handle, obj_class, obj_handle FROM reference WHERE ref_class = ?"

--- a/gramps_webapi/api/resources/util.py
+++ b/gramps_webapi/api/resources/util.py
@@ -92,6 +92,19 @@ pd = PlaceDisplay()
 _ = glocale.translation.gettext
 _LOG = logging.getLogger(__name__)
 
+# Single-tree-per-database DBAPI backends whose `.dbapi` has no `treeid`
+# because there's only ever one tree in the database -- checked by class
+# *name*, not `isinstance`, since Gramps' plugin loader imports database
+# backend plugins as freestanding modules under a bare name, so a real
+# request's `db_handle` is a different class object than one imported
+# directly here (see object_query.py's `_resolve_dialect` docstring for
+# the full explanation of why `isinstance` is unreliable for this check).
+# Used by preload_event_backlinks() to decide when a missing `treeid`
+# safely means "no tree scoping needed" versus "unknown backend, don't
+# guess" -- mirrors object_query.py's `_resolve_treeid()`, which faces
+# the identical hazard for its own raw SQL against `.dbapi`.
+_SINGLE_TREE_DBAPI_CLASS_NAMES = frozenset({"SQLite", "PostgreSQL"})
+
 
 def get_person_by_handle(db_handle: DbReadBase, handle: Handle) -> Union[Person, dict]:
     """Safe get person by handle."""
@@ -291,11 +304,25 @@ def preload_event_backlinks(
     shape) support this. Returns None for anything else (no `dbapi`
     attribute), so callers must fall back to the per-event query path on
     a None result.
+
+    Tree scoping: a `.dbapi.treeid` (SharedPostgreSQL) scopes the query
+    explicitly. Its absence is only trusted to mean "no tree scoping
+    needed" for the known single-tree-per-database backends in
+    `_SINGLE_TREE_DBAPI_CLASS_NAMES` (SQLite, the single-user PostgreSQL
+    addon) -- anything else falls back to `None` (the safe, per-event
+    path) rather than guessing, since guessing wrong here means silently
+    mixing another tenant's event participants into this tree's index,
+    not just an error.
     """
     dbapi = getattr(db_handle, "dbapi", None)
     if dbapi is None:
         return None
     treeid = getattr(dbapi, "treeid", None)
+    if (
+        treeid is None
+        and type(db_handle).__name__ not in _SINGLE_TREE_DBAPI_CLASS_NAMES
+    ):
+        return None
     sql = "SELECT ref_handle, obj_class, obj_handle FROM reference WHERE ref_class = ?"
     params: list = ["Event"]
     if treeid is not None:

--- a/gramps_webapi/api/resources/util.py
+++ b/gramps_webapi/api/resources/util.py
@@ -293,12 +293,18 @@ def get_participant_from_event_localized(
 def preload_event_backlinks(
     db_handle: DbReadBase,
 ) -> Optional[dict[Handle, list[tuple[str, Handle]]]]:
-    """Bulk-load every Event's (obj_class, obj_handle) backlinks in one
-    query, for get_event_participants_for_handle() to consult via
-    `backlink_index` instead of calling find_backlink_handles() once per
-    event -- see that function's docstring, and search/indexer.py's
-    reindex_full(), the intended caller (many events, each needing its
-    own participant list, in one pass).
+    """Bulk-load every Event's Person/Family (obj_class, obj_handle)
+    backlinks in one query, for get_event_participants_for_handle() to
+    consult via `backlink_index` instead of calling find_backlink_handles()
+    once per event -- see that function's docstring, and
+    search/indexer.py's reindex_full(), the intended caller (many events,
+    each needing its own participant list, in one pass).
+
+    Filtered to obj_class Person/Family at the SQL level: those are the
+    only classes get_event_participants_for_handle() ever consults (only
+    Person and Family carry an EventRef), so anything else referencing an
+    Event -- there isn't any today, but nothing enforces that -- would
+    otherwise inflate the in-memory index for rows no caller reads.
 
     Reaches into db_handle.dbapi directly rather than going through
     find_backlink_handles() event by event, so only DBAPI-backed
@@ -328,7 +334,15 @@ def preload_event_backlinks(
         and type(db_handle).__name__ not in SINGLE_TREE_DBAPI_CLASS_NAMES
     ):
         return None
-    sql = "SELECT ref_handle, obj_class, obj_handle FROM reference WHERE ref_class = ?"
+    # obj_class filter matches find_backlink_handles(include_classes=[...])'s
+    # scope in get_event_participants_for_handle(): only Person/Family carry
+    # an EventRef, so only those obj_class rows are ever consulted. A
+    # literal IN-list (not a bound param) since the values are fixed, not
+    # user input -- keeps the param list identical to an unfiltered query.
+    sql = (
+        "SELECT ref_handle, obj_class, obj_handle FROM reference "
+        "WHERE ref_class = ? AND obj_class IN ('Person', 'Family')"
+    )
     params: list = ["Event"]
     if treeid is not None:
         sql += " AND treeid = ?"

--- a/gramps_webapi/api/search/indexer.py
+++ b/gramps_webapi/api/search/indexer.py
@@ -153,9 +153,16 @@ class SearchIndexerBase:
             if i % chunk_size == 0 and i != 0:
                 self._add_objects(obj_dicts)
                 obj_dicts = []
-            if progress_cb:
-                progress_cb(current=i, total=total, prev=prev)
-            prev = i
+                # Tied to the same chunk_size cadence as the indexing
+                # flush above, not called every single object: each call
+                # is a Celery update_state() (JSON-encode + a Redis
+                # round trip), and for a tree with hundreds of thousands
+                # of objects, calling this per-object turns a ~1-minute
+                # reindex into one dominated by hundreds of thousands of
+                # Redis writes instead of the indexing work itself.
+                if progress_cb:
+                    progress_cb(current=i, total=total, prev=prev)
+                prev = i
         self._add_objects(obj_dicts)
         if progress_cb:
             progress_cb(current=total - 1, total=total)

--- a/gramps_webapi/api/search/indexer.py
+++ b/gramps_webapi/api/search/indexer.py
@@ -225,6 +225,23 @@ class SearchIndexerBase:
         self, db_handle: DbReadBase, progress_cb: ProgressCallback | None = None
     ):
         """Update the index incrementally."""
+        if self.index.count() == 0:
+            # Empty index -- every object in db_handle is "new", so this
+            # call is really a full reindex (e.g. right after a bulk
+            # import into a previously-empty tree). The path below fetches
+            # each new/changed object individually by handle
+            # (obj_strings_from_handle -> get_<class>_from_handle: one DB
+            # round trip per object, before even counting the extra
+            # per-object lookups object_to_strings() does for
+            # Family/Event parent and participant names). reindex_full()
+            # instead streams every object via the DB's own bulk iterators
+            # (iter_people() etc. -- one query per object type, not one
+            # per object), which is what it's already built for. For a
+            # tree with hundreds of thousands of objects fresh off a bulk
+            # import, that's the difference between roughly ten queries
+            # and potentially millions of individual round trips.
+            self.reindex_full(db_handle, progress_cb=progress_cb)
+            return
         update_info = self._get_update_info(db_handle)
         total = sum(
             len(handles)

--- a/gramps_webapi/api/search/indexer.py
+++ b/gramps_webapi/api/search/indexer.py
@@ -153,16 +153,9 @@ class SearchIndexerBase:
             if i % chunk_size == 0 and i != 0:
                 self._add_objects(obj_dicts)
                 obj_dicts = []
-                # Tied to the same chunk_size cadence as the indexing
-                # flush above, not called every single object: each call
-                # is a Celery update_state() (JSON-encode + a Redis
-                # round trip), and for a tree with hundreds of thousands
-                # of objects, calling this per-object turns a ~1-minute
-                # reindex into one dominated by hundreds of thousands of
-                # Redis writes instead of the indexing work itself.
-                if progress_cb:
-                    progress_cb(current=i, total=total, prev=prev)
-                prev = i
+            if progress_cb:
+                progress_cb(current=i, total=total, prev=prev)
+            prev = i
         self._add_objects(obj_dicts)
         if progress_cb:
             progress_cb(current=total - 1, total=total)

--- a/gramps_webapi/api/search/text.py
+++ b/gramps_webapi/api/search/text.py
@@ -39,7 +39,7 @@ from gramps.gen.lib.primaryobj import BasicPrimaryObject as GrampsObject
 from unidecode import unidecode
 
 from ...const import GRAMPS_OBJECT_PLURAL, PRIMARY_GRAMPS_OBJECTS
-from ..resources.util import get_event_participants_for_handle
+from ..resources.util import get_event_participants_for_handle, preload_event_backlinks
 from .text_semantic import (
     person_to_text,
     family_to_text,
@@ -53,13 +53,22 @@ from .text_semantic import (
 )
 
 
-def object_to_strings(obj: GrampsObject, db_handle: DbReadBase) -> Tuple[str, str]:
+def object_to_strings(
+    obj: GrampsObject,
+    db_handle: DbReadBase,
+    backlink_index: Optional[Dict[Any, Any]] = None,
+) -> Tuple[str, str]:
     """Create strings from a Gramps object's textual pieces.
 
     This function returns a tuple of two strings: the first one contains
     the concatenated string of the object and the strings of all
     non-private child objects. The second contains the concatenated
-    strings of the objects and all non-private *and* private child objects."""
+    strings of the objects and all non-private *and* private child objects.
+
+    `backlink_index`, if given, is passed through to
+    get_event_participants_for_handle() -- see that function's and
+    preload_event_backlinks()'s docstrings. Pass None (the default) for
+    a one-off call on a single object."""
     strings = obj.get_text_data_list()
     private_strings = []
     if hasattr(obj, "gramps_id") and obj.gramps_id not in strings:
@@ -75,7 +84,9 @@ def object_to_strings(obj: GrampsObject, db_handle: DbReadBase) -> Tuple[str, st
                 text_data_child_list.append(parent_obj.get_primary_name())
     # event: add primary/family role participants' names
     if isinstance(obj, Event):
-        participants = get_event_participants_for_handle(db_handle, obj.handle)
+        participants = get_event_participants_for_handle(
+            db_handle, obj.handle, backlink_index=backlink_index
+        )
         for role, person in participants["people"]:
             if role.is_primary():
                 text_data_child_list.append(person.get_primary_name())
@@ -170,13 +181,19 @@ def obj_strings_from_handle(
 
 
 def obj_strings_from_object(
-    db_handle: DbReadBase, class_name: str, obj: GrampsObject, semantic: bool = False
+    db_handle: DbReadBase,
+    class_name: str,
+    obj: GrampsObject,
+    semantic: bool = False,
+    backlink_index: Optional[Dict[Any, Any]] = None,
 ) -> Optional[Dict[str, Any]]:
     """Return object strings from a handle and Gramps class name."""
     if semantic:
         obj_string_public, obj_string_all = object_to_strings_semantic(obj, db_handle)
     else:
-        obj_string_public, obj_string_all = object_to_strings(obj, db_handle)
+        obj_string_public, obj_string_all = object_to_strings(
+            obj, db_handle, backlink_index=backlink_index
+        )
     private = hasattr(obj, "private") and obj.private
     if obj_string_all:
         return {
@@ -194,13 +211,23 @@ def iter_obj_strings(
     db_handle: DbReadBase, semantic: bool = False
 ) -> Generator[Dict[str, Any], None, None]:
     """Iterate over object strings in the whole database."""
+    # One query for every event's backlinks instead of one query per
+    # event (a full pass processes every event) -- see
+    # preload_event_backlinks()'s docstring. None (its fallback for a
+    # backend gramps-web-api doesn't control) just means
+    # get_event_participants_for_handle() queries per event as before.
+    backlink_index = preload_event_backlinks(db_handle)
     for class_name in PRIMARY_GRAMPS_OBJECTS:
         plural_name = GRAMPS_OBJECT_PLURAL[class_name]
         iter_method = db_handle.method("iter_%s", plural_name)
         assert iter_method is not None  # type checker
         for obj in iter_method():
             obj_strings = obj_strings_from_object(
-                db_handle, class_name, obj, semantic=semantic
+                db_handle,
+                class_name,
+                obj,
+                semantic=semantic,
+                backlink_index=backlink_index,
             )
             if obj_strings:
                 yield obj_strings

--- a/gramps_webapi/api/search/text.py
+++ b/gramps_webapi/api/search/text.py
@@ -216,7 +216,11 @@ def iter_obj_strings(
     # preload_event_backlinks()'s docstring. None (its fallback for a
     # backend gramps-web-api doesn't control) just means
     # get_event_participants_for_handle() queries per event as before.
-    backlink_index = preload_event_backlinks(db_handle)
+    # Only worth building for the non-semantic path: obj_strings_from_object()
+    # routes a semantic pass through object_to_strings_semantic(), which
+    # never receives backlink_index, so building it here would pay the
+    # full reference-table scan for a dict nothing consults.
+    backlink_index = None if semantic else preload_event_backlinks(db_handle)
     for class_name in PRIMARY_GRAMPS_OBJECTS:
         plural_name = GRAMPS_OBJECT_PLURAL[class_name]
         iter_method = db_handle.method("iter_%s", plural_name)

--- a/gramps_webapi/api/tasks.py
+++ b/gramps_webapi/api/tasks.py
@@ -225,8 +225,30 @@ def _search_reindex_full(
 
 
 def progress_callback_count(self, title: str = "", message: str = "") -> Callable:
+    """Build a progress callback that reports via Celery's `update_state()`.
+
+    Throttled to (at most) one report per integer percentage point, the
+    same way `__main__.py`'s CLI `progress_callback_count_factory` throttles
+    its logging: `pct`/`pct_prev` are derived from `current`/`total` alone,
+    with `prev` defaulting to `current - 1` when a caller doesn't pass one.
+    That makes the throttle self-contained -- a producer that calls back
+    once per object with no `prev` (most of them: check.py, media.py,
+    media_importer.py, delete.py, restore.py, and reindex_incremental's own
+    per-object loop) still collapses to ~100 `update_state()` calls
+    regardless of tree size, each one a JSON-encode plus a Redis round
+    trip. A producer that *does* pass real `prev` values (reindex_full,
+    batched by chunk_size) throttles the same way, just computed from its
+    own strides instead of single-object steps.
+    """
+
     def callback(current: int, total: int, prev: int | None = None) -> None:
         if total == 0 or self.request.id is None:
+            return
+        pct = int(100 * current / total)
+        if prev is None:
+            prev = current - 1
+        pct_prev = int(100 * prev / total)
+        if current != 0 and pct == pct_prev:
             return
         self.update_state(
             state="PROGRESS",

--- a/tests/test_endpoints/test_search.py
+++ b/tests/test_endpoints/test_search.py
@@ -99,6 +99,72 @@ class TestSearchEngine(unittest.TestCase):
         )
 
 
+class TestSearchReindexIncrementalOnEmptyIndex(unittest.TestCase):
+    """reindex_incremental() on a never-before-indexed tree.
+
+    Unlike TestSearchEngine, this class builds a fresh SearchIndexer
+    whose index is still empty (count() == 0) when reindex_incremental()
+    is called -- the case the automatic post-import reindex actually
+    hits, and the one that routes to reindex_full() internally instead
+    of the per-object diff-and-update path.
+    """
+
+    def setUp(self):
+        """Create a fresh, empty index for each test."""
+        self.index_dir = tempfile.mkdtemp()
+        self.dbmgr = WebDbManager(name="example_gramps", create_if_missing=False)
+        db_url = f"sqlite:///{self.index_dir}/search_index.db"
+        self.search = SearchIndexer(self.dbmgr.dirname, db_url)
+
+    def tearDown(self):
+        """Remove the temporary index directory."""
+        shutil.rmtree(self.index_dir)
+
+    def test_empty_index_is_fully_indexed_and_searchable(self):
+        """reindex_incremental() on an empty index indexes every object."""
+        self.assertEqual(self.search.index.count(), 0)
+        db = self.dbmgr.get_db().db
+        self.search.reindex_incremental(db)
+        db.close()
+        self.assertGreater(self.search.index.count(), 0)
+        total, rv = self.search.search("I0044", page=1, pagesize=10)
+        self.assertEqual(len(rv), 1)
+        # event participants (see get_event_participants_for_handle /
+        # preload_event_backlinks) must be indexed too, not just skipped
+        # because the fast bulk path was taken.
+        total, rv = self.search.search("Lewis von", page=1, pagesize=20)
+        self.assertEqual(
+            {(hit["object_type"], hit["handle"]) for hit in rv},
+            {
+                ("person", "GNUJQCL9MD64AM56OH"),
+                ("family", "9OUJQCBOHW9UEK9CNV"),
+                ("note", "d0436be64ac277b615b79b34e72"),
+                ("event", "a5af0ecb107303354a0"),
+                ("event", "a5af0ecb11f5ac3110e"),
+                ("event", "a5af0ecb12e29af8a5d"),
+                ("event", "a5af0ed5df832ee65c1"),
+            },
+        )
+
+    def test_empty_index_throttles_progress_callback(self):
+        """reindex_incremental() on an empty index reports progress at the
+        reindex_full() chunk cadence, not once per object."""
+        calls = []
+
+        def progress_cb(current, total, prev=None):
+            calls.append(current)
+
+        db = self.dbmgr.get_db().db
+        self.search.reindex_incremental(db, progress_cb=progress_cb)
+        db.close()
+        object_count = self.search.index.count()
+        self.assertGreater(object_count, 0)
+        # Unthrottled (per-object) reporting would call back once per
+        # object; the chunked cadence calls back a small, bounded number
+        # of times regardless of tree size.
+        self.assertLess(len(calls), object_count)
+
+
 class TestSearch(unittest.TestCase):
     """Test cases for the /api/search endpoint for full-text searches."""
 

--- a/tests/test_endpoints/test_search.py
+++ b/tests/test_endpoints/test_search.py
@@ -146,9 +146,13 @@ class TestSearchReindexIncrementalOnEmptyIndex(unittest.TestCase):
             },
         )
 
-    def test_empty_index_throttles_progress_callback(self):
-        """reindex_incremental() on an empty index reports progress at the
-        reindex_full() chunk cadence, not once per object."""
+    def test_empty_index_reports_progress_per_object(self):
+        """reindex_incremental() on an empty index still reports progress
+        for every object indexed via reindex_full()'s own per-object
+        progress_cb() calls -- throttling that reporting down to Celery's
+        actual Redis writes is progress_callback_count()'s job (see
+        tests/test_tasks.py), not something reindex_full() should do to
+        every caller regardless of how it's consumed."""
         calls = []
 
         def progress_cb(current, total, prev=None):
@@ -159,10 +163,9 @@ class TestSearchReindexIncrementalOnEmptyIndex(unittest.TestCase):
         db.close()
         object_count = self.search.index.count()
         self.assertGreater(object_count, 0)
-        # Unthrottled (per-object) reporting would call back once per
-        # object; the chunked cadence calls back a small, bounded number
-        # of times regardless of tree size.
-        self.assertLess(len(calls), object_count)
+        # One call per object, plus reindex_full()'s own final call after
+        # the loop (current=total - 1, matching the last object's index).
+        self.assertEqual(len(calls), object_count + 1)
 
 
 class TestSearch(unittest.TestCase):

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -22,7 +22,7 @@
 import logging
 from unittest.mock import MagicMock
 
-from gramps_webapi.api.tasks import _index_objects
+from gramps_webapi.api.tasks import _index_objects, progress_callback_count
 
 TRANS_DICT = [
     {"handle": "aaaa1111", "_class": "Person"},
@@ -87,3 +87,54 @@ def test_index_objects_indexes_every_object():
     assert [call.args[0] for call in indexer.add_or_update_object.call_args_list] == [
         obj["handle"] for obj in TRANS_DICT
     ]
+
+
+def _make_task():
+    task = MagicMock()
+    task.request.id = "task-id"
+    return task
+
+
+def test_progress_callback_count_throttles_per_object_calls():
+    """A producer that calls back once per object with no `prev` (every
+    producer feeding this callback except reindex_full: check_database,
+    the media/media_importer/delete/restore tasks, and reindex_incremental's
+    own per-object loop) must still collapse to about one update_state()
+    call per integer percentage point, not one Redis write per object."""
+    task = _make_task()
+    callback = progress_callback_count(task, title="Reindexing")
+
+    total = 10_000
+    for current in range(total):
+        callback(current=current, total=total)
+
+    assert task.update_state.call_count < 150
+    assert task.update_state.call_count == len(
+        {int(100 * current / total) for current in range(total)}
+    )
+
+
+def test_progress_callback_count_throttles_explicit_prev():
+    """A producer that passes real `prev` values (reindex_full, batched by
+    chunk_size) is throttled from those strides instead."""
+    task = _make_task()
+    callback = progress_callback_count(task)
+
+    callback(current=0, total=1000, prev=None)
+    assert task.update_state.call_count == 1
+    callback(current=5, total=1000, prev=0)  # still inside the 0% bucket
+    assert task.update_state.call_count == 1
+    callback(current=10, total=1000, prev=5)  # crosses into the 1% bucket
+    assert task.update_state.call_count == 2
+
+
+def test_progress_callback_count_noop_without_task_id():
+    """No Celery request in flight (e.g. a task invoked synchronously in
+    tests) means update_state() would have nothing to attach to."""
+    task = _make_task()
+    task.request.id = None
+    callback = progress_callback_count(task)
+
+    callback(current=0, total=100)
+
+    task.update_state.assert_not_called()

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -435,3 +435,103 @@ def test_validate_object_dict_accepts_reference_with_target():
     }
     with Flask(__name__).app_context():
         validate_object_dict(fix_object_dict(obj_dict))
+
+
+class _FakeCursor:
+    """Minimal stand-in for the DBAPI Cursor context manager."""
+
+    def __init__(self, batches):
+        self._batches = list(batches)
+        self.executed = None
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        return False
+
+    def execute(self, sql, params):
+        self.executed = (sql, list(params))
+
+    def fetchmany(self):
+        if self._batches:
+            return self._batches.pop(0)
+        return []
+
+
+class _FakeDbapi:
+    """Minimal stand-in for `db_handle.dbapi`, with an optional `treeid`."""
+
+    def __init__(self, batches, treeid=None):
+        self._cursor = _FakeCursor(batches)
+        if treeid is not None:
+            self.treeid = treeid
+
+    def cursor(self):
+        return self._cursor
+
+
+def test_preload_event_backlinks_no_dbapi_returns_none():
+    """A backend with no `.dbapi` at all (not DBAPI-backed) is unsupported."""
+    from gramps_webapi.api.resources.util import preload_event_backlinks
+
+    class NoDbapiBackend:
+        pass
+
+    assert preload_event_backlinks(NoDbapiBackend()) is None
+
+
+def test_preload_event_backlinks_sqlite_queries_unscoped():
+    """SQLite is single-tree-per-database, so no `treeid` filter is added."""
+    from gramps_webapi.api.resources.util import preload_event_backlinks
+
+    class SQLite:
+        def __init__(self, dbapi):
+            self.dbapi = dbapi
+
+    dbapi = _FakeDbapi(batches=[[("h1", "Person", "p1"), ("h1", "Family", "f1")], []])
+    result = preload_event_backlinks(SQLite(dbapi))
+
+    assert result == {"h1": [("Person", "p1"), ("Family", "f1")]}
+    sql, params = dbapi._cursor.executed
+    assert "treeid" not in sql
+    assert params == ["Event"]
+
+
+def test_preload_event_backlinks_sharedpostgresql_scopes_by_treeid():
+    """SharedPostgreSQL shares tables across trees, so `treeid` must be used."""
+    from gramps_webapi.api.resources.util import preload_event_backlinks
+
+    class SharedPostgreSQL:
+        def __init__(self, dbapi):
+            self.dbapi = dbapi
+
+    dbapi = _FakeDbapi(batches=[[("h1", "Person", "p1")], []], treeid=7)
+    result = preload_event_backlinks(SharedPostgreSQL(dbapi))
+
+    assert result == {"h1": [("Person", "p1")]}
+    sql, params = dbapi._cursor.executed
+    assert "treeid" in sql
+    assert params == ["Event", 7]
+
+
+def test_preload_event_backlinks_unknown_backend_without_treeid_returns_none():
+    """An unrecognized DBAPI-backed backend with no `treeid` must not be
+    queried unscoped.
+
+    Only SQLite and the single-user PostgreSQL addon are known to be
+    single-tree-per-database; guessing that any other backend lacking a
+    `treeid` is also single-tree would risk silently mixing another
+    tenant's event participants into this tree's search index if that
+    guess is wrong. The safe fallback is to decline the optimization
+    (return None) so the caller uses the always-correct per-event
+    find_backlink_handles() path instead.
+    """
+    from gramps_webapi.api.resources.util import preload_event_backlinks
+
+    class SomeFutureSharedBackend:
+        def __init__(self, dbapi):
+            self.dbapi = dbapi
+
+    dbapi = _FakeDbapi(batches=[[("h1", "Person", "p1")], []])
+    assert preload_event_backlinks(SomeFutureSharedBackend(dbapi)) is None


### PR DESCRIPTION
## Summary
- **Progress-callback throttling.** The Celery-facing callback (`progress_callback_count` in `tasks.py`) called `update_state()` (a JSON-encode plus a Redis round trip) on **every single object**, with no throttling. For a tree with hundreds of thousands of objects, this alone dominates reindex time with Redis writes rather than actual indexing work. `progress_callback_count` now throttles itself to (at most) one report per integer percentage point, the same way `__main__.py`'s CLI callback already does — this fixes every producer feeding it (`reindex_full`, `reindex_incremental`, `check_database`, the media/media_importer/delete/restore tasks), not just `reindex_full()`, and keeps 1% progress granularity instead of collapsing to ~10 updates.
- **Bulk-load event backlinks.** Building an `Event`'s indexable text calls `find_backlink_handles()` to find its participants — previously once per event (one query per event in the whole tree). `preload_event_backlinks()` bulk-loads every event's Person/Family backlinks in a single query up front instead, for the backends gramps-web-api controls (sqlite/postgresql/sharedpostgresql); anything else falls back to the previous per-event query path via a `None` result. Only built for the non-semantic reindex path (the semantic path never consults it).
- **Route `reindex_incremental()` to `reindex_full()` when the index starts empty.** The other two fixes only matter if `reindex_full()` is actually reached — but the automatic post-import reindex (`import_file()`) always calls `reindex_incremental()`, never `reindex_full()` directly. Without this, a fresh/empty index still does a per-object diff-and-update pass (`obj_strings_from_handle()`: one `get_<class>_from_handle()` round trip per object, plus the same unthrottled progress reporting) even though every object is "new". `reindex_full()` instead streams every object via the DB's own bulk iterators (`iter_people()` etc. — one query per object type, not one per object). This is the fix that makes the first two actually fire during a normal import into an empty tree.
- **Fail closed on unrecognized backends in `preload_event_backlinks()`.** It treated a missing `.dbapi.treeid` as "no tree scoping needed", the same as sqlite/single-user PostgreSQL. For any other DBAPI-backed backend this codebase doesn't already know about, that's an unverified guess: `object_query.py`'s `_resolve_treeid()` faces the identical hazard for its own raw SQL against `.dbapi` and deliberately doesn't make it, aborting instead for anything it can't positively identify as single-tree. `preload_event_backlinks()` now only trusts a missing `treeid` for the known single-tree classes (`SQLite`, `PostgreSQL`, shared with `object_query.py` via `db_backend.py`) and falls back to `None` — the always-correct per-event `find_backlink_handles()` path — for anything else, rather than risking another tenant's event participants leaking into this tree's search index.

## Measured impact
On an 847k-object synthetic tree imported into a real (non-localhost) SharedPostgreSQL instance (with all three perf fixes, plus an unmerged bulk-import path not part of this PR), the reindex phase went from ~410s to ~300s, with `find_backlink_handles()` dropping from ~30% to ~5% of profiler samples (stack sampling via py-spy).

Separately re-measured after the review-fix commit, against an 849k-object tree already sitting in a local Postgres instance (`SharedPostgreSQL`, same class of tree, isolating just the backlink-preload effect): full `reindex_full()` went from 201.3s (master, 331,066 `find_backlink_handles()` calls) to 160.0s (this branch, 0 calls) — a 20.5% reduction. Progress-throttling is covered separately by unit tests (`test_tasks.py`), not re-benchmarked against real Celery/Redis in this run. See PR comments for the full numbers on both this tree and `example_gramps`.

## Test plan
- [x] `tests/test_endpoints/test_search.py` — including `test_reindexing`, and a new `TestSearchReindexIncrementalOnEmptyIndex` class that builds a genuinely empty index and calls `reindex_incremental()` on it, asserting it correctly routes to `reindex_full()` and indexes everything (including event participants) — the exact case neither this class's own pre-existing tests nor the CLI's `index-incremental` test exercised (both only ever call it after the index was already populated by a prior full reindex)
- [x] `tests/test_util.py` — new `preload_event_backlinks()` unit tests: no `.dbapi` at all, sqlite querying unscoped, sharedpostgresql scoping by `treeid`, and the fail-closed case for an unrecognized backend without a `treeid` (this last one reproduces the leak and fails without the fix)
- [x] `tests/test_tasks.py` — new `progress_callback_count()` unit tests: throttles a producer that calls back once per object with no `prev`, throttles a producer that passes explicit `prev` (chunked, like `reindex_full`), and is a no-op with no Celery request in flight
- [x] `tests/test_search_metadata.py` (16 tests) — passing
- [x] Manual end-to-end timing against a real SharedPostgreSQL deployment (Docker) with an 847k-object tree, and again locally against an 849k-object tree after the review-fix commit (see Measured impact)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G5KppLuQPf6dNRakLUmZWZ