### PR TITLE
Expose some config options in metadata

### DIFF
--- a/gramps_webapi/api/resources/metadata.py
+++ b/gramps_webapi/api/resources/metadata.py
@@ -21,9 +21,12 @@
 """Metadata API resource."""
 
 import functools
+import shutil
 from importlib import metadata
+from importlib.util import find_spec
 
 import gramps_ql as gql
+import limits
 import object_ql as oql
 import sifts
 from flask import Response, current_app
@@ -63,6 +66,50 @@ def _get_ocr_info() -> tuple[bool, list[str]]:
         return True, [lang for lang in pytesseract.get_languages() if lang != "osd"]
     except pytesseract.TesseractNotFoundError:
         return False, []
+
+
+@functools.cache
+def _has_module(name: str) -> bool:
+    """Check whether a module is importable, without importing it."""
+    try:
+        return find_spec(name) is not None
+    except (ImportError, ValueError):
+        return False
+
+
+@functools.cache
+def _get_face_detection_available() -> bool:
+    """Detect whether face detection is available (worker-lifetime constant)."""
+    # see `gramps_webapi.api.image.detect_faces`
+    return _has_module("cv2") and _has_module("numpy")
+
+
+@functools.cache
+def _get_thumbnail_support() -> dict[str, bool]:
+    """Detect thumbnailing support for file types needing extra dependencies."""
+    # see `gramps_webapi.api.image.ThumbnailHandler._get_image_pdf` and
+    # `._get_image_video` - both the Python package and the binary are required
+    return {
+        "pdf": _has_module("pdf2image") and shutil.which("pdftoppm") is not None,
+        "video": _has_module("ffmpeg") and shutil.which("ffmpeg") is not None,
+    }
+
+
+@functools.cache
+def _parse_rate_limit(limit_string: str) -> list[dict[str, int]] | None:
+    """Parse a rate limit string into structured limits, or None if invalid.
+
+    A rate limit string is written in the mini-language of the `limits` library,
+    e.g. `1 per day` or `100/hour;1000/day`, which clients cannot be expected to
+    parse, so it is broken down into an amount per time window instead.
+    """
+    try:
+        items = limits.parse_many(limit_string)
+    except ValueError:
+        return None
+    return [
+        {"amount": item.amount, "window_seconds": item.get_expiry()} for item in items
+    ]
 
 
 @functools.cache
@@ -226,8 +273,24 @@ class MetadataResource(ProtectedResource, GrampsJSONEncoder):
                 "ocr_languages": ocr_languages,
                 "semantic_search": has_semantic_search,
                 "chat": has_chat,
+                "face_detection": _get_face_detection_available(),
+                "thumbnails": _get_thumbnail_support(),
+                # may be stored in the database, so it is looked up rather than
+                # read from the app config
+                "email": bool(get_config("DEFAULT_FROM_EMAIL")),
+                "max_thumbnail_file_bytes": current_app.config[
+                    "MAX_THUMBNAIL_FILE_BYTES"
+                ],
             },
         }
+        max_upload_bytes = current_app.config["MAX_MEDIA_ARCHIVE_UPLOAD_BYTES"]
+        if max_upload_bytes is not None:
+            # omitted rather than null if no limit is configured
+            result["server"]["max_media_archive_upload_bytes"] = max_upload_bytes
+        rate_limit = _parse_rate_limit(current_app.config["RATE_LIMIT_MEDIA_ARCHIVE"])
+        if rate_limit is not None:
+            # omitted if the configured limit string is unparseable
+            result["server"]["rate_limit_media_archive"] = rate_limit
         if has_permissions({PERM_EDIT_SETTINGS}):
             # re-checked per request since some options can be stored in the database
             result["deprecations"] = check_deprecations(

--- a/gramps_webapi/api/resources/schemas.py
+++ b/gramps_webapi/api/resources/schemas.py
@@ -1937,7 +1937,9 @@ class ObjectChangeSchema(_Base):
         metadata={"description": "Handle of the changed object."},
     )
     ref_handle = fields.Str(
-        metadata={"description": "Handle of a referenced object, if this change is a reference update."},
+        metadata={
+            "description": "Handle of a referenced object, if this change is a reference update."
+        },
     )
     trans_type = fields.Int(
         metadata={"description": "Change type: 0 (add), 1 (update), or 2 (delete)."},
@@ -1946,10 +1948,14 @@ class ObjectChangeSchema(_Base):
         metadata={"description": "Unix timestamp when the change was committed."},
     )
     old_data = fields.Raw(
-        metadata={"description": "Object state before the change (only included if requested)."},
+        metadata={
+            "description": "Object state before the change (only included if requested)."
+        },
     )
     new_data = fields.Raw(
-        metadata={"description": "Object state after the change (only included if requested)."},
+        metadata={
+            "description": "Object state after the change (only included if requested)."
+        },
     )
 
 
@@ -2136,6 +2142,103 @@ class DeprecationSchema(_Base):
     )
 
 
+class RateLimitSchema(_Base):
+    """A rate limit expressed as a number of requests per time window."""
+
+    amount = fields.Int(
+        metadata={"description": "Number of requests allowed per time window."},
+    )
+    window_seconds = fields.Int(
+        metadata={"description": "Length of the time window in seconds."},
+    )
+
+
+class ThumbnailSupportSchema(_Base):
+    """Availability of thumbnailing for file types needing extra dependencies."""
+
+    pdf = fields.Bool(
+        metadata={
+            "description": "Whether thumbnails can be generated for PDF files"
+            " (requires pdf2image and Poppler)."
+        },
+    )
+    video = fields.Bool(
+        metadata={
+            "description": "Whether thumbnails can be generated for video files"
+            " (requires ffmpeg-python and the ffmpeg binary)."
+        },
+    )
+
+
+class ServerSchema(_Base):
+    """Server capabilities and configuration relevant to clients."""
+
+    multi_tree = fields.Bool(
+        metadata={"description": "Whether the server hosts multiple family trees."},
+    )
+    task_queue = fields.Bool(
+        metadata={
+            "description": "Whether a task queue is available, so that long-running"
+            " operations return a task rather than a result."
+        },
+    )
+    ocr = fields.Bool(
+        metadata={"description": "Whether OCR of images is available."},
+    )
+    ocr_languages = fields.List(
+        fields.Str(),
+        metadata={"description": "Language codes available for OCR."},
+    )
+    semantic_search = fields.Bool(
+        metadata={"description": "Whether semantic search is available."},
+    )
+    chat = fields.Bool(
+        metadata={"description": "Whether the AI chat endpoint is available."},
+    )
+    face_detection = fields.Bool(
+        metadata={
+            "description": "Whether face detection in images is available"
+            " (requires OpenCV and NumPy)."
+        },
+    )
+    thumbnails = fields.Nested(
+        ThumbnailSupportSchema,
+        metadata={
+            "description": "Availability of thumbnailing for file types needing"
+            " extra dependencies."
+        },
+    )
+    email = fields.Bool(
+        metadata={
+            "description": "Whether the server is configured to send e-mails."
+            " If false, flows relying on e-mail (such as enabling new users) will"
+            " not work."
+        },
+    )
+    max_media_archive_upload_bytes = fields.Int(
+        metadata={
+            "description": "Configured maximum size of an uploaded media archive in"
+            " bytes. Absent if no limit is configured. Note that uploads are"
+            " additionally limited by the free disk space available to the server, so"
+            " an upload smaller than this value can still be rejected."
+        },
+    )
+    max_thumbnail_file_bytes = fields.Int(
+        metadata={
+            "description": "Maximum size in bytes of a media file for which"
+            " thumbnails will be generated. Larger files are rejected by the"
+            " thumbnail endpoints."
+        },
+    )
+    rate_limit_media_archive = fields.List(
+        fields.Nested(RateLimitSchema),
+        metadata={
+            "description": "Rate limits, per user, for creating a media archive for"
+            " download. All of the limits apply simultaneously."
+        },
+    )
+
+
 class MetadataSchema(_Base):
     """Server and database metadata returned by /api/metadata/."""
 
@@ -2177,7 +2280,8 @@ class MetadataSchema(_Base):
     search = fields.Dict(
         metadata={"description": "Information about search-related libraries."},
     )
-    server = fields.Dict(
+    server = fields.Nested(
+        ServerSchema,
         metadata={"description": "Information about server capabilities."},
     )
     surnames = fields.List(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ dependencies = [
     "Flask-Cors",
     "Flask-JWT-Extended>=4.2.1,!=4.4.0,!=4.4.1",
     "Flask-Limiter>=2.9.0",
+    "limits",  # used directly to parse rate limit strings
     "Flask-SQLAlchemy",
     "marshmallow>=3.13.0",
     "waitress",

--- a/tests/test_endpoints/test_metadata.py
+++ b/tests/test_endpoints/test_metadata.py
@@ -21,7 +21,8 @@
 
 import unittest
 
-from gramps_webapi.auth.const import ROLE_EDITOR
+from gramps_webapi.api.resources.metadata import _parse_rate_limit
+from gramps_webapi.auth.const import ROLE_EDITOR, ROLE_GUEST
 
 from . import BASE_URL, get_test_client
 from .checks import check_conforms_to_openapi_schema, check_requires_token
@@ -52,6 +53,76 @@ class TestMetadata(unittest.TestCase):
         assert "version" in res["search"]["sifts"]
         assert "count" in res["search"]["sifts"]
         assert res["search"]["sifts"]["count"] > 1
+
+    def test_get_metadata_server_capabilities(self):
+        """Test the server block reports capabilities and client-relevant config."""
+        res = check_conforms_to_openapi_schema(self, TEST_URL, "Metadata")
+        server = res["server"]
+        for key in [
+            "multi_tree",
+            "task_queue",
+            "ocr",
+            "semantic_search",
+            "chat",
+            "face_detection",
+            "email",
+        ]:
+            self.assertIsInstance(server[key], bool, key)
+        self.assertIsInstance(server["ocr_languages"], list)
+        self.assertIsInstance(server["thumbnails"]["pdf"], bool)
+        self.assertIsInstance(server["thumbnails"]["video"], bool)
+        self.assertIsInstance(server["max_thumbnail_file_bytes"], int)
+        # the rate limit mini-language is parsed server-side into amount per window
+        self.assertEqual(
+            server["rate_limit_media_archive"],
+            [{"amount": 1, "window_seconds": 86400}],
+        )
+        # no upload limit is configured in the test config, so the key is omitted
+        self.assertNotIn("max_media_archive_upload_bytes", server)
+
+    def test_get_metadata_server_visible_to_guest(self):
+        """Test that the server block is returned for the lowest role, too."""
+        header = fetch_header(self.client, role=ROLE_GUEST)
+        rv = self.client.get(TEST_URL, headers=header)
+        self.assertEqual(rv.status_code, 200)
+        self.assertIn("email", rv.json["server"])
+        self.assertIn("max_thumbnail_file_bytes", rv.json["server"])
+        # deprecations remain restricted to users allowed to edit settings
+        self.assertNotIn("deprecations", rv.json)
+
+
+class TestParseRateLimit(unittest.TestCase):
+    """Test cases for parsing rate limit strings."""
+
+    def test_parse_rate_limit_forms(self):
+        """Test the equivalent forms of the rate limit mini-language."""
+        for limit_string in ["1 per day", "1/day", "1 per 1 day"]:
+            self.assertEqual(
+                _parse_rate_limit(limit_string),
+                [{"amount": 1, "window_seconds": 86400}],
+                limit_string,
+            )
+
+    def test_parse_rate_limit_multiples(self):
+        """Test a window spanning multiple units."""
+        self.assertEqual(
+            _parse_rate_limit("2 per 5 minutes"),
+            [{"amount": 2, "window_seconds": 300}],
+        )
+
+    def test_parse_rate_limit_multiple_limits(self):
+        """Test that several simultaneous limits are all reported."""
+        self.assertEqual(
+            _parse_rate_limit("100/hour;1000/day"),
+            [
+                {"amount": 100, "window_seconds": 3600},
+                {"amount": 1000, "window_seconds": 86400},
+            ],
+        )
+
+    def test_parse_rate_limit_invalid(self):
+        """Test that an unparseable limit does not raise."""
+        self.assertIsNone(_parse_rate_limit("once in a blue moon"))
 
 
 class TestMetadataResearcher(unittest.TestCase):


### PR DESCRIPTION
# Expose client-relevant server capabilities under `/api/metadata`

Adds fields to the `server` block of `GET /api/metadata/`, visible to all
authenticated roles, so frontends can adapt up front instead of discovering
capabilities and limits from error responses.

| Key | Value |
|---|---|
| `face_detection` | bool — OpenCV + NumPy available |
| `thumbnails` | `{pdf, video}` — package *and* binary available |
| `email` | bool — `DEFAULT_FROM_EMAIL` set |
| `max_thumbnail_file_bytes` | int |
| `max_media_archive_upload_bytes` | int, omitted if uncapped |
| `rate_limit_media_archive` | `[{amount, window_seconds}]` |

The rate limit is parsed server-side with `limits.parse_many`, since the
configured string is Flask-Limiter's mini-language (`1 per day`,
`100/hour;1000/day`) that clients cannot be expected to parse. `MetadataSchema.server`
becomes a nested `ServerSchema`, so the block is now documented in the OpenAPI
spec. `limits` becomes a direct dependency.

All additions are additive; clients must tolerate missing keys on older servers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
