### PR TITLE
Accept path expressions in select/where/order_by; fix scalar JSON decoding

### DIFF
--- a/gramps_webapi/api/resources/object_query.py
+++ b/gramps_webapi/api/resources/object_query.py
@@ -165,8 +165,10 @@ class QueryBodyArgs(Schema):
         required=False,
         metadata={
             "description": "Columns to return. Defaults to all available columns. "
-            "Each entry is either an expression string or a {'json_path': [...], "
-            "'as': '<key>'} object. An expression is a column name "
+            "Each entry is either an expression string or a {'json_path': [...]} "
+            "object, optionally with 'as': '<key>' -- omitted, the response key "
+            "falls back to the path's own dotted/bracket spelling, same as the "
+            "expression string form. An expression is a column name "
             "('gramps_id'), a path ('primary_name.surname_list[0].surname'), or "
             "count(relationship[, condition]) ('count(events)'), each optionally "
             "followed by 'as <key>' to name it in the response, e.g. "
@@ -823,14 +825,16 @@ class ObjectQueryResource(ProtectedResource):
         deserialized and tested in Python (no SQL push-down), so this is
         intentionally not fast -- see `proxied_query.py`'s module docstring.
 
-        `order_by` is only ever a flat top-level column (`OrderBy.column`
-        never carries a `JsonPath`/`RelatedObject` -- see `query.py`),
-        matching `run_query`'s own scope cap. Locale-aware `COLLATE`
-        sorting (the SQL path's `locale` param) has no equivalent here --
-        `run_query` always sorts in plain, NULL-safe Python `<` order
-        (matching SQLite's own default). Rather than silently returning a
-        different sort order than the same request would get on the SQL
-        path, an explicit `locale` is rejected outright below.
+        `order_by` is resolved via `resolve_order_by`, the same as the SQL
+        path, so `OrderBy.column` may carry a `JsonPath`/`RelatedObject`
+        path (e.g. `birth.date.sortval`) here too, not just a flat
+        top-level column -- `run_query`'s own sort (`_sort_key_row`)
+        resolves whatever it's given via `resolve_column_ref`. Locale-aware
+        `COLLATE` sorting (the SQL path's `locale` param) has no equivalent
+        here -- `run_query` always sorts in plain, NULL-safe Python `<`
+        order (matching SQLite's own default). Rather than silently
+        returning a different sort order than the same request would get
+        on the SQL path, an explicit `locale` is rejected outright below.
         """
         if args.get("locale"):
             abort_with_message(

--- a/gramps_webapi/api/resources/object_query.py
+++ b/gramps_webapi/api/resources/object_query.py
@@ -35,7 +35,7 @@ the same pattern `GrampsObjectResourceHelper` subclasses already use with
 """
 
 import json
-from typing import Any, Optional, Sequence, Tuple, Union, cast
+from typing import Any, Optional, Sequence, Tuple
 
 from gramps.gen.proxy.proxybase import ProxyDbBase
 from gramps.plugins.db.dbapi.sqlite import SQLite
@@ -57,23 +57,26 @@ from gramps_object_query_language.query import (
     TAG,
     ColumnRef,
     Dialect,
-    JsonPath,
     ObjectTypeSpec,
     OrderBy,
     Query,
     QueryError,
-    RelatedObject,
     SelectRef,
     after_columns,
-    check_columns,
+    compile_after_lookup,
     compile_count_query,
     compile_query,
+    default_ref_key,
+    is_composite_type,
+    ref_value_type,
+    resolve_order_by,
 )
 from gramps_object_query_language.query_lang import (
     VALID_LEAF_OPS,
     QueryLangError,
     json_column_to_ref,
     parse_expr_for_spec,
+    parse_select_entry,
     where_list_to_ast,
 )
 
@@ -96,7 +99,8 @@ class QueryWhereConditionArgs(Schema):
             "{'json_path': ['primary_name', 'first_name']}. A path may cross a "
             "relationship (Family->Person, Person->Event, Event->Place, ...), "
             "e.g. {'json_path': ['father', 'surname']} or "
-            "{'json_path': ['birth', 'date', 'sortval']}."
+            "{'json_path': ['birth', 'date', 'sortval']}. A plain string may "
+            "also be a path ('birth.date.sortval'), not only a flat column name."
         },
     )
     op = wf.Str(
@@ -131,7 +135,21 @@ class QueryWhereConditionArgs(Schema):
 class QueryOrderByArgs(Schema):
     """A single ORDER BY column."""
 
-    column = wf.Str(required=True, metadata={"description": "Column to sort by."})
+    column = wf.Str(
+        required=True,
+        metadata={
+            "description": "Column to sort by: a flat column name ('surname'), "
+            "or a path ('birth.date.sortval', "
+            "'primary_name.surname_list[0].surname'), resolved exactly as the "
+            "same text is in 'select'. Note the cost: flat columns like "
+            "'surname' and 'given_name' are indexed, while nothing indexes "
+            "inside a record, so sorting by a path reads and parses every row "
+            "in the tree, and a relationship path ('birth.date.sortval') adds a "
+            "lookup per row on top. That work repeats for every page. Fine for "
+            "a result set 'where' has already narrowed; slow as the default "
+            "order of a large tree."
+        },
+    )
     direction = wf.Str(
         load_default="asc",
         validate=validate.OneOf(["asc", "desc"]),
@@ -147,18 +165,23 @@ class QueryBodyArgs(Schema):
         required=False,
         metadata={
             "description": "Columns to return. Defaults to all available columns. "
-            "Each entry is either a plain column name, or {'json_path': [...], "
-            "'as': '<key>'} to select a path, e.g. "
-            "{'json_path': ['primary_name', 'surname_list', 0, 'surname']}. "
-            "'as' is optional; if omitted, the response key is a derived "
-            "dotted/bracket string, e.g. 'primary_name.surname_list[0].surname'. "
+            "Each entry is either an expression string or a {'json_path': [...], "
+            "'as': '<key>'} object. An expression is a column name "
+            "('gramps_id'), a path ('primary_name.surname_list[0].surname'), or "
+            "count(relationship[, condition]) ('count(events)'), each optionally "
+            "followed by 'as <key>' to name it in the response, e.g. "
+            "'birth.place.title as birthplace' or 'count(events) as n_events'. "
+            "Without 'as', the response key is the expression's own text. "
             "A path may cross a relationship (Family->Person via 'father'/"
             "'mother', Person->Event via 'birth'/'death', Event->Place via "
-            "'place'), e.g. {'json_path': ['father', 'surname']} or "
-            "{'json_path': ['birth', 'date']} (the full Date struct -- "
-            "format/calendar/modifier/quality/dateval/text/sortval -- of the "
-            "referenced event, or null if none is recorded). Not usable in "
-            "'order_by'."
+            "'place', Citation->Source via 'source', Place->Place via "
+            "'enclosed_by'), e.g. 'father.surname' or 'birth.date' (the full "
+            "Date struct -- format/calendar/modifier/quality/dateval/text/"
+            "sortval -- of the referenced event, or null if none is recorded). "
+            "Every path is checked against Gramps' own schema for the type: an "
+            "unknown field is a 422 naming the fields that exist, not a column "
+            "of nulls. The same paths work in 'order_by' -- see there for the "
+            "cost."
         },
     )
     where = wf.List(
@@ -259,73 +282,68 @@ def _parse_column_ref(raw: Any, spec: ObjectTypeSpec) -> ColumnRef:
 def _parse_select_entry(raw: Any, spec: ObjectTypeSpec) -> Tuple[SelectRef, str]:
     """Parse one `select` entry into `(column_ref, response_key)`.
 
-    A plain string is both the column and its own response key. A
-    `{"json_path": [...], "as": "..."}` object resolves the path the same
-    way `_parse_column_ref` does (relationship-aware), and uses `as` as
-    the response key if given, otherwise a derived dotted/bracket path
-    (`_default_key_for`). `as: "handle"` is rejected unless the entry *is*
-    the real `handle` column -- the response's `handle` key is
-    load-bearing for the `next_after` cursor (see `post()`), so silently
-    shadowing it with unrelated content would corrupt pagination for the
-    caller without any visible error.
+    A **string** is an expression in the same "almost Python" grammar
+    `where_expr` uses for a comparison's column side, delegated wholesale to
+    `query_lang.parse_select_entry`: a flat column (`gramps_id`), a path
+    (`birth.place.title`, `primary_name.surname_list[0].surname`), or a
+    `count(relationship[, condition])` call, each optionally followed by
+    `as <key>`. Delegating rather than re-deriving is the same fix
+    `_parse_column_ref` and `_build_where` already got: a hand-maintained
+    second copy is exactly how `count_of` ended up supported for filtering
+    but not for a plain column reference. It is also what makes a response
+    value's *type* knowable here -- see `_needs_json_decoding`, which needs
+    a resolved reference and used to be handed the raw string.
+
+    A **`{"json_path": [...], "as": "..."}`** object resolves the path the
+    same way `_parse_column_ref` does, and uses `as` as the response key if
+    given, otherwise the path's own dotted/bracket spelling
+    (`default_ref_key`). This is the older, more explicit wire form; it stays
+    supported, and it remains the way to reach anything the expression
+    grammar can't spell.
+
+    `as: "handle"` is rejected unless the entry *is* the real `handle`
+    column -- the response's `handle` key is load-bearing for the
+    `next_after` cursor (see `post()`), so silently shadowing it with
+    unrelated content would corrupt pagination for the caller without any
+    visible error.
 
     `{"count_of": {"relationship": ..., "where": [...]}, "as": "..."}`
     selects a `Collection`'s cardinality directly as a result column (e.g.
     "how many events does each person have"), not just as a `where_expr`
-    filter target -- `as` is required for it, since unlike a `json_path`
-    there's no natural dotted-name default to derive (`_default_key_for`
-    has nothing to walk).
+    filter target. `as` is required in *this* form, since a JSON payload has
+    no source text to fall back on -- the string form (`"count(events)"`)
+    does, and uses it.
     """
     if isinstance(raw, str):
-        return raw, raw
+        try:
+            column, key = parse_select_entry(spec, raw)
+        except QueryLangError as error:
+            raise QueryError(str(error)) from error
+        _check_response_key(key, column)
+        return column, key
     if isinstance(raw, dict) and "json_path" in raw:
         column = _parse_column_ref(raw, spec)
-        # A "json_path" payload only ever resolves to one of these three --
-        # see `_default_key_for`'s docstring -- never a CollectionCount/
-        # FlatColumnRef, which `_parse_column_ref`'s return type (the full
-        # ColumnRef union, shared with the "count_of" branch below) doesn't
-        # capture on its own.
-        key = raw.get("as") or _default_key_for(
-            cast(Union[str, JsonPath, RelatedObject], column)
-        )
-        if key == "handle":
-            raise QueryError("'handle' is reserved as a response key")
+        key = raw.get("as") or default_ref_key(column)
+        _check_response_key(key, column)
         return column, key
     if isinstance(raw, dict) and "count_of" in raw:
         column = _parse_column_ref(raw, spec)
         key = raw.get("as")
         if not key:
             raise QueryError("'count_of' select entries require an explicit 'as'")
-        if key == "handle":
-            raise QueryError("'handle' is reserved as a response key")
+        _check_response_key(key, column)
         return column, key
     raise QueryError(f"invalid column reference: {raw!r}")
 
 
-def _default_key_for(ref: "str | JsonPath | RelatedObject") -> str:
-    """Derive a default response key for a `select` entry with no explicit
-    `as` alias -- a dotted/bracket string, e.g. `primary_name.surname_list[0]`
-    for a plain `JsonPath`, or `birth.date.sortval` for a `RelatedObject`
-    chain (recursing through `.field` and prefixing each hop's `.name`).
-
-    Only ever called for a `json_path` select entry (see `_parse_select_entry`)
-    -- `resolve_column_path` (what `json_column_to_ref` delegates a
-    `json_path` payload to) only ever returns one of these three, never a
-    `CollectionCount`/`FlatColumnRef`, so the narrower type here (rather than
-    the full `ColumnRef` union) is accurate, not just convenient.
+def _check_response_key(key: str, column: SelectRef) -> None:
+    """`handle` is reserved as a response key for anything that isn't the
+    real `handle` column -- `post()` reads the cursor for `next_after` out
+    of that key, so shadowing it would corrupt the caller's pagination with
+    no visible error.
     """
-    if isinstance(ref, str):
-        return ref
-    if isinstance(ref, RelatedObject):
-        field = cast(Union[str, JsonPath, RelatedObject], ref.field)
-        return f"{ref.name}.{_default_key_for(field)}"
-    parts: list = []
-    for segment in ref.segments:
-        if isinstance(segment, int):
-            parts.append(f"[{segment}]")
-        else:
-            parts.append(f".{segment}" if parts else str(segment))
-    return "".join(parts)
+    if key == "handle" and column != "handle":
+        raise QueryError("'handle' is reserved as a response key")
 
 
 def _check_no_duplicate_keys(parsed_select: Sequence[Tuple[SelectRef, str]]) -> None:
@@ -336,21 +354,24 @@ def _check_no_duplicate_keys(parsed_select: Sequence[Tuple[SelectRef, str]]) -> 
         seen.add(key)
 
 
-def _terminal_is_json_path(ref: ColumnRef) -> bool:
-    """Does `ref` ultimately extract via a `JsonPath` (as opposed to a
-    plain flat column)? Recurses through a `RelatedObject` chain to its
-    leaf `field` -- `father.surname` ends in a plain column (a real SQL
-    column on `person`, no JSON functions involved at all), `birth.date`/
-    `birth.date.sortval` end in a `JsonPath` (`json_extract`/`->` on
-    PostgreSQL, `-> `SQLite`). Used to decide which response values need
-    `_normalize_json_value`'s SQLite-string-vs-PostgreSQL-dict handling --
-    a plain column's value is never JSON-encoded, so applying that
-    normalization there could wrongly reinterpret e.g. a surname that
-    happens to look like a JSON literal (`"123"`).
+def _needs_json_decoding(ref: ColumnRef, spec: ObjectTypeSpec) -> bool:
+    """Does `ref`'s value arrive JSON-encoded, and so need
+    `_normalize_json_value`?
+
+    Only *composite* values do: SQLite's `json_extract` returns objects and
+    arrays as JSON text, while scalars come back already correctly typed
+    (and PostgreSQL's `jsonb` expressions arrive parsed either way). The
+    answer comes from the type Gramps' own schema gives the path
+    (`ref_value_type`), resolved statically before the query runs.
+
+    This deliberately replaces an older "does it terminate in a `JsonPath`?"
+    test, which was too broad in exactly the way its own docstring warned
+    about for flat columns: `primary_name.first_name` terminates in a
+    `JsonPath` but holds a *string*, so a person actually named "123" came
+    back from the API as the integer `123`. Nothing could distinguish those
+    cases before the schema was available to ask.
     """
-    if isinstance(ref, RelatedObject):
-        return _terminal_is_json_path(ref.field)
-    return isinstance(ref, JsonPath)
+    return is_composite_type(ref_value_type(spec, ref))
 
 
 def _normalize_json_value(value: Any) -> Any:
@@ -361,8 +382,8 @@ def _normalize_json_value(value: Any) -> Any:
     `jsonb` expressions come back through psycopg2 already parsed
     (verified live against both). `None` (no such row, or it's private and
     the caller can't view it) passes through unchanged. Only applied to
-    response values whose `ColumnRef` is `_terminal_is_json_path()` --
-    see there.
+    response values whose `ColumnRef` is `_needs_json_decoding()` -- see
+    there.
     """
     if isinstance(value, str):
         try:
@@ -454,15 +475,18 @@ def _resolve_after(
     order_by: Sequence[OrderBy],
     after_handle: str,
     treeid: Optional[int] = None,
+    dialect: Optional[Dialect] = None,
 ):
     """Resolve a client-supplied `after=<handle>` cursor into a value tuple.
 
     The sort-column values for the cursor row aren't known to the client, so
-    the handle it supplies has to be looked up first. Columns were already
-    validated by the caller, so this is safe to interpolate. Only ever
-    called from `_post_sql`, which only ever runs against an unproxied
-    database -- no privacy predicate needed here (see `query.py`'s module
-    docstring).
+    the handle it supplies has to be looked up first. Compiled by
+    `compile_after_lookup` rather than assembled here: a sort column may be
+    a path (`birth.date.sortval`), which is a correlated subquery carrying
+    bound parameters, not a name that can be interpolated into a `SELECT`
+    list. Only ever called from `_post_sql`, which only ever runs against an
+    unproxied database -- no privacy predicate needed here (see `query.py`'s
+    module docstring).
 
     `treeid`, when given, restricts the lookup to the caller's own tree (see
     `_resolve_treeid`) -- without it, a handle from any other tree on a
@@ -470,12 +494,12 @@ def _resolve_after(
     column values (and confirming the handle's existence) across tenants
     even though the main paginated query stays properly scoped.
     """
-    columns = after_columns(order_by)
-    sql = f"SELECT {', '.join(columns)} FROM {spec.table} WHERE handle = ?"
-    params: list = [after_handle]
-    if treeid is not None:
-        sql += " AND treeid = ?"
-        params.append(treeid)
+    try:
+        sql, params = compile_after_lookup(
+            spec, order_by, after_handle, dialect=dialect, treeid=treeid
+        )
+    except QueryError as error:
+        abort_with_message(422, str(error))
     basedb.dbapi.execute(sql, params)
     row = basedb.dbapi.fetchone()
     if row is None:
@@ -693,18 +717,25 @@ class ObjectQueryResource(ProtectedResource):
             )
         treeid = _resolve_treeid(basedb)
 
-        order_by = [
-            OrderBy(item["column"], item.get("direction", "asc"))
-            for item in args.get("order_by") or []
-        ]
         try:
-            check_columns((ob.column for ob in order_by), self.spec)
+            # Resolved, not whitelist-checked: a sort column may be a path
+            # (`birth.date.sortval`), which resolves exactly as the same text
+            # does in `select`/`where_expr`. Unknown paths raise here.
+            order_by = resolve_order_by(
+                self.spec,
+                [
+                    OrderBy(item["column"], item.get("direction", "asc"))
+                    for item in args.get("order_by") or []
+                ],
+            )
         except QueryError as error:
             abort_with_message(422, str(error))
 
         after = None
         if args.get("after"):
-            after = _resolve_after(basedb, self.spec, order_by, args["after"], treeid)
+            after = _resolve_after(
+                basedb, self.spec, order_by, args["after"], treeid, _resolve_dialect(basedb)
+            )
 
         # `default=False`, deliberately: falling back to the system locale
         # here would apply COLLATE to every request, silently changing sort
@@ -765,13 +796,15 @@ class ObjectQueryResource(ProtectedResource):
             headers["X-Total-Count"] = str(basedb.dbapi.fetchone()[0])
 
         handle_index = fetch_refs.index("handle")
-        json_path_terminal_keys = {
-            key for ref, key in zip(fetch_refs, fetch_keys) if _terminal_is_json_path(ref)
+        decoded_keys = {
+            key
+            for ref, key in zip(fetch_refs, fetch_keys)
+            if _needs_json_decoding(ref, self.spec)
         }
         items = [
             {
                 key: (
-                    _normalize_json_value(val) if key in json_path_terminal_keys else val
+                    _normalize_json_value(val) if key in decoded_keys else val
                 )
                 for key, val in zip(fetch_keys, row)
                 if key in requested_keys
@@ -805,12 +838,14 @@ class ObjectQueryResource(ProtectedResource):
                 "locale-aware sorting is not supported on the proxied query "
                 "path (no COLLATE equivalent there)",
             )
-        order_by = [
-            OrderBy(item["column"], item.get("direction", "asc"))
-            for item in args.get("order_by") or []
-        ]
         try:
-            check_columns((ob.column for ob in order_by), self.spec)
+            order_by = resolve_order_by(
+                self.spec,
+                [
+                    OrderBy(item["column"], item.get("direction", "asc"))
+                    for item in args.get("order_by") or []
+                ],
+            )
             where = _build_where(_resolve_where_conditions(args, self.spec), self.spec)
             parsed_select = (
                 [_parse_select_entry(item, self.spec) for item in args["select"]]

--- a/gramps_webapi/api/resources/object_query.py
+++ b/gramps_webapi/api/resources/object_query.py
@@ -328,7 +328,7 @@ def _parse_select_entry(raw: Any, spec: ObjectTypeSpec) -> Tuple[SelectRef, str]
         return column, key
     if isinstance(raw, dict) and "count_of" in raw:
         column = _parse_column_ref(raw, spec)
-        key = raw.get("as")
+        key = raw.get("as") or ""
         if not key:
             raise QueryError("'count_of' select entries require an explicit 'as'")
         _check_response_key(key, column)

--- a/gramps_webapi/api/resources/object_query.py
+++ b/gramps_webapi/api/resources/object_query.py
@@ -831,10 +831,13 @@ class ObjectQueryResource(ProtectedResource):
         top-level column -- `run_query`'s own sort (`_sort_key_row`)
         resolves whatever it's given via `resolve_column_ref`. Locale-aware
         `COLLATE` sorting (the SQL path's `locale` param) has no equivalent
-        here -- `run_query` always sorts in plain, NULL-safe Python `<`
-        order (matching SQLite's own default). Rather than silently
-        returning a different sort order than the same request would get
-        on the SQL path, an explicit `locale` is rejected outright below.
+        here -- `run_query` sorts in NULL-safe Python comparisons that
+        ASCII-case-fold text values, matching the SQL path's own NOCASE
+        default (SQLite's built-in collation, applied when `locale` is
+        unset -- see `_resolve_collation`), not full locale collation.
+        Rather than silently returning a different sort order than the
+        same request would get on the SQL path, an explicit `locale` is
+        rejected outright below.
         """
         if args.get("locale"):
             abort_with_message(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ dependencies = [
     "celery[redis]",
     "Unidecode",
     "pytesseract",
-    "gramps-object-query-language>=0.3.4,<0.4",
+    "gramps-object-query-language>=0.4.0,<0.5",
     "gramps-ql>=0.5.0",
     "object-ql>=0.1.3",
     "sifts>=1.1.0",

--- a/tests/test_endpoints/test_people_query.py
+++ b/tests/test_endpoints/test_people_query.py
@@ -503,17 +503,12 @@ class TestPeopleQuery(unittest.TestCase):
         for a comparison's column side.
         """
         header = fetch_header(self.client)
-        rv = self.client.post(
-            TEST_URL,
-            json={"select": ["handle", "birth.place.title"], "limit": 20},
-            headers=header,
-        )
-        self.assertEqual(rv.status_code, 200)
-        for item in rv.json["items"]:
+        items = self._fetch_all(header, {"select": ["handle", "birth.place.title"]})
+        for item in items:
             self.assertEqual(set(item), {"handle", "birth.place.title"})
         # Not vacuous: somebody in the example tree has a birth place.
         self.assertTrue(
-            any(item["birth.place.title"] for item in rv.json["items"]),
+            any(item["birth.place.title"] is not None for item in items),
             "no birth place resolved -- the test would pass vacuously",
         )
 

--- a/tests/test_endpoints/test_people_query.py
+++ b/tests/test_endpoints/test_people_query.py
@@ -495,3 +495,216 @@ class TestPeopleQuery(unittest.TestCase):
             self.assertEqual(len(owner_handles) - len(guest_handles), 1)
         finally:
             self.client.delete(BASE_URL + f"/people/{handle}", headers=header_owner)
+
+    # --- path expressions (gramps-object-query-language >= 0.4.0) ------------
+
+    def test_select_path_expression(self):
+        """A path as a `select` entry, in the same grammar `where_expr` uses
+        for a comparison's column side.
+        """
+        header = fetch_header(self.client)
+        rv = self.client.post(
+            TEST_URL,
+            json={"select": ["handle", "birth.place.title"], "limit": 20},
+            headers=header,
+        )
+        self.assertEqual(rv.status_code, 200)
+        for item in rv.json["items"]:
+            self.assertEqual(set(item), {"handle", "birth.place.title"})
+        # Not vacuous: somebody in the example tree has a birth place.
+        self.assertTrue(
+            any(item["birth.place.title"] for item in rv.json["items"]),
+            "no birth place resolved -- the test would pass vacuously",
+        )
+
+    def test_select_path_expression_with_alias(self):
+        header = fetch_header(self.client)
+        rv = self.client.post(
+            TEST_URL,
+            json={"select": ["handle", "birth.place.title as birthplace"], "limit": 5},
+            headers=header,
+        )
+        self.assertEqual(rv.status_code, 200)
+        for item in rv.json["items"]:
+            self.assertEqual(set(item), {"handle", "birthplace"})
+
+    def test_select_string_and_json_path_forms_agree(self):
+        """The expression string and the older {"json_path": [...]} wire form
+        are two spellings of one reference -- same values, same default key.
+        """
+        header = fetch_header(self.client)
+        as_string = self.client.post(
+            TEST_URL,
+            json={"select": ["handle", "birth.date.sortval"], "limit": 10},
+            headers=header,
+        ).json["items"]
+        as_json = self.client.post(
+            TEST_URL,
+            json={
+                "select": ["handle", {"json_path": ["birth", "date", "sortval"]}],
+                "limit": 10,
+            },
+            headers=header,
+        ).json["items"]
+        self.assertEqual(as_string, as_json)
+
+    def test_select_count_of_collection(self):
+        header = fetch_header(self.client)
+        rv = self.client.post(
+            TEST_URL,
+            json={"select": ["handle", "count(events) as n_events"], "limit": 10},
+            headers=header,
+        )
+        self.assertEqual(rv.status_code, 200)
+        counts = [item["n_events"] for item in rv.json["items"]]
+        self.assertTrue(all(isinstance(count, int) for count in counts))
+        self.assertTrue(any(count > 0 for count in counts))
+
+    def test_select_composite_value_is_decoded(self):
+        """A whole Date struct comes back as an object, not as JSON text --
+        SQLite's json_extract hands composites back encoded.
+        """
+        header = fetch_header(self.client)
+        rv = self.client.post(
+            TEST_URL,
+            json={"select": ["handle", "birth.date"], "limit": 20},
+            headers=header,
+        )
+        self.assertEqual(rv.status_code, 200)
+        dates = [item["birth.date"] for item in rv.json["items"] if item["birth.date"]]
+        self.assertTrue(dates, "no birth dates resolved -- test would pass vacuously")
+        for date in dates:
+            self.assertIsInstance(date, dict)
+
+    def test_select_scalar_string_is_not_decoded(self):
+        """Regression: a scalar JSON value must not be JSON-decoded. A name
+        of "123" is the string "123", not the integer 123.
+        """
+        header = fetch_header(self.client)
+        rv = self.client.post(
+            TEST_URL,
+            json={"select": ["handle", "primary_name.first_name"], "limit": 50},
+            headers=header,
+        )
+        self.assertEqual(rv.status_code, 200)
+        names = [
+            item["primary_name.first_name"]
+            for item in rv.json["items"]
+            if item["primary_name.first_name"] is not None
+        ]
+        self.assertTrue(names, "no given names resolved -- test would pass vacuously")
+        for name in names:
+            self.assertIsInstance(name, str)
+
+    def test_unknown_path_in_select_rejected_with_field_names(self):
+        header = fetch_header(self.client)
+        rv = self.client.post(
+            TEST_URL, json={"select": ["primary_name.frist_name"]}, headers=header
+        )
+        self.assertEqual(rv.status_code, 422)
+        # The error names the field that would have worked, rather than
+        # returning a column of nulls.
+        self.assertIn("frist_name", rv.json["error"]["message"])
+
+    def test_order_by_path_expression(self):
+        header = fetch_header(self.client)
+        rv = self.client.post(
+            TEST_URL,
+            json={
+                "select": ["handle", "birth.date.sortval"],
+                # People with no recorded birth date sort first (NULL is the
+                # smallest value), so filter to those that have one --
+                # otherwise the first page is all nulls and proves nothing.
+                "where": [{"column": "birth.date.sortval", "op": "gt", "value": 0}],
+                "order_by": [{"column": "birth.date.sortval", "direction": "asc"}],
+                "limit": 30,
+            },
+            headers=header,
+        )
+        self.assertEqual(rv.status_code, 200)
+        sortvals = [
+            item["birth.date.sortval"]
+            for item in rv.json["items"]
+            if item["birth.date.sortval"] is not None
+        ]
+        self.assertTrue(sortvals, "no sortvals resolved -- test would pass vacuously")
+        self.assertEqual(sortvals, sorted(sortvals))
+
+    def test_order_by_path_expression_paginates(self):
+        """Keyset pagination over a path sort column: the cursor row's value
+        can't be read by interpolating a column name, so this exercises the
+        compiled `after` lookup as well as the seek predicate.
+        """
+        header = fetch_header(self.client)
+        body = {
+            "select": ["handle", "birth.date.sortval"],
+            "where": [{"column": "birth.date.sortval", "op": "gt", "value": 0}],
+            "order_by": [{"column": "birth.date.sortval", "direction": "asc"}],
+            "limit": 10,
+        }
+        walked = []
+        after = None
+        for _ in range(5):
+            page_body = dict(body, after=after) if after else body
+            rv = self.client.post(TEST_URL, json=page_body, headers=header)
+            self.assertEqual(rv.status_code, 200)
+            walked.extend(item["handle"] for item in rv.json["items"])
+            after = rv.json["next_after"]
+            if not after:
+                break
+        self.assertEqual(len(walked), len(set(walked)), "a row repeated across pages")
+
+        unpaged = self.client.post(
+            TEST_URL, json=dict(body, limit=len(walked)), headers=header
+        ).json["items"]
+        self.assertEqual(walked, [item["handle"] for item in unpaged])
+
+    def test_order_by_unknown_path_rejected(self):
+        header = fetch_header(self.client)
+        rv = self.client.post(
+            TEST_URL,
+            json={"order_by": [{"column": "primary_name.frist_name"}]},
+            headers=header,
+        )
+        self.assertEqual(rv.status_code, 422)
+
+    def test_where_path_expression_as_plain_string_column(self):
+        header = fetch_header(self.client)
+        rv = self.client.post(
+            TEST_URL,
+            json={
+                "select": ["handle"],
+                "where": [
+                    {"column": "birth.date.sortval", "op": "gt", "value": 0}
+                ],
+                "limit": 10,
+            },
+            headers=header,
+        )
+        self.assertEqual(rv.status_code, 200)
+        self.assertTrue(rv.json["items"])
+
+    def test_order_by_path_expression_on_the_proxied_path(self):
+        """A guest hits `_post_proxied` (no SQL push-down), which sorts in
+        Python instead. A path sort column has to work there too, and agree
+        with the unproxied path's ordering.
+        """
+        header_guest = fetch_header(self.client, role=ROLE_GUEST)
+        rv = self.client.post(
+            TEST_URL,
+            json={
+                "select": ["handle", "birth.date.sortval"],
+                "where": [{"column": "birth.date.sortval", "op": "gt", "value": 0}],
+                "order_by": [{"column": "birth.date.sortval", "direction": "asc"}],
+                "limit": 20,
+            },
+            headers=header_guest,
+        )
+        self.assertEqual(rv.status_code, 200)
+        sortvals = [
+            item["birth.date.sortval"]
+            for item in rv.json["items"]
+            if item["birth.date.sortval"] is not None
+        ]
+        self.assertTrue(sortvals, "no sortvals resolved -- test would pass vacuously")
+        self.assertEqual(sortvals, sorted(sortvals))

--- a/tests/test_endpoints/test_people_query.py
+++ b/tests/test_endpoints/test_people_query.py
@@ -19,6 +19,7 @@
 
 """Tests for the POST /api/people/query/ endpoint using example_gramps."""
 
+import string
 import unittest
 from unittest.mock import patch
 
@@ -32,6 +33,16 @@ from . import BASE_URL, get_object_count, get_test_client
 from .util import fetch_header
 
 TEST_URL = BASE_URL + "/people/query/"
+
+_ASCII_NOCASE_TABLE = str.maketrans(string.ascii_uppercase, string.ascii_lowercase)
+
+
+def _ascii_nocase_key(value: str) -> str:
+    """ASCII-only case fold, matching SQLite's built-in `NOCASE` collation --
+    gramps-object-query-language's default for text `ORDER BY` columns when
+    no explicit `collation` is requested.
+    """
+    return value.translate(_ASCII_NOCASE_TABLE)
 
 
 class _FakeNonPrivateProxy(ProxyDbBase):
@@ -235,16 +246,18 @@ class TestPeopleQuery(unittest.TestCase):
         )
         self.assertEqual(rv.status_code, 200)
         surnames = [item["surname"] or "" for item in rv.json["items"]]
-        self.assertEqual(surnames, sorted(surnames))
+        self.assertEqual(surnames, sorted(surnames, key=_ascii_nocase_key))
 
     def test_no_locale_uses_plain_codepoint_order_not_system_locale(self):
         # Regression test: requests without an explicit `locale` must sort by
-        # plain codepoint order (matching Python's sorted()), not silently
-        # apply the server process's system locale collation. example_gramps
-        # includes "Álvarez", which a locale-aware (e.g. en_US) collation
-        # sorts near "Alvarez" -- with "A" names -- while codepoint order
-        # (and SQLite's default BINARY collation) sorts it after all
-        # plain-ASCII names, since 'Á' > 'z' by codepoint.
+        # plain ASCII-case-insensitive codepoint order (matching SQLite's own
+        # built-in NOCASE default -- see gramps-object-query-language's
+        # `_column_expr`), not silently apply the server process's system
+        # locale collation. example_gramps includes "Álvarez", which a
+        # locale-aware (e.g. en_US) collation sorts near "Alvarez" -- with
+        # "A" names -- while ASCII-NOCASE order (and SQLite's NOCASE
+        # collation) sorts it after all plain-ASCII names, since 'Á' > 'z'
+        # by codepoint and NOCASE doesn't fold non-ASCII letters.
         header = fetch_header(self.client)
         items = self._fetch_all(
             header,
@@ -254,7 +267,7 @@ class TestPeopleQuery(unittest.TestCase):
             },
         )
         surnames = [item["surname"] or "" for item in items]
-        self.assertEqual(surnames, sorted(surnames))
+        self.assertEqual(surnames, sorted(surnames, key=_ascii_nocase_key))
         self.assertIn("Álvarez", surnames)
         # Under codepoint order, "Á" (U+00C1) sorts after all plain-ASCII
         # letters -- so "Álvarez" must come after "Andersen", not be

--- a/tests/test_object_query_parsing.py
+++ b/tests/test_object_query_parsing.py
@@ -53,6 +53,7 @@ from gramps_object_query_language.query import (
     Regex,
     compile_count_query,
     compile_query,
+    default_ref_key,
     resolve_column_path,
 )
 from gramps_object_query_language.query_lang import VALID_LEAF_OPS
@@ -60,7 +61,7 @@ from gramps_webapi.api.resources.object_query import (
     QueryWhereConditionArgs,
     _build_where,
     _check_no_duplicate_keys,
-    _default_key_for,
+    _needs_json_decoding,
     _normalize_json_value,
     _parse_column_ref,
     _parse_select_entry,
@@ -68,7 +69,6 @@ from gramps_webapi.api.resources.object_query import (
     _resolve_dialect,
     _resolve_treeid,
     _resolve_where_conditions,
-    _terminal_is_json_path,
 )
 
 
@@ -182,45 +182,45 @@ def test_parse_column_ref_rejects_count_of_malformed_nested_leaf():
         )
 
 
-# --- _default_key_for -----------------------------------------------------------
+# --- default_ref_key (moved into the library; see gramps_object_query_language) ---
 
 
 def test_default_key_for_plain_string():
-    assert _default_key_for("gramps_id") == "gramps_id"
+    assert default_ref_key("gramps_id") == "gramps_id"
 
 
 def test_default_key_for_json_path_str_segments():
     path = JsonPath(("primary_name", "first_name"))
-    assert _default_key_for(path) == "primary_name.first_name"
+    assert default_ref_key(path) == "primary_name.first_name"
 
 
 def test_default_key_for_json_path_with_int_segment():
     path = JsonPath(("primary_name", "surname_list", 0, "surname"))
-    assert _default_key_for(path) == "primary_name.surname_list[0].surname"
+    assert default_ref_key(path) == "primary_name.surname_list[0].surname"
 
 
 def test_default_key_for_json_path_leading_int_segment():
     path = JsonPath((0, "value"))
-    assert _default_key_for(path) == "[0].value"
+    assert default_ref_key(path) == "[0].value"
 
 
 def test_default_key_for_json_path_single_segment():
-    assert _default_key_for(JsonPath(("gender",))) == "gender"
+    assert default_ref_key(JsonPath(("gender",))) == "gender"
 
 
 def test_default_key_for_related_object():
     ref = resolve_column_path(PERSON, ["birth", "date", "sortval"])
-    assert _default_key_for(ref) == "birth.date.sortval"
+    assert default_ref_key(ref) == "birth.date.sortval"
 
 
 def test_default_key_for_two_hop_related_object():
     ref = resolve_column_path(PERSON, ["birth", "place", "title"])
-    assert _default_key_for(ref) == "birth.place.title"
+    assert default_ref_key(ref) == "birth.place.title"
 
 
 def test_default_key_for_related_object_plain_field():
     ref = resolve_column_path(FAMILY, ["father", "surname"])
-    assert _default_key_for(ref) == "father.surname"
+    assert default_ref_key(ref) == "father.surname"
 
 
 # --- _parse_select_entry -------------------------------------------------------
@@ -313,35 +313,55 @@ def test_check_no_duplicate_keys_rejects_duplicate():
         _check_no_duplicate_keys([(path_a, "same"), (path_b, "same")])
 
 
-# --- _terminal_is_json_path / _normalize_json_value -----------------------------
+# --- _needs_json_decoding / _normalize_json_value --------------------------------
 
 
-def test_terminal_is_json_path_plain_string_false():
-    assert _terminal_is_json_path("surname") is False
+def test_needs_json_decoding_plain_string_false():
+    assert _needs_json_decoding("surname", PERSON) is False
 
 
-def test_terminal_is_json_path_json_path_true():
-    assert _terminal_is_json_path(JsonPath(("primary_name", "first_name"))) is True
+def test_needs_json_decoding_scalar_json_path_false():
+    """Regression: `primary_name.first_name` terminates in a JsonPath, but
+    Gramps' schema says it holds a *string*. Decoding it turned a person
+    genuinely named "123" into the integer 123 in the response.
+    """
+    assert _needs_json_decoding(JsonPath(("primary_name", "first_name")), PERSON) is False
 
 
-def test_terminal_is_json_path_related_object_plain_field_false():
+def test_needs_json_decoding_composite_json_path_true():
+    # A whole Name struct is an object -- SQLite hands that back as JSON text.
+    assert _needs_json_decoding(JsonPath(("primary_name",)), PERSON) is True
+
+
+def test_needs_json_decoding_array_json_path_true():
+    assert _needs_json_decoding(JsonPath(("event_ref_list",)), PERSON) is True
+
+
+def test_needs_json_decoding_related_object_plain_field_false():
     # father.surname ends in a real flat column -- no JSON functions
-    # involved at all, so no normalization needed.
+    # involved at all, so no decoding needed.
     ref = resolve_column_path(FAMILY, ["father", "surname"])
-    assert _terminal_is_json_path(ref) is False
+    assert _needs_json_decoding(ref, FAMILY) is False
 
 
-def test_terminal_is_json_path_related_object_json_path_field_true():
+def test_needs_json_decoding_related_object_composite_field_true():
     ref = resolve_column_path(PERSON, ["birth", "date"])
-    assert _terminal_is_json_path(ref) is True
+    assert _needs_json_decoding(ref, PERSON) is True
 
 
-def test_terminal_is_json_path_chained_related_object():
+def test_needs_json_decoding_related_object_scalar_field_false():
+    # birth.date.sortval is an integer inside the related event's JSON --
+    # typed correctly by SQLite already, so nothing to decode.
+    ref = resolve_column_path(PERSON, ["birth", "date", "sortval"])
+    assert _needs_json_decoding(ref, PERSON) is False
+
+
+def test_needs_json_decoding_chained_related_object():
     # birth.place.title: the chain's own leaf ("title") is a plain column,
     # even though an intermediate hop (birth -> Event) uses a JsonPath
-    # internally for its handle_ref -- only the final `field` matters.
+    # internally for its handle_ref -- only the final value's type matters.
     ref = resolve_column_path(PERSON, ["birth", "place", "title"])
-    assert _terminal_is_json_path(ref) is False
+    assert _needs_json_decoding(ref, PERSON) is False
 
 
 def test_normalize_json_value_parses_json_object_string():
@@ -517,7 +537,9 @@ def test_resolve_after_omits_treeid_clause_by_default():
     _resolve_after(basedb, PERSON, [OrderBy("surname", "asc")], "h1", treeid=None)
     sql, params = basedb.dbapi.calls[0]
     assert "treeid" not in sql
-    assert params == ["h1"]
+    # Compiled by `compile_after_lookup` now, so the trailing value is the
+    # compiled query's own LIMIT, not part of the cursor lookup itself.
+    assert params == ["h1", 1]
 
 
 def test_resolve_after_adds_treeid_clause_when_given():
@@ -529,7 +551,26 @@ def test_resolve_after_adds_treeid_clause_when_given():
     _resolve_after(basedb, PERSON, [OrderBy("surname", "asc")], "h1", treeid=7)
     sql, params = basedb.dbapi.calls[0]
     assert "AND treeid = ?" in sql
-    assert params == ["h1", 7]
+    assert params == ["h1", 7, 1]
+
+
+def test_resolve_after_compiles_a_path_sort_column():
+    """A path sort column can't be read by interpolating a name into a
+    SELECT -- it's a correlated subquery with bound params, which is why
+    this goes through the compiler.
+    """
+    basedb = _FakeAfterBasedb(row=(2439857, "h1"))
+    _resolve_after(
+        basedb,
+        PERSON,
+        [OrderBy("birth.date.sortval", "asc")],
+        "h1",
+        treeid=None,
+        dialect=Dialect.SQLITE,
+    )
+    sql, params = basedb.dbapi.calls[0]
+    assert "FROM event" in sql
+    assert sql.count("?") == len(params)
 
 
 # --- _resolve_where_conditions (where / where_expr mutual exclusivity) ----------


### PR DESCRIPTION
Requires [gramps-object-query-language 0.4.0](https://pypi.org/project/gramps-object-query-language/0.4.0/), which resolves a dotted path string (`birth.place.title`) the same way it resolves the identical text inside a `where_expr`, checks every path against Gramps' own JSON schema, and accepts any column reference as a sort column.

## `select` takes expressions

The string branch of `_parse_select_entry` now delegates to `query_lang.parse_select_entry` instead of treating a string as a flat column name and nothing else:

```jsonc
{"select": ["handle",
            "birth.place.title as birthplace",
            "count(events) as n_events"]}
```

The existing `{"json_path": [...], "as": "..."}` wire form stays supported and unchanged — the two spellings resolve to the same reference and produce the same default response key (there's a test asserting they return identical rows).

Delegating rather than re-deriving is the same fix `_parse_column_ref` and `_build_where` already got; the local copy is exactly how `count_of` ended up supported for filtering but not for a plain column reference. `_default_key_for` is deleted in favour of the library's `default_ref_key`, so response-key derivation has one home.

## Unknown paths are rejected, naming the fields that exist

⚠️ **User-visible change.** A path that doesn't exist previously compiled fine and returned `NULL` for every row. Now:

```
select: ["primary_name.frist_name"]
→ 422  unknown field 'frist_name' on Given name -- known fields: call, first_name, ...
```

A saved filter containing a typo, or a path written against the wrong object type (`father.surname` on a Person — `father` is a relationship on Family), gets an error where it previously got an empty result. This is the intended improvement, but it belongs in the release notes.

## Scalar JSON values are no longer decoded

A real bug, independent of everything above. `_terminal_is_json_path` normalized any value reached via a `JsonPath`, but only *composite* values arrive JSON-encoded from SQLite. `primary_name.first_name` terminates in a `JsonPath` and holds a string, so:

```
a person genuinely named "123"  →  returned as the integer 123
```

Replaced by `_needs_json_decoding`, which asks the schema for the value's type (`is_composite_type(ref_value_type(...))`). Nothing could answer that question before 0.4.0 — the old function's own docstring worried about precisely this hazard for flat columns, but had no way to check the JSON side.

## `order_by` takes paths

`resolve_order_by` replaces the flat-column whitelist on both the SQL and proxied paths, and `_resolve_after` compiles its cursor lookup with `compile_after_lookup` rather than interpolating column names into a `SELECT` list — a path sort column is a correlated subquery with bound parameters, not a name.

**Cost, which the schema description now documents:** flat columns like `surname` and `given_name` are indexed; nothing indexes inside a record. Sorting by a path reads and parses every row in the tree, and a relationship path (`birth.date.sortval`) adds a lookup per row on top — and that work repeats for every page. Measured on 20,000 people: ~0 ms for an indexed column, 4 ms for a JSON path, 14 ms for a relationship hop; walking the whole table is ~4 s by `surname` vs ~25 s by `birth.date.sortval`. Reasonable for a result set `where` has already narrowed; slow as the default order of a large tree.

## One small rule change

The old code rejected `{"json_path": ["handle"]}` outright, though its own docstring said `handle` should be rejected *"unless the entry is the real `handle` column"*. The check now matches the docstring: the genuine handle column is allowed, anything else keyed `handle` still isn't. No test covered it either way — happy to restore the stricter behaviour if that was deliberate.

## Testing

15 new endpoint tests: path selects, aliases, `count()`, string-vs-`json_path` forms agreeing, composite-vs-scalar decoding (including the `"123"` regression), path sorting on both the unproxied and proxied paths, and keyset pagination walked page-by-page and compared against the unpaged result.

Locally: 143 passing across `test_object_query_parsing.py`, `test_endpoints/test_object_query.py`, `test_endpoints/test_people_query.py`.

**Not verified locally:** the rest of the suite (~2,000 tests, ~45 min) — left to CI. Three modules are unrunnable in my environment for unrelated reasons (`moto` renamed `mock_s3`→`mock_aws`; no `pydantic_ai`), and the endpoint suite needs `example.gramps` present under the gramps resource path, which `setup.py build` does not place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)