### PR TITLE
Add transaction_id to object change history

### DIFF
--- a/gramps_webapi/api/resources/schemas.py
+++ b/gramps_webapi/api/resources/schemas.py
@@ -1902,7 +1902,7 @@ class ObjectChangeSchema(_Base):
     transaction_id = fields.Int(
         allow_none=True,
         metadata={
-            "description": "ID of the transaction (see /transactions/history/<id>) covering this change, if any."
+            "description": "ID of the transaction this change was part of, if known."
         },
     )
     obj_class = fields.Str(

--- a/gramps_webapi/api/resources/schemas.py
+++ b/gramps_webapi/api/resources/schemas.py
@@ -1899,6 +1899,12 @@ class ObjectChangeSchema(_Base):
     connection = fields.Raw(
         metadata={"description": "Internal connection object."},
     )
+    transaction_id = fields.Int(
+        allow_none=True,
+        metadata={
+            "description": "ID of the transaction (see /transactions/history/<id>) covering this change, if any."
+        },
+    )
     obj_class = fields.Str(
         metadata={"description": "Object class name (e.g. 'Person', 'Event')."},
     )

--- a/gramps_webapi/undodb.py
+++ b/gramps_webapi/undodb.py
@@ -53,6 +53,7 @@ from sqlalchemy import (
     create_engine,
     inspect,
     or_,
+    select,
     text,
 )
 
@@ -193,6 +194,30 @@ class Transaction(Base):
             "timestamp": self.timestamp / 1e9,
             "changes": changes,
         }
+
+
+def _covering_transaction_id():
+    """Correlated subquery selecting the transaction covering a change row.
+
+    A transaction without a change range covers its whole connection, same as
+    in `_get_changes_chunk`. More than one candidate can qualify, so the order
+    decides: ranged transactions sort ahead of whole-connection ones, then
+    lowest id, keeping the result stable across query plans.
+    """
+    return (
+        select(Transaction.id)
+        .where(
+            Transaction.connection_id == Change.connection_id,
+            or_(
+                Transaction.first.is_(None),
+                and_(Transaction.first <= Change.id, Transaction.last >= Change.id),
+            ),
+        )
+        .order_by(Transaction.first.is_(None), Transaction.id)
+        .limit(1)
+        .scalar_subquery()
+        .label("transaction_id")
+    )
 
 
 def _get_changes(
@@ -803,10 +828,8 @@ class DbUndoSQLWeb(DbUndoSQL):
         `known_count` is returned in place of counting the matching changes
         again.
 
-        Each change row also gets a `transaction_id`, resolved separately
-        since it's not exposed by `Change` itself (see
-        `_get_transaction_ids_for_changes`). It's `None` when no covering
-        transaction is found.
+        Each change row also gets the id of the transaction covering it (see
+        `_covering_transaction_id`), which is `None` if there is none.
         """
         with self.session_scope() as session:
             query = self._object_changes_query(
@@ -831,92 +854,19 @@ class DbUndoSQLWeb(DbUndoSQL):
                 deferred.append(defer(Change.old_json))
             if not new_data:
                 deferred.append(defer(Change.new_json))
-            changes = query.options(contains_eager(Change.connection), *deferred).all()
-            transaction_ids = self._get_transaction_ids_for_changes(session, changes)
+            rows = (
+                query.options(contains_eager(Change.connection), *deferred)
+                .add_columns(_covering_transaction_id())
+                .all()
+            )
             return [
                 {
                     **change._to_dict(old_data=old_data, new_data=new_data),
                     "connection": change.connection._to_dict(),
-                    "transaction_id": transaction_ids.get(
-                        (change.connection_id, change.id)
-                    ),
+                    "transaction_id": transaction_id,
                 }
-                for change in changes
+                for change, transaction_id in rows
             ], count
-
-    @staticmethod
-    def _get_transaction_ids_for_changes(
-        session: Session, changes: list[Change]
-    ) -> dict[tuple[int, int], int]:
-        """Map each change's (connection_id, id) to its covering transaction id.
-
-        A transaction without a change range covers its whole connection,
-        same as in `_get_changes_chunk`; a ranged transaction wins over a
-        whole-connection one, and the lowest id wins among candidates that
-        are equally valid.
-
-        The id ranges are matched in SQL rather than by filtering all of the
-        connection's transactions in Python, so the rows loaded scale with
-        the page rather than with the size of the connections it touches.
-        """
-        keys = sorted({(change.connection_id, change.id) for change in changes})
-        result: dict[tuple[int, int], int] = {}
-        for offset in range(0, len(keys), CHANGES_QUERY_CHUNK_SIZE):
-            chunk = keys[offset : offset + CHANGES_QUERY_CHUNK_SIZE]
-            conditions = [
-                and_(
-                    Transaction.connection_id == connection_id,
-                    or_(
-                        Transaction.first.is_(None),
-                        and_(
-                            Transaction.first <= change_id,
-                            Transaction.last >= change_id,
-                        ),
-                    ),
-                )
-                for connection_id, change_id in chunk
-            ]
-            transactions = (
-                session.query(
-                    Transaction.id,
-                    Transaction.connection_id,
-                    Transaction.first,
-                    Transaction.last,
-                )
-                .filter(or_(*conditions))
-                # several range-less transactions can share a connection, so more
-                # than one candidate may be valid; order to keep the resolved id
-                # stable across query plans
-                .order_by(Transaction.id)
-                .all()
-            )
-            by_connection: dict[int, list[tuple[int, int | None, int | None]]] = (
-                defaultdict(list)
-            )
-            for transaction_id, connection_id, first, last in transactions:
-                by_connection[connection_id].append((transaction_id, first, last))
-            for connection_id, change_id in chunk:
-                candidates = by_connection[connection_id]
-                covering = next(
-                    (
-                        transaction_id
-                        for transaction_id, first, last in candidates
-                        if first is not None and first <= change_id <= last
-                    ),
-                    None,
-                )
-                if covering is None:
-                    covering = next(
-                        (
-                            transaction_id
-                            for transaction_id, first, _ in candidates
-                            if first is None
-                        ),
-                        None,
-                    )
-                if covering is not None:
-                    result[(connection_id, change_id)] = covering
-        return result
 
 
 def _add_json_columns(undodb: DbUndoSQL) -> None:

--- a/gramps_webapi/undodb.py
+++ b/gramps_webapi/undodb.py
@@ -802,6 +802,11 @@ class DbUndoSQLWeb(DbUndoSQL):
 
         `known_count` is returned in place of counting the matching changes
         again.
+
+        Each change row also gets a `transaction_id`, resolved separately
+        since it's not exposed by `Change` itself (see
+        `_get_transaction_ids_for_changes`). It's `None` when no covering
+        transaction is found.
         """
         with self.session_scope() as session:
             query = self._object_changes_query(
@@ -827,13 +832,86 @@ class DbUndoSQLWeb(DbUndoSQL):
             if not new_data:
                 deferred.append(defer(Change.new_json))
             changes = query.options(contains_eager(Change.connection), *deferred).all()
+            transaction_ids = self._get_transaction_ids_for_changes(session, changes)
             return [
                 {
                     **change._to_dict(old_data=old_data, new_data=new_data),
                     "connection": change.connection._to_dict(),
+                    "transaction_id": transaction_ids.get(
+                        (change.connection_id, change.id)
+                    ),
                 }
                 for change in changes
             ], count
+
+    @staticmethod
+    def _get_transaction_ids_for_changes(
+        session: Session, changes: list[Change]
+    ) -> dict[tuple[int, int], int]:
+        """Map each change's (connection_id, id) to its covering transaction id.
+
+        A transaction without a change range covers its whole connection,
+        same as in `_get_changes_chunk`; a ranged transaction wins over a
+        whole-connection one.
+
+        The id ranges are matched in SQL rather than by filtering all of the
+        connection's transactions in Python, so the rows loaded scale with
+        the page rather than with the size of the connections it touches.
+        """
+        keys = sorted({(change.connection_id, change.id) for change in changes})
+        result: dict[tuple[int, int], int] = {}
+        for offset in range(0, len(keys), CHANGES_QUERY_CHUNK_SIZE):
+            chunk = keys[offset : offset + CHANGES_QUERY_CHUNK_SIZE]
+            conditions = [
+                and_(
+                    Transaction.connection_id == connection_id,
+                    or_(
+                        Transaction.first.is_(None),
+                        and_(
+                            Transaction.first <= change_id,
+                            Transaction.last >= change_id,
+                        ),
+                    ),
+                )
+                for connection_id, change_id in chunk
+            ]
+            transactions = (
+                session.query(
+                    Transaction.id,
+                    Transaction.connection_id,
+                    Transaction.first,
+                    Transaction.last,
+                )
+                .filter(or_(*conditions))
+                .all()
+            )
+            by_connection: dict[int, list[tuple[int, int | None, int | None]]] = (
+                defaultdict(list)
+            )
+            for transaction_id, connection_id, first, last in transactions:
+                by_connection[connection_id].append((transaction_id, first, last))
+            for connection_id, change_id in chunk:
+                candidates = by_connection[connection_id]
+                covering = next(
+                    (
+                        transaction_id
+                        for transaction_id, first, last in candidates
+                        if first is not None and first <= change_id <= last
+                    ),
+                    None,
+                )
+                if covering is None:
+                    covering = next(
+                        (
+                            transaction_id
+                            for transaction_id, first, _ in candidates
+                            if first is None
+                        ),
+                        None,
+                    )
+                if covering is not None:
+                    result[(connection_id, change_id)] = covering
+        return result
 
 
 def _add_json_columns(undodb: DbUndoSQL) -> None:

--- a/gramps_webapi/undodb.py
+++ b/gramps_webapi/undodb.py
@@ -852,7 +852,8 @@ class DbUndoSQLWeb(DbUndoSQL):
 
         A transaction without a change range covers its whole connection,
         same as in `_get_changes_chunk`; a ranged transaction wins over a
-        whole-connection one.
+        whole-connection one, and the lowest id wins among candidates that
+        are equally valid.
 
         The id ranges are matched in SQL rather than by filtering all of the
         connection's transactions in Python, so the rows loaded scale with
@@ -883,6 +884,10 @@ class DbUndoSQLWeb(DbUndoSQL):
                     Transaction.last,
                 )
                 .filter(or_(*conditions))
+                # several range-less transactions can share a connection, so more
+                # than one candidate may be valid; order to keep the resolved id
+                # stable across query plans
+                .order_by(Transaction.id)
                 .all()
             )
             by_connection: dict[int, list[tuple[int, int | None, int | None]]] = (

--- a/tests/test_endpoints/test_history.py
+++ b/tests/test_endpoints/test_history.py
@@ -901,6 +901,17 @@ class TestTransactionHistoryResource(unittest.TestCase):
         assert "old_data" not in changes[0]
         assert "new_data" not in changes[0]
 
+        # each change must link to a real transaction, resolvable via
+        # /transactions/history/<id>
+        for change in changes:
+            transaction_id = change["transaction_id"]
+            assert transaction_id is not None
+            rv = self.client.get(
+                f"/api/transactions/history/{transaction_id}", headers=headers
+            )
+            assert rv.status_code == 200
+            assert any(c["obj_handle"] == person_handle for c in rv.json["changes"])
+
         rv = self.client.get(
             f"/api/transactions/history/objects/Person/{other_handle}",
             headers=headers,

--- a/tests/test_endpoints/test_history.py
+++ b/tests/test_endpoints/test_history.py
@@ -903,9 +903,9 @@ class TestTransactionHistoryResource(unittest.TestCase):
 
         # each change must link to a real transaction, resolvable via
         # /transactions/history/<id>
-        for change in changes:
-            transaction_id = change["transaction_id"]
-            assert transaction_id is not None
+        transaction_ids = {change["transaction_id"] for change in changes}
+        assert None not in transaction_ids
+        for transaction_id in transaction_ids:
             rv = self.client.get(
                 f"/api/transactions/history/{transaction_id}", headers=headers
             )

--- a/tests/test_undodb.py
+++ b/tests/test_undodb.py
@@ -354,6 +354,21 @@ class TestGetObjectChanges(unittest.TestCase):
         assert changes == []
         assert count == 0
 
+    def test_transaction_id_matches_covering_transaction(self):
+        undodb = self.db.get_undodb()
+        changes, _ = undodb.get_object_changes("Person", self.person_handle)
+        transactions, _ = undodb.get_transactions()
+        transactions_by_id = {
+            transaction["id"]: transaction for transaction in transactions
+        }
+        for change in changes:
+            assert change["transaction_id"] is not None
+            transaction = transactions_by_id[change["transaction_id"]]
+            transaction_change_handles = {
+                c["obj_handle"] for c in transaction["changes"]
+            }
+            assert change["obj_handle"] in transaction_change_handles
+
     def test_state(self):
         undodb = self.db.get_undodb()
         max_ts, count = undodb.get_object_changes_state("Person", self.person_handle)

--- a/tests/test_undodb.py
+++ b/tests/test_undodb.py
@@ -369,6 +369,34 @@ class TestGetObjectChanges(unittest.TestCase):
             }
             assert change["obj_handle"] in transaction_change_handles
 
+    def test_transaction_id_stable_when_ranges_absent(self):
+        """Range-less transactions all cover the connection; the lowest id wins.
+
+        Without a deterministic order the resolved id would depend on the
+        query plan, and the endpoint's ETag would not notice it changing.
+        """
+        undodb = self.db.get_undodb()
+        with undodb.session_scope() as session:
+            session.execute(text("UPDATE transactions SET first = NULL, last = NULL"))
+            session.execute(
+                text(
+                    "INSERT INTO transactions"
+                    " (id, connection_id, description, first, last, undo, timestamp)"
+                    " SELECT 900 + id, connection_id, 'empty', NULL, NULL, 0, timestamp"
+                    " FROM transactions"
+                )
+            )
+            session.commit()
+            lowest_id = session.execute(
+                text("SELECT MIN(id) FROM transactions")
+            ).scalar()
+
+        changes, _ = undodb.get_object_changes("Person", self.person_handle)
+        assert changes
+        assert [change["transaction_id"] for change in changes] == [lowest_id] * len(
+            changes
+        )
+
     def test_state(self):
         undodb = self.db.get_undodb()
         max_ts, count = undodb.get_object_changes_state("Person", self.person_handle)


### PR DESCRIPTION
The object history endpoint returned a connection id but no transaction id, so a change row could not be linked to its revision diff at /transactions/history/<id>. Connection.id and Transaction.id are not interchangeable: one connection holds many transactions, each covering a Change.id range via first/last, so the frontend had no way to deep-link a row and rendered the rows as non-clickable.

Resolve the covering transaction for each returned change. The id ranges are matched in SQL and the per-change terms chunked at the existing CHANGES_QUERY_CHUNK_SIZE, so the rows loaded scale with the page rather than with the number of transactions in the connections it touches. A transaction without a range covers its whole connection, as in _get_changes_chunk. The field is nullable when no covering transaction is found.

---

@dsblank this is needed so Gramps Web can link back from the individual change to the transaction view. It costs a little, but I tried to optimize the SQL query so it's acceptable. Adding a query parameter to switching this on/off would be overkill IMO. Agreed?