### PR TITLE
Fixes: Bring where and where_expr in sync, and add backlinks

### DIFF
--- a/gramps_webapi/api/resources/object_query.py
+++ b/gramps_webapi/api/resources/object_query.py
@@ -39,7 +39,7 @@ from typing import Any, Optional, Sequence, Tuple
 
 from gramps.gen.proxy.proxybase import ProxyDbBase
 from gramps.plugins.db.dbapi.sqlite import SQLite
-from marshmallow import Schema, validate
+from marshmallow import Schema, ValidationError, validate, validates_schema
 from webargs import fields as wf
 
 from gramps_object_query_language.evaluator import GETTER_BY_TABLE, resolve_column_ref
@@ -88,11 +88,55 @@ from . import ProtectedResource
 from .schemas import ObjectQueryResponseSchema
 
 
+class QueryExistsPayloadArgs(Schema):
+    """The payload of a WHERE condition node's `exists` combinator --
+    `{"relationship": ..., "where": [...]}`, the same shape `where_expr`'s
+    `exists(relationship, condition)` already produces (see
+    `gramps_object_query_language.query_lang`'s `_node_from_json`). Defined
+    before `QueryWhereConditionArgs` so its own `exists` field can reference
+    this directly, with no forward-reference lambda needed; the reverse
+    reference (`where`, here) still needs one, since `QueryWhereConditionArgs`
+    isn't defined yet at this point in the file.
+    """
+
+    relationship = wf.Str(
+        required=True,
+        metadata={
+            "description": "A registered collection name on the enclosing "
+            "condition's own object type, e.g. 'notes', 'children', "
+            "'backlinks' -- the same names `where_expr`'s `exists(...)`/"
+            "`count(...)` accept."
+        },
+    )
+    where = wf.List(
+        wf.Nested(lambda: QueryWhereConditionArgs()),
+        required=False,
+        metadata={
+            "description": "Condition narrowing which related rows count, "
+            "evaluated against the collection's own target type -- the same "
+            "shape as the outer 'where'. Omitted entirely means 'at least "
+            "one related row at all,' with no further condition."
+        },
+    )
+
+
 class QueryWhereConditionArgs(Schema):
-    """A single WHERE leaf condition."""
+    """A single WHERE condition *node*: either a leaf (`column`+`op`,
+    optionally `value`/`value_column`) or exactly one combinator (`and`/
+    `or`/`not`/`exists`) wrapping further nodes of this same shape -- the
+    same boolean-tree grammar `where_expr` already has (see
+    `gramps_object_query_language.query_lang`'s `where_list_to_ast`/
+    `_node_from_json`, which this schema's output is built to feed
+    unchanged; see `_build_where` below).
+
+    `column`/`op` are optional at the field level (unlike before) because
+    they're only required for a leaf, not a combinator -- that and every
+    other shape rule (`_check_shape` below) needs more than one field's own
+    validators can express on their own, so it's checked cross-field.
+    """
 
     column = wf.Raw(
-        required=True,
+        required=False,
         metadata={
             "description": "Column to compare: either a plain column name (e.g. "
             "'gramps_id'), or {'json_path': [...]} for a path, e.g. "
@@ -100,22 +144,26 @@ class QueryWhereConditionArgs(Schema):
             "relationship (Family->Person, Person->Event, Event->Place, ...), "
             "e.g. {'json_path': ['father', 'surname']} or "
             "{'json_path': ['birth', 'date', 'sortval']}. A plain string may "
-            "also be a path ('birth.date.sortval'), not only a flat column name."
+            "also be a path ('birth.date.sortval'), not only a flat column "
+            "name. Required for a leaf condition (one with no 'and'/'or'/"
+            "'not'/'exists'); not allowed otherwise."
         },
     )
     op = wf.Str(
-        required=True,
+        required=False,
         validate=validate.OneOf(list(VALID_LEAF_OPS)),
         metadata={
             "description": "Comparison operator: eq, ne, lt, lte, gt, gte, like, "
-            "regex, contains, or in."
+            "regex, contains, or in. Required for a leaf condition; not "
+            "allowed otherwise."
         },
     )
     value = wf.Raw(
         required=False,
         metadata={
             "description": "Value to compare against. Must be a list when op is "
-            "'in'. Mutually exclusive with 'value_column'; exactly one is required."
+            "'in'. Mutually exclusive with 'value_column'; for a leaf condition "
+            "exactly one is required."
         },
     )
     value_column = wf.Raw(
@@ -130,6 +178,72 @@ class QueryWhereConditionArgs(Schema):
             "'in'/'like'/'regex'."
         },
     )
+    and_ = wf.List(
+        wf.Nested(lambda: QueryWhereConditionArgs()),
+        required=False,
+        data_key="and",
+        # `attribute` (not just `data_key`) so the *loaded* dict this schema
+        # produces -- what actually reaches _build_where/where_list_to_ast --
+        # is keyed "and", matching the wire shape where_expr's own parser
+        # already emits (query_lang.py's _node_from_json checks `"and" in
+        # node`, never `"and_"`). `and`/`or`/`not` are reserved words only as
+        # Python *identifiers*; a plain string dict key has no such
+        # restriction, so this is legal and does exactly what's needed.
+        attribute="and",
+        metadata={"description": "True only if every condition in this list is."},
+    )
+    or_ = wf.List(
+        wf.Nested(lambda: QueryWhereConditionArgs()),
+        required=False,
+        data_key="or",
+        attribute="or",
+        metadata={"description": "True if any condition in this list is."},
+    )
+    not_ = wf.Nested(
+        lambda: QueryWhereConditionArgs(),
+        required=False,
+        data_key="not",
+        attribute="not",
+        metadata={"description": "True only if the wrapped condition is false."},
+    )
+    exists = wf.Nested(
+        QueryExistsPayloadArgs,
+        required=False,
+        metadata={
+            "description": "True if at least one row in the named collection "
+            "(optionally narrowed by 'where') exists -- the JSON-body "
+            "equivalent of where_expr's exists(relationship[, condition])."
+        },
+    )
+
+    @validates_schema
+    def _check_shape(self, data: dict, **kwargs: Any) -> None:
+        """Exactly one of: a leaf (`column`+`op`), or one combinator key --
+        matching `where_expr`'s own grammar, where a condition is always
+        unambiguously one or the other. `data` is already keyed by each
+        field's `attribute` (`"and"`/`"or"`/`"not"`, not the `and_`/`or_`/
+        `not_` Python names those fields have to use instead of the
+        reserved words -- see those fields' own comments), so these checks
+        and their error messages both use the same spelling a client
+        actually sent.
+        """
+        combinators = [key for key in ("and", "or", "not", "exists") if key in data]
+        if len(combinators) > 1:
+            raise ValidationError(
+                f"at most one of 'and'/'or'/'not'/'exists' is allowed per "
+                f"condition, got: {sorted(combinators)}"
+            )
+        is_leaf_ish = any(key in data for key in ("column", "op", "value", "value_column"))
+        if combinators and is_leaf_ish:
+            raise ValidationError(
+                "a condition can't combine 'and'/'or'/'not'/'exists' with "
+                "'column'/'op'/'value'/'value_column'"
+            )
+        if not combinators and not ("column" in data and "op" in data):
+            raise ValidationError(
+                "a condition must be either a leaf ('column' and 'op' "
+                "required) or exactly one of 'and'/'or'/'not'/'exists'"
+            )
 
 
 class QueryOrderByArgs(Schema):
@@ -189,7 +303,15 @@ class QueryBodyArgs(Schema):
     where = wf.List(
         wf.Nested(QueryWhereConditionArgs),
         required=False,
-        metadata={"description": "Leaf conditions, implicitly combined with AND."},
+        metadata={
+            "description": "Top-level conditions, implicitly combined with AND "
+            "(the list itself is never wrapped in an extra 'and'). Each entry "
+            "is a full condition tree -- a leaf, or an 'and'/'or'/'not'/'exists' "
+            "combinator nesting further conditions of this same shape -- the "
+            "JSON-native equivalent of `where_expr` below (same grammar, two "
+            "wire formats; pick whichever a given client finds easier to "
+            "construct, a string or a JSON tree). See `QueryWhereConditionArgs`."
+        },
     )
     where_expr = wf.Str(
         required=False,
@@ -402,12 +524,13 @@ def _validate_leaf_condition(condition: dict) -> None:
     same reasoning `where`/`where_expr` mutual exclusivity is checked here
     rather than in the schema.
 
-    Only ever applied to a raw, client-submitted `where` JSON leaf (see
-    `_build_where`'s guard) -- a `where_expr`-sourced condition is always
-    well-formed already, by construction of `parse_expr_for_spec`'s own
-    translation, so re-checking it here would be redundant; it's also not
-    always a leaf at all (`or`/`not`/`and`/`exists` nodes have none of
-    `column`/`value`/`value_column`), which this function assumes.
+    Applied to every leaf reachable in a `where` tree, at any depth, by
+    `_validate_where_tree` -- never called directly on something that might
+    not be a leaf (`and`/`or`/`not`/`exists` nodes have none of `column`/
+    `value`/`value_column`), which this function assumes. A `where_expr`
+    -sourced condition is always well-formed already, by construction of
+    `parse_expr_for_spec`'s own translation, so re-checking it here is
+    redundant but harmless, not a correctness requirement of that path.
     """
     has_value = "value" in condition
     has_value_column = "value_column" in condition
@@ -424,25 +547,57 @@ def _validate_leaf_condition(condition: dict) -> None:
             abort_with_message(422, "'in' operator requires a non-empty list value")
 
 
+def _validate_where_tree(conditions: Sequence[dict]) -> None:
+    """Applies `_validate_leaf_condition` to every leaf reachable at *any*
+    depth, not just the top level -- a leaf can now be nested inside `and`/
+    `or`/`not`/`exists`'s own `where` (`QueryWhereConditionArgs`'s
+    combinators), and inside a `count_of` column's own `where` (has been
+    possible since `count(...)` shipped, `column`/`value_column` being
+    untyped `wf.Raw()` -- confirmed live, before this function existed, that
+    a malformed leaf nested there already silently bypassed validation
+    rather than 422ing).
+
+    Recurses into `and`/`or`'s own lists, `not`'s single wrapped condition,
+    `exists.where`, and `count_of.where` reached through either `column` or
+    `value_column` -- every place this schema (or `where_expr`, which
+    reaches this same function) can nest a further condition list.
+    """
+    for condition in conditions:
+        if "column" in condition:
+            _validate_leaf_condition(condition)
+            for column_ref in (condition.get("column"), condition.get("value_column")):
+                if isinstance(column_ref, dict) and "count_of" in column_ref:
+                    _validate_where_tree(column_ref["count_of"].get("where") or [])
+        elif "and" in condition:
+            _validate_where_tree(condition["and"])
+        elif "or" in condition:
+            _validate_where_tree(condition["or"])
+        elif "not" in condition:
+            _validate_where_tree([condition["not"]])
+        elif "exists" in condition:
+            _validate_where_tree(condition["exists"].get("where") or [])
+
+
 def _build_where(conditions: Optional[Sequence[dict]], spec: ObjectTypeSpec):
     """Build a `query.py` WHERE expression from top-level conditions,
     implicitly AND-combined (see `QueryBodyArgs.where`'s docstring).
 
     The actual JSON -> `query.py` AST translation -- leaves, and
-    `where_expr`'s `and`/`or`/`not`/`exists`/`count(...)` nesting, and
-    same-table field-vs-field `FlatColumnRef` wrapping -- is
-    `where_list_to_ast`'s job (gramps_object_query_language.query_lang),
-    not reimplemented here; see that function's docstring for why. Only the
-    leaf-shape validation stays local, since it's specific to the raw,
-    untrusted `where` JSON body (see `_validate_leaf_condition`) -- skipped
-    for anything that isn't a leaf (`or`/`not`/`and`/`exists`, `where_expr`
-    -only shapes the `where` schema can never produce in the first place).
+    `and`/`or`/`not`/`exists`/`count(...)` nesting (now reachable from a raw
+    `where` JSON body the same way `where_expr` always could -- see
+    `QueryWhereConditionArgs`), and same-table field-vs-field
+    `FlatColumnRef` wrapping -- is `where_list_to_ast`'s job
+    (gramps_object_query_language.query_lang), not reimplemented here; see
+    that function's docstring for why. Only the leaf-shape validation stays
+    local, since it's specific to the raw, untrusted `where` JSON body (see
+    `_validate_leaf_condition`/`_validate_where_tree`) -- a `where_expr`
+    -sourced condition is always well-formed already by construction, so
+    this is redundant-but-harmless work for that path, not a correctness
+    requirement of it.
     """
     if not conditions:
         return None
-    for condition in conditions:
-        if "column" in condition:
-            _validate_leaf_condition(condition)
+    _validate_where_tree(conditions)
     try:
         return where_list_to_ast(list(conditions), spec)
     except QueryError as error:

--- a/gramps_webapi/api/resources/object_query.py
+++ b/gramps_webapi/api/resources/object_query.py
@@ -581,7 +581,10 @@ def _validate_where_tree(conditions: Sequence[dict]) -> None:
                     count_of = column_ref["count_of"]
                     if not isinstance(count_of, dict):
                         abort_with_message(422, "'count_of' must be an object")
-                    _validate_where_tree(count_of.get("where") or [])
+                    count_of_where = count_of.get("where")
+                    _validate_where_tree(
+                        [] if count_of_where is None else count_of_where
+                    )
         elif "and" in condition:
             _validate_where_tree(condition["and"])
         elif "or" in condition:
@@ -592,7 +595,8 @@ def _validate_where_tree(conditions: Sequence[dict]) -> None:
             exists = condition["exists"]
             if not isinstance(exists, dict):
                 abort_with_message(422, "'exists' must be an object")
-            _validate_where_tree(exists.get("where") or [])
+            exists_where = exists.get("where")
+            _validate_where_tree([] if exists_where is None else exists_where)
 
 
 def _build_where(conditions: Optional[Sequence[dict]], spec: ObjectTypeSpec):

--- a/gramps_webapi/api/resources/object_query.py
+++ b/gramps_webapi/api/resources/object_query.py
@@ -561,13 +561,27 @@ def _validate_where_tree(conditions: Sequence[dict]) -> None:
     `exists.where`, and `count_of.where` reached through either `column` or
     `value_column` -- every place this schema (or `where_expr`, which
     reaches this same function) can nest a further condition list.
+
+    Type-checks every level: a non-list `conditions` (e.g. a nested `where`
+    that arrived as a string or dict instead of a list) or a non-dict
+    condition aborts with 422 rather than silently skipping validation --
+    both `count_of.where` and `exists.where` are untyped (`wf.Raw()`), so
+    malformed values there would otherwise reach `where_list_to_ast`
+    unchecked and risk a 500 instead of a clean 422.
     """
+    if not isinstance(conditions, (list, tuple)):
+        abort_with_message(422, "a 'where' condition list must be an array")
     for condition in conditions:
+        if not isinstance(condition, dict):
+            abort_with_message(422, "each 'where' condition must be an object")
         if "column" in condition:
             _validate_leaf_condition(condition)
             for column_ref in (condition.get("column"), condition.get("value_column")):
                 if isinstance(column_ref, dict) and "count_of" in column_ref:
-                    _validate_where_tree(column_ref["count_of"].get("where") or [])
+                    count_of = column_ref["count_of"]
+                    if not isinstance(count_of, dict):
+                        abort_with_message(422, "'count_of' must be an object")
+                    _validate_where_tree(count_of.get("where") or [])
         elif "and" in condition:
             _validate_where_tree(condition["and"])
         elif "or" in condition:
@@ -575,7 +589,10 @@ def _validate_where_tree(conditions: Sequence[dict]) -> None:
         elif "not" in condition:
             _validate_where_tree([condition["not"]])
         elif "exists" in condition:
-            _validate_where_tree(condition["exists"].get("where") or [])
+            exists = condition["exists"]
+            if not isinstance(exists, dict):
+                abort_with_message(422, "'exists' must be an object")
+            _validate_where_tree(exists.get("where") or [])
 
 
 def _build_where(conditions: Optional[Sequence[dict]], spec: ObjectTypeSpec):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ dependencies = [
     "celery[redis]",
     "Unidecode",
     "pytesseract",
-    "gramps-object-query-language>=0.4.0,<0.5",
+    "gramps-object-query-language>=0.5.0,<0.6",
     "gramps-ql>=0.5.0",
     "object-ql>=0.1.3",
     "sifts>=1.1.0",

--- a/tests/test_endpoints/test_object_query_where_tree.py
+++ b/tests/test_endpoints/test_object_query_where_tree.py
@@ -1,0 +1,168 @@
+#
+# Gramps Web API - A RESTful API for the Gramps genealogy program
+#
+# Copyright (C) 2026      Douglas Blank
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+#
+
+"""Live-HTTP dual-path tests: `where_expr` and the equivalent raw `where`
+JSON must agree, for every boolean-tree shape (`and`/`or`/`not`/`exists`,
+including `backlinks`).
+
+Before `QueryWhereConditionArgs` was widened to accept these shapes, only
+`where_expr` could express them at all -- `where: [{"exists": {...}}]` 422'd
+("Unknown field: exists") for *any* collection, old or new, not a
+deliberate restriction, just drift between the two once `where_expr`'s own
+grammar grew past what the JSON schema still modeled (see `object_query.py`'s
+`QueryWhereConditionArgs` docstring). `test_object_query_parsing.py` covers
+the same agreement at the AST level, independent of the Flask app; this
+file is the real end-to-end confirmation, through actual HTTP requests
+against the real example database, that both wire formats reach the same
+result set, not just the same AST shape.
+"""
+
+import unittest
+
+from . import BASE_URL, get_test_client
+from .util import fetch_header
+
+PEOPLE_URL = BASE_URL + "/people/query/"
+NOTES_URL = BASE_URL + "/notes/query/"
+
+
+class TestWhereTreeDualPath(unittest.TestCase):
+    """Every case here is checked through both `where_expr` and the
+    equivalent raw `where` JSON, asserting they return the same status code
+    and the identical set of matched handles.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        """Test class setup."""
+        cls.client = get_test_client()
+        cls.maxDiff = None
+
+    def _assert_expr_and_where_agree(self, url, expr, where_json):
+        header = fetch_header(self.client)
+        rv_expr = self.client.post(
+            url, json={"select": ["handle"], "where_expr": expr}, headers=header
+        )
+        rv_where = self.client.post(
+            url, json={"select": ["handle"], "where": where_json}, headers=header
+        )
+        self.assertEqual(rv_expr.status_code, 200, rv_expr.json)
+        self.assertEqual(rv_where.status_code, 200, rv_where.json)
+        handles_expr = sorted(item["handle"] for item in rv_expr.json["items"])
+        handles_where = sorted(item["handle"] for item in rv_where.json["items"])
+        self.assertEqual(handles_expr, handles_where)
+        return handles_where
+
+    def test_or(self):
+        self._assert_expr_and_where_agree(
+            PEOPLE_URL,
+            "gender == 1 or gender == 2",
+            [
+                {
+                    "or": [
+                        {"column": "gender", "op": "eq", "value": 1},
+                        {"column": "gender", "op": "eq", "value": 2},
+                    ]
+                }
+            ],
+        )
+
+    def test_and(self):
+        self._assert_expr_and_where_agree(
+            PEOPLE_URL,
+            "gender == 1 and gramps_id != ''",
+            [
+                {
+                    "and": [
+                        {"column": "gender", "op": "eq", "value": 1},
+                        {"column": "gramps_id", "op": "ne", "value": ""},
+                    ]
+                }
+            ],
+        )
+
+    def test_not(self):
+        self._assert_expr_and_where_agree(
+            PEOPLE_URL,
+            "not (gender == 1)",
+            [{"not": {"column": "gender", "op": "eq", "value": 1}}],
+        )
+
+    def test_exists_pre_existing_collection(self):
+        # "notes" has been a registered collection since exists(...) itself
+        # shipped -- this is the exact case that first surfaced the gap
+        # (see this file's own module docstring): exists() on an
+        # already-long-shipped collection, not just a new one.
+        self._assert_expr_and_where_agree(
+            PEOPLE_URL,
+            "exists(notes)",
+            [{"exists": {"relationship": "notes"}}],
+        )
+
+    def test_not_exists_backlinks(self):
+        handles = self._assert_expr_and_where_agree(
+            NOTES_URL,
+            "not exists(backlinks)",
+            [{"not": {"exists": {"relationship": "backlinks"}}}],
+        )
+        # A meaningful, non-trivial result set either way, not just "both
+        # sides happened to return zero rows" -- example_gramps has both
+        # referenced and orphan notes.
+        self.assertTrue(handles)
+
+    def test_exists_backlinks_class_filter(self):
+        handles = self._assert_expr_and_where_agree(
+            NOTES_URL,
+            'exists(backlinks, _class == "Person")',
+            [
+                {
+                    "exists": {
+                        "relationship": "backlinks",
+                        "where": [{"column": "_class", "op": "eq", "value": "Person"}],
+                    }
+                }
+            ],
+        )
+        self.assertTrue(handles)
+
+    def test_malformed_in_nested_in_exists_where_rejected_both_ways(self):
+        # Regression test for the nested-leaf-validation gap found while
+        # widening the schema (see object_query.py's _validate_where_tree):
+        # a malformed 'in' value nested inside exists()'s own condition used
+        # to bypass validation silently. where_expr already rejects this at
+        # parse time (query_lang.py's _translate_list requires a real list
+        # literal); the raw `where` form needs _validate_where_tree to catch
+        # the equivalent live at request time.
+        header = fetch_header(self.client)
+        rv_where = self.client.post(
+            NOTES_URL,
+            json={
+                "select": ["handle"],
+                "where": [
+                    {
+                        "exists": {
+                            "relationship": "backlinks",
+                            "where": [{"column": "_class", "op": "in", "value": "not-a-list"}],
+                        }
+                    }
+                ],
+            },
+            headers=header,
+        )
+        self.assertEqual(rv_where.status_code, 422)

--- a/tests/test_object_query_parsing.py
+++ b/tests/test_object_query_parsing.py
@@ -1130,6 +1130,34 @@ def test_non_dict_condition_in_and_rejected_with_422():
     assert exc_info.value.code == 422
 
 
+# `count_of.where`/`exists.where` used to default via `.get("where") or []`,
+# which treats any *falsy* value -- not just a missing/None key -- as if the
+# `where` had been omitted. A caller-supplied "" or {} is falsy but still
+# malformed, and would have silently skipped straight past the non-list
+# check below instead of 422ing. Only a missing/None key should default to
+# [].
+
+
+def test_falsy_non_list_count_of_where_rejected_with_422():
+    conditions = [
+        {
+            "column": {"count_of": {"relationship": "children", "where": ""}},
+            "op": "gt",
+            "value": 0,
+        }
+    ]
+    with pytest.raises(HTTPException) as exc_info:
+        _build_where(conditions, FAMILY)
+    assert exc_info.value.code == 422
+
+
+def test_falsy_non_list_exists_where_rejected_with_422():
+    conditions = [{"exists": {"relationship": "backlinks", "where": {}}}]
+    with pytest.raises(HTTPException) as exc_info:
+        _build_where(conditions, NOTE)
+    assert exc_info.value.code == 422
+
+
 # --- treeid threading through every SQL-emitting path -----------------------
 #
 # `_resolve_treeid` (tested above) is only half the story -- the value it

--- a/tests/test_object_query_parsing.py
+++ b/tests/test_object_query_parsing.py
@@ -31,10 +31,13 @@ import pytest
 from gramps.plugins.db.dbapi.sqlite import SQLite
 from werkzeug.exceptions import HTTPException
 
+from marshmallow import ValidationError
+
 from gramps_object_query_language.query import (
     EVENT,
     FAMILY,
     MEDIA,
+    NOTE,
     PERSON,
     And,
     CollectionCount,
@@ -58,6 +61,7 @@ from gramps_object_query_language.query import (
 )
 from gramps_object_query_language.query_lang import VALID_LEAF_OPS
 from gramps_webapi.api.resources.object_query import (
+    QueryExistsPayloadArgs,
     QueryWhereConditionArgs,
     _build_where,
     _check_no_duplicate_keys,
@@ -759,31 +763,100 @@ def test_build_where_nested_or_and_leaf():
     assert isinstance(where.exprs[1], Or)
 
 
-# --- _build_where: end-to-end via where_expr (and/exists/count_of/FlatColumnRef) --
+# --- _build_where: end-to-end via where_expr and via raw `where` JSON ---------
 #
 # These go through the real _resolve_where_conditions -> _build_where pair
-# together, the same as _post_sql, since 'and'/'exists'/'count_of' only ever
-# arise from where_expr (QueryWhereConditionArgs' schema can't produce them
-# for a raw `where` body) -- see where_list_to_ast's docstring for why these
-# are delegated there rather than hand-built here.
+# together, the same as _post_sql. 'and'/'or'/'not'/'exists'/'count_of' used
+# to only be reachable via where_expr -- QueryWhereConditionArgs' schema
+# rejected them for a raw `where` body (a 422, "Unknown field: exists" etc.,
+# for *any* collection, not just a new one -- confirmed live against
+# test_build_where_exists() below before the schema was widened). That gap
+# is exactly how it went unnoticed for as long as it did: every test in this
+# section only ever exercised `_where()`/where_expr, so a regression on the
+# `where` side had nothing here to catch it. Every case below now goes
+# through `_assert_expr_and_where_agree`, which checks both paths produce
+# the *identical* AST, not just "both don't crash" -- see that helper's own
+# docstring.
 
 
 def _where(expr: str, spec=PERSON):
     return _build_where(_resolve_where_conditions({"where_expr": expr}, spec), spec)
 
 
+def _assert_expr_and_where_agree(expr: str, where_json: list, spec=PERSON):
+    """Asserts `where_expr` and the equivalent raw `where` JSON produce the
+    identical `query.py` AST, and returns it (so a caller can still make
+    its own assertions on the shape, same as `_where()`'s callers already
+    do). `where_json` is loaded through `QueryWhereConditionArgs` first
+    (`many=True`, matching how `QueryBodyArgs.where`'s own `wf.List(wf.Nested(
+    QueryWhereConditionArgs))` field loads a request body) rather than
+    handed to `_build_where` as a raw dict -- so this also exercises the
+    schema's own `attribute`/`data_key` mapping for `and`/`or`/`not`, not
+    just `_build_where`'s AST-building logic.
+    """
+    loaded = QueryWhereConditionArgs(many=True).load(where_json)
+    where_from_json = _build_where(loaded, spec)
+    where_from_expr = _where(expr, spec)
+    assert repr(where_from_json) == repr(where_from_expr), (
+        f"where={where_from_json!r} but where_expr={where_from_expr!r}"
+    )
+    return where_from_expr
+
+
 def test_build_where_and_group_nested_under_not():
-    where = _where("not (gender == 1 and gramps_id == 'I1')")
+    where = _assert_expr_and_where_agree(
+        "not (gender == 1 and gramps_id == 'I1')",
+        [{"not": {"and": [
+            {"column": "gender", "op": "eq", "value": 1},
+            {"column": "gramps_id", "op": "eq", "value": "I1"},
+        ]}}],
+    )
     assert isinstance(where, Not)
     assert isinstance(where.expr, And)
     assert all(isinstance(e, Eq) for e in where.expr.exprs)
 
 
+def test_build_where_or_group_via_where_expr_and_json():
+    where = _assert_expr_and_where_agree(
+        "gender == 1 or gender == 2",
+        [{"or": [
+            {"column": "gender", "op": "eq", "value": 1},
+            {"column": "gender", "op": "eq", "value": 2},
+        ]}],
+    )
+    assert isinstance(where, Or)
+    assert len(where.exprs) == 2
+
+
+def test_build_where_not_group_via_where_expr_and_json():
+    where = _assert_expr_and_where_agree(
+        "not (gender == 1)",
+        [{"not": {"column": "gender", "op": "eq", "value": 1}}],
+    )
+    assert isinstance(where, Not)
+    assert isinstance(where.expr, Eq)
+
+
 def test_build_where_exists():
-    where = _where("exists(events, type.value == 12)")
+    where = _assert_expr_and_where_agree(
+        "exists(events, type.value == 12)",
+        [{"exists": {
+            "relationship": "events",
+            "where": [{"column": {"json_path": ["type", "value"]}, "op": "eq", "value": 12}],
+        }}],
+    )
     assert isinstance(where, Exists)
     assert where.collection.name == "events"
     assert where.condition is not None
+
+
+def test_build_where_exists_no_condition():
+    where = _assert_expr_and_where_agree(
+        "exists(events)",
+        [{"exists": {"relationship": "events"}}],
+    )
+    assert isinstance(where, Exists)
+    assert where.condition is None
 
 
 def test_build_where_exists_any_sugar_equivalent():
@@ -793,11 +866,46 @@ def test_build_where_exists_any_sugar_equivalent():
 
 
 def test_build_where_count_of():
-    where = _where("count(events) > 2")
+    where = _assert_expr_and_where_agree(
+        "count(events) > 2",
+        [{"column": {"count_of": {"relationship": "events"}}, "op": "gt", "value": 2}],
+    )
     assert isinstance(where, Gt)
     assert isinstance(where.column, CollectionCount)
     assert where.column.collection.name == "events"
     assert where.value == 2
+
+
+def test_build_where_backlinks_not_exists():
+    where = _assert_expr_and_where_agree(
+        "not exists(backlinks)",
+        [{"not": {"exists": {"relationship": "backlinks"}}}],
+        spec=NOTE,
+    )
+    assert isinstance(where, Not)
+    assert isinstance(where.expr, Exists)
+
+
+def test_build_where_backlinks_class_filter():
+    where = _assert_expr_and_where_agree(
+        'exists(backlinks, _class == "Person")',
+        [{"exists": {
+            "relationship": "backlinks",
+            "where": [{"column": "_class", "op": "eq", "value": "Person"}],
+        }}],
+        spec=NOTE,
+    )
+    assert isinstance(where, Exists)
+    assert where.collection.name == "backlinks"
+
+
+def test_build_where_backlinks_count():
+    where = _assert_expr_and_where_agree(
+        "count(backlinks) == 0",
+        [{"column": {"count_of": {"relationship": "backlinks"}}, "op": "eq", "value": 0}],
+        spec=NOTE,
+    )
+    assert isinstance(where.column, CollectionCount)
 
 
 def test_build_where_value_column_same_table_wrapped_as_flat_column_ref():
@@ -826,6 +934,140 @@ def test_where_op_schema_matches_valid_leaf_ops():
     op_field = QueryWhereConditionArgs().fields["op"]
     allowed = {choice for validator in op_field.validators for choice in validator.choices}
     assert allowed == set(VALID_LEAF_OPS)
+
+
+# --- QueryWhereConditionArgs: schema-level shape validation -------------------
+#
+# A condition node must be exactly one of: a leaf (column+op[+value/
+# value_column]), or one combinator (and/or/not/exists) -- checked in
+# _check_shape, since no single field's own `required`/`validate` can
+# express "required unless X is present" on its own.
+
+
+def test_where_schema_accepts_plain_leaf():
+    loaded = QueryWhereConditionArgs().load({"column": "gender", "op": "eq", "value": 1})
+    assert loaded == {"column": "gender", "op": "eq", "value": 1}
+
+
+def test_where_schema_accepts_and_or_not_exists():
+    assert "and" in QueryWhereConditionArgs().load(
+        {"and": [{"column": "gender", "op": "eq", "value": 1}]}
+    )
+    assert "or" in QueryWhereConditionArgs().load(
+        {"or": [{"column": "gender", "op": "eq", "value": 1}]}
+    )
+    assert "not" in QueryWhereConditionArgs().load(
+        {"not": {"column": "gender", "op": "eq", "value": 1}}
+    )
+    assert "exists" in QueryWhereConditionArgs().load(
+        {"exists": {"relationship": "notes"}}
+    )
+
+
+def test_where_schema_loaded_dict_uses_wire_keys_not_python_attribute_names():
+    # Regression test for the schema's own and_/or_/not_ Python attribute
+    # names (and/or/not are reserved words, can't be literal attribute
+    # names) -- without `attribute="and"` etc. on each field, .load() would
+    # return "and_"/"or_"/"not_" keys, which where_list_to_ast's
+    # _node_from_json (checking `"and" in node`, never `"and_"`) would
+    # silently fail to recognize as a combinator at all.
+    loaded = QueryWhereConditionArgs().load(
+        {"and": [{"column": "gender", "op": "eq", "value": 1}]}
+    )
+    assert set(loaded) == {"and"}
+
+
+def test_where_schema_rejects_empty_condition():
+    with pytest.raises(ValidationError):
+        QueryWhereConditionArgs().load({})
+
+
+def test_where_schema_rejects_leaf_missing_op():
+    with pytest.raises(ValidationError):
+        QueryWhereConditionArgs().load({"column": "gender"})
+
+
+def test_where_schema_rejects_leaf_missing_column():
+    with pytest.raises(ValidationError):
+        QueryWhereConditionArgs().load({"op": "eq", "value": 1})
+
+
+def test_where_schema_rejects_combinator_mixed_with_leaf():
+    with pytest.raises(ValidationError):
+        QueryWhereConditionArgs().load(
+            {
+                "column": "gender",
+                "op": "eq",
+                "value": 1,
+                "not": {"column": "gender", "op": "eq", "value": 0},
+            }
+        )
+
+
+def test_where_schema_rejects_two_combinators():
+    with pytest.raises(ValidationError):
+        QueryWhereConditionArgs().load(
+            {
+                "and": [{"column": "a", "op": "eq", "value": 1}],
+                "or": [{"column": "b", "op": "eq", "value": 1}],
+            }
+        )
+
+
+def test_exists_payload_schema_requires_relationship():
+    with pytest.raises(ValidationError):
+        QueryExistsPayloadArgs().load({})
+
+
+# --- nested-leaf validation: _validate_leaf_condition applied at any depth ---
+#
+# Regression tests for a gap found while widening QueryWhereConditionArgs:
+# _build_where's leaf-validation used to only ever walk the *top-level*
+# `where` list -- a leaf nested inside `count_of`'s own `where` already
+# silently bypassed it (confirmed live: a malformed non-list "in" value
+# there was accepted and iterated character-by-character instead of
+# rejected); widening the schema for and/or/not/exists made this far more
+# reachable (any nested leaf, at any depth), so _validate_where_tree walks
+# the full tree now, not just the top level.
+
+
+def test_malformed_in_rejected_when_nested_in_or():
+    conditions = QueryWhereConditionArgs(many=True).load(
+        [{"or": [{"column": "gender", "op": "in", "value": "not-a-list"}]}]
+    )
+    with pytest.raises(HTTPException) as exc_info:
+        _build_where(conditions, PERSON)
+    assert exc_info.value.code == 422
+
+
+def test_malformed_in_rejected_when_nested_in_exists_where():
+    conditions = QueryWhereConditionArgs(many=True).load(
+        [{"exists": {
+            "relationship": "backlinks",
+            "where": [{"column": "_class", "op": "in", "value": "not-a-list"}],
+        }}]
+    )
+    with pytest.raises(HTTPException) as exc_info:
+        _build_where(conditions, NOTE)
+    assert exc_info.value.code == 422
+
+
+def test_malformed_in_rejected_when_nested_in_count_of_where():
+    conditions = [
+        {
+            "column": {
+                "count_of": {
+                    "relationship": "children",
+                    "where": [{"column": "gender", "op": "in", "value": "not-a-list"}],
+                }
+            },
+            "op": "gt",
+            "value": 0,
+        }
+    ]
+    with pytest.raises(HTTPException) as exc_info:
+        _build_where(conditions, FAMILY)
+    assert exc_info.value.code == 422
 
 
 # --- treeid threading through every SQL-emitting path -----------------------

--- a/tests/test_object_query_parsing.py
+++ b/tests/test_object_query_parsing.py
@@ -1070,6 +1070,66 @@ def test_malformed_in_rejected_when_nested_in_count_of_where():
     assert exc_info.value.code == 422
 
 
+def test_non_list_count_of_where_rejected_with_422():
+    # count_of's `where` is untyped (wf.Raw()), so a caller can send a
+    # non-list value there -- must 422, not be silently skipped and reach
+    # where_list_to_ast (or crash trying to iterate/index into it).
+    conditions = [
+        {
+            "column": {
+                "count_of": {"relationship": "children", "where": "not-a-list"}
+            },
+            "op": "gt",
+            "value": 0,
+        }
+    ]
+    with pytest.raises(HTTPException) as exc_info:
+        _build_where(conditions, FAMILY)
+    assert exc_info.value.code == 422
+
+
+def test_non_dict_count_of_rejected_with_422():
+    conditions = [
+        {"column": {"count_of": "not-a-dict"}, "op": "gt", "value": 0}
+    ]
+    with pytest.raises(HTTPException) as exc_info:
+        _build_where(conditions, FAMILY)
+    assert exc_info.value.code == 422
+
+
+def test_non_dict_exists_rejected_with_422():
+    # Bypasses QueryWhereConditionArgs.load() -- its own `exists` field is a
+    # typed Nested(QueryExistsPayloadArgs), so a non-dict there never reaches
+    # _build_where through the schema; this exercises _validate_where_tree's
+    # own defensive check directly, the same way the count_of tests above do.
+    conditions = [{"exists": "not-a-dict"}]
+    with pytest.raises(HTTPException) as exc_info:
+        _build_where(conditions, NOTE)
+    assert exc_info.value.code == 422
+
+
+def test_non_list_exists_where_rejected_with_422():
+    # Same rationale: QueryExistsPayloadArgs.where is a typed wf.List, so
+    # this bypasses .load() to exercise _validate_where_tree's own check.
+    conditions = [
+        {"exists": {"relationship": "backlinks", "where": "not-a-list"}}
+    ]
+    with pytest.raises(HTTPException) as exc_info:
+        _build_where(conditions, NOTE)
+    assert exc_info.value.code == 422
+
+
+def test_non_dict_condition_in_and_rejected_with_422():
+    conditions = QueryWhereConditionArgs(many=True).load(
+        [{"and": [{"column": "gender", "op": "eq", "value": "M"}]}]
+    )
+    # Tamper post-load to simulate a non-dict leaf slipping into the tree.
+    conditions[0]["and"].append("not-a-dict")
+    with pytest.raises(HTTPException) as exc_info:
+        _build_where(conditions, PERSON)
+    assert exc_info.value.code == 422
+
+
 # --- treeid threading through every SQL-emitting path -----------------------
 #
 # `_resolve_treeid` (tested above) is only half the story -- the value it


### PR DESCRIPTION
The `/query/` endpoints have two methods of expressing a where clause:

1. in JSON
2. in Python syntax, our semantics

But they had drifted out of sync. I considered removing the JSON, but if a developer wanted to created another QL, it is easier to convert to JSON. In a future version, we can just delete the JSON version to eliminate the two paths.

In any event, this PR brings the two versions back into sync, and adds support for a new construct in gramps-object-query-language: the ability to query backlinks.

## Summary

- `where_expr`'s grammar grew `and`/`or`/`not`, `exists(...)`, `count(...)`, and comprehension sugar over time, but `QueryWhereConditionArgs` (the raw `where` JSON body's schema) stayed frozen at leaf-only from when the two were first wired up as equally expressive. As a result, `where_expr: "exists(notes)"` worked while the JSON equivalent 422'd (`Unknown field: exists`) for any collection — not a deliberate restriction, just schema drift, since `_build_where` already called `where_list_to_ast` unconditionally and handled the full nested shape.
- `QueryWhereConditionArgs` now models a real condition tree: a leaf, or exactly one of `and`/`or`/`not`/`exists`, validated cross-field (self-referential via `Nested(lambda: ...)`).
- Also fixes a related gap found while widening this: leaf validation (`_validate_leaf_condition`) only ever walked the top-level `where` list, so a malformed leaf nested inside `count_of`'s own `where` silently bypassed validation. `_validate_where_tree` now recurses through every nesting point this schema can produce.
- Every combinator test case, new and pre-existing, is checked through both `where_expr` and the equivalent raw `where` JSON via a shared dual-path helper, closing the coverage gap that let the original drift go unnoticed.
- Bumps `gramps-object-query-language` to `>=0.5.0,<0.6` for its backlinks support.

## Test plan

- [x] Targeted pytest coverage for the where-combinator schema (leaf/and/or/not/exists, nested `count_of`, dual-path `where_expr` vs raw JSON) passes on the fork
- [x] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bw5BecPRFMM6kfNHVv2pLz